### PR TITLE
Pretty printing for model types

### DIFF
--- a/src/EmissionModels.jl
+++ b/src/EmissionModels.jl
@@ -783,8 +783,8 @@ A Poisson regression model.
 # Fields
 - `input_dim::Int`: Dimensionality of the input data.
 - `output_dim::Int`: Dimensionality of the output data.
-- `include_intercept::Bool`: Whether to include a regression intercept.
 - `β::AbstractMatrix{<:Real}`: The regression coefficients matrix.
+- `include_intercept::Bool`: Whether to include a regression intercept.
 - `λ::Real;`: L2 Regularization parameter.
 """
 mutable struct PoissonRegressionEmission{T<:Real, M<:AbstractMatrix{T}} <: RegressionEmission
@@ -804,7 +804,7 @@ end
 
 function Base.show(io::IO, pre::PoissonRegressionEmission; gap = "")
 
-
+    println(io, gap)
 end
 
 

--- a/src/EmissionModels.jl
+++ b/src/EmissionModels.jl
@@ -26,6 +26,18 @@ mutable struct GaussianEmission{T<:Real, V<:AbstractVector{T}, M<:AbstractMatrix
     Σ::M  # covariance matrix
 end
 
+function Base.show(io::IO, ge::GaussianEmission; gap = "")
+    println(io, gap, "Gaussian Emission model:")
+    println(io, gap, "------------------------")
+    if ge.output_dim > 4
+        println(io, gap, " size(μ) = ($(length(ge.μ)),)")
+        println(io, gap, " size(Σ) = ($(size(ge.Σ,1)), $(size(ge.Σ,2)))")
+    else
+        println(io, gap, " μ = $(ge.μ)")
+        println(io, gap, " Σ = $(ge.Σ)")
+    end
+end
+
 """
     function GaussianEmission(; output_dim::Int, μ::AbstractVector, Σ::AbstractMatrix)
 
@@ -220,6 +232,15 @@ mutable struct GaussianRegressionEmission{T<:Real, M<:AbstractMatrix{T}} <: Regr
     λ::T # regularization parameter
 end
 
+function Base.show(io::IO, gre::GaussianRegressionEmission; gap = "")
+    println(io, gap, "Gaussian Regression Emission model:")
+    println(io, gap, "-----------------------------------")
+    println(io, gap, " size(β) = ($(size(gre.β,1)), $(size(gre.β,2)))")
+    println(io, gap, " size(Σ) = ($(size(gre.Σ,1)), $(size(gre.Σ,2)))")
+    println(io, gap, " intrcpt = $(gre.include_intercept)")
+    println(io, gap, "      λ  = $(round(gre.λ, digits=3))")
+end
+
 """
     GaussianRegressionEmission(input_dim, output_dim, include_intercept, β, Σ, λ)
 
@@ -336,6 +357,15 @@ mutable struct AutoRegressionEmission <: AutoRegressiveEmission
     output_dim::Int
     order::Int
     innerGaussianRegression::GaussianRegressionEmission
+end
+
+function Base.show(io::IO, are::AutoRegressionEmission; gap = "")
+    println(io, gap, "AutoRegression Emission model:")
+    println(io, gap, "------------------------------")
+    println(io, gap, " output_dim = $(are.output_dim)")
+    println(io, gap, " (AR) order = $(are.order)")
+    Base.show(io, are.innerGaussianRegression, gap = " " * gap)
+
 end
 
 """
@@ -581,6 +611,20 @@ mutable struct BernoulliRegressionEmission{T<:Real, M<:AbstractMatrix{T}} <: Reg
     λ::T # regularization parameter
 end
 
+
+
+
+# ! finish
+
+function Base.show(io::IO, bre::BernoulliRegressionEmission; gap = "")
+    println(io, gap, "Bernoulli Regression model:")
+    println(io, gap, "---------------------------")
+    println(io, gap, bre.β, bre.λ)
+end
+
+
+
+
 """
     BernoulliRegressionEmission(Args)
 
@@ -750,6 +794,23 @@ mutable struct PoissonRegressionEmission{T<:Real, M<:AbstractMatrix{T}} <: Regre
     include_intercept::Bool
     λ::T
 end
+
+
+
+
+
+
+# ! finish
+
+function Base.show(io::IO, pre::PoissonRegressionEmission; gap = "")
+
+
+end
+
+
+
+
+
 
 """
     PoissonRegressionEmission(Args)

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -41,7 +41,7 @@ function Base.show(io::IO, hmm::HiddenMarkovModel; gap = "")
             Base.show(io, b, gap = gap * "  ")
             println(io, gap, "  ----------------")
         end
-        println(io, gap * "  $(K-3) more ...")
+        println(io, gap * "  $(hmm.K-3) more ...")
     else
         for (i,b) in enumerate(hmm.B)
             Base.show(io, b, gap = gap * "  ")

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -20,46 +20,37 @@ mutable struct HiddenMarkovModel{T<:Real, V<:AbstractVector{T}, M<:AbstractMatri
     K::Int # number of states
 end
 
-
-# ! finish
-
 function Base.show(io::IO, hmm::HiddenMarkovModel; gap = "")
     println(io, gap, "Hidden Markov Model:")
     println(io, gap, "--------------------")
 
-
-
-    if size(A, 1) > 3
-        println(io, gap, " size(A) = ($(size(hmm.A,1)), $(size(hmm.A,2)))")
+    if hmm.K > 3
+        println(io, gap, " size(A)  = ($(size(hmm.A,1)), $(size(hmm.A,2)))")
+        println(io, gap, " size(πₖ) = ($(size(hmm.πₖ,1)),)")
     else
-        println(io, gap, " A = $(hmm.A)")
-        println(io, gap, " πₖ = ")
+        println(io, gap, " A  = $(round.(hmm.A, digits=4))")
+        println(io, gap, " πₖ = $(round.(hmm.πₖ, digits=4))")
     end
-
-    println(io, gap, " πₖ = ")
 
     println(io, gap, " Emission Models:")
     println(io, gap, " ----------------")
-    if K > 4
+
+    if hmm.K > 4
         # only show 3
-        for b in B[1:3]
+        for b in hmm.B[1:3]
             Base.show(io, b, gap = gap * "  ")
+            println(io, gap, "  ----------------")
         end
-        println(io, gap * "  ", "$(K-3) more ...")
+        println(io, gap * "  $(K-3) more ...")
     else
-        for b in B
+        for (i,b) in enumerate(hmm.B)
             Base.show(io, b, gap = gap * "  ")
+            if i < hmm.K
+                println(io, gap, "  ----------------")
+            end
         end
     end
-
-
 end
-
-
-
-
-
-
 
 """
     initialize_forward_backward(model::AbstractHMM, num_obs::Int)

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -20,6 +20,47 @@ mutable struct HiddenMarkovModel{T<:Real, V<:AbstractVector{T}, M<:AbstractMatri
     K::Int # number of states
 end
 
+
+# ! finish
+
+function Base.show(io::IO, hmm::HiddenMarkovModel; gap = "")
+    println(io, gap, "Hidden Markov Model:")
+    println(io, gap, "--------------------")
+
+
+
+    if size(A, 1) > 3
+        println(io, gap, " size(A) = ($(size(hmm.A,1)), $(size(hmm.A,2)))")
+    else
+        println(io, gap, " A = $(hmm.A)")
+        println(io, gap, " πₖ = ")
+    end
+
+    println(io, gap, " πₖ = ")
+
+    println(io, gap, " Emission Models:")
+    println(io, gap, " ----------------")
+    if K > 4
+        # only show 3
+        for b in B[1:3]
+            Base.show(io, b, gap = gap * "  ")
+        end
+        println(io, gap * "  ", "$(K-3) more ...")
+    else
+        for b in B
+            Base.show(io, b, gap = gap * "  ")
+        end
+    end
+
+
+end
+
+
+
+
+
+
+
 """
     initialize_forward_backward(model::AbstractHMM, num_obs::Int)
 

--- a/src/LinearDynamicalSystems.jl
+++ b/src/LinearDynamicalSystems.jl
@@ -118,6 +118,22 @@ Base.@kwdef struct LinearDynamicalSystem{T<:Real, S<:AbstractStateModel{T}, O<:A
     fit_bool::Vector{Bool}
 end
 
+function Base.show(io::IO, lds::LinearDynamicalSystem)
+    println(io, "Linear Dynamical System:")
+    Base.show(io, lds.state_model, gap = " ")
+    Base.show(io, lds.obs_model, gap = " ")
+    println(io, " Parameters to update:")
+    println(io, " ---------------------")
+
+    if lds.obs_model isa PoissonObservationModel
+        prms = ["x0", "P0", "A", "Q", "C, log_d"][lds.fit_bool[1:5]] # C and log_d are either both updated or neither 
+    else
+        prms = ["x0", "P0", "A", "Q", "C", "R"][lds.fit_bool[1:6]]
+    end
+
+    println(io, "  $(join(prms, ", "))")
+end
+
 """
     stateparams(lds::LinearDynamicalSystem{T,S,O}) 
 

--- a/src/LinearDynamicalSystems.jl
+++ b/src/LinearDynamicalSystems.jl
@@ -54,6 +54,21 @@ Base.@kwdef mutable struct GaussianObservationModel{T<:Real, M<:AbstractMatrix{T
     R::M
 end
 
+function Base.show(io::IO, gom::GaussianObservationModel; gap = "")
+    nobs, nstate = size(gom.C)
+
+    println(io, gap, "Gaussian Observation Model:")
+    println(io, gap, "---------------------------")
+
+    if nobs * nstate > 12
+        println(io, gap, " size(C) = ($nobs, $nstate)")
+        println(io, gap, " size(R) = ($nobs, $nobs)")
+    else
+        println(io, gap, " C = $(round.(gom.C, digits=2))")
+        println(io, gap, " R = $(round.(gom.R, digits=2))")
+    end
+end
+
 """
     PoissonObservationModel{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}} <: AbstractObservationModel{T}
 
@@ -66,6 +81,21 @@ Represents the observation model of a Linear Dynamical System with Poisson obser
 Base.@kwdef mutable struct PoissonObservationModel{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}} <: AbstractObservationModel{T}
     C::M
     log_d::V
+end
+
+function Base.show(io::IO, pom::PoissonObservationModel, gap = "")
+    nobs, nstate = size(gom.C)
+
+    println(io, gap, "Poisson Observation Model:")
+    println(io, gap, "--------------------------")
+
+    if nobs > 4 || nstate > 4
+        println(io, gap, " size(C) = ($nobs, $nstate)")
+    else
+        println(io, gap, " C = $(round.(pom.C, digits=2))")
+    end
+    println(io, gap, " log_d   = $(round(pom.log_d, digits = 3))")
+    println(io, gap, " d       = $(round(exp(pom.log_d), digits = 2))")
 end
 
 """

--- a/src/LinearDynamicalSystems.jl
+++ b/src/LinearDynamicalSystems.jl
@@ -18,6 +18,28 @@ Base.@kwdef mutable struct GaussianStateModel{T<:Real, M<:AbstractMatrix{T}, V<:
     P0::M 
 end
 
+function Base.show(io::IO, gsm::GaussianStateModel; gap = "")
+    nstate = size(gsm.A, 1)
+
+    println(io, gap, "Gaussian State Model:")
+    println(io, gap, "---------------------")
+    if nstate > 4
+        println(io, gap, " State Parameters:")
+        println(io, gap, "  size(A)  = ($nstate, $nstate)")
+        println(io, gap, "  size(Q)  = ($nstate, $nstate)")
+        println(io, gap, " Initial State:")
+        println(io, gap, "  size(x0) = ($nstate, )")
+        println(io, gap, "  size(P0) = ($nstate, $nstate)")
+    else
+        println(io, gap, " State Parameters:")
+        println(io, gap, "  A  = $(round.(gsm.A, digits=3))")
+        println(io, gap, "  Q  = $(round.(gsm.Q, digits=2))")
+        println(io, gap, " Initial State:")
+        println(io, gap, "  x0 = $(round.(gsm.x0, digits=2))")
+        println(io, gap, "  P0 = $(round.(gsm.P0, digits=2))")
+    end
+end
+
 """
     GaussianObservationModel{T<:Real, M<:AbstractMatrix{T}} 
 

--- a/src/LinearDynamicalSystems.jl
+++ b/src/LinearDynamicalSystems.jl
@@ -83,7 +83,7 @@ Base.@kwdef mutable struct PoissonObservationModel{T<:Real, M<:AbstractMatrix{T}
     log_d::V
 end
 
-function Base.show(io::IO, pom::PoissonObservationModel, gap = "")
+function Base.show(io::IO, pom::PoissonObservationModel; gap = "")
     nobs, nstate = size(pom.C)
 
     println(io, gap, "Poisson Observation Model:")
@@ -94,8 +94,8 @@ function Base.show(io::IO, pom::PoissonObservationModel, gap = "")
     else
         println(io, gap, " C = $(round.(pom.C, digits=2))")
     end
-    println(io, gap, " log_d   = $(round(pom.log_d, digits = 3))")
-    println(io, gap, " d       = $(round(exp(pom.log_d), digits = 2))")
+    println(io, gap, " log_d   = $(round.(pom.log_d, digits = 3))")
+    println(io, gap, " d       = $(round.(exp.(pom.log_d), digits = 2))")
 end
 
 """
@@ -118,12 +118,12 @@ Base.@kwdef struct LinearDynamicalSystem{T<:Real, S<:AbstractStateModel{T}, O<:A
     fit_bool::Vector{Bool}
 end
 
-function Base.show(io::IO, lds::LinearDynamicalSystem)
-    println(io, "Linear Dynamical System:")
-    Base.show(io, lds.state_model, gap = " ")
-    Base.show(io, lds.obs_model, gap = " ")
-    println(io, " Parameters to update:")
-    println(io, " ---------------------")
+function Base.show(io::IO, lds::LinearDynamicalSystem; gap = "")
+    println(io, gap, "Linear Dynamical System:")
+    Base.show(io, lds.state_model, gap = gap * " ")
+    Base.show(io, lds.obs_model, gap = gap * " ")
+    println(io, gap, " Parameters to update:")
+    println(io, gap, " ---------------------")
 
     if lds.obs_model isa PoissonObservationModel
         prms = ["x0", "P0", "A", "Q", "C, log_d"][lds.fit_bool[1:5]] # C and log_d are either both updated or neither 
@@ -131,7 +131,7 @@ function Base.show(io::IO, lds::LinearDynamicalSystem)
         prms = ["x0", "P0", "A", "Q", "C", "R"][lds.fit_bool[1:6]]
     end
 
-    println(io, "  $(join(prms, ", "))")
+    println(io, gap, "  $(join(prms, ", "))")
 end
 
 """

--- a/src/LinearDynamicalSystems.jl
+++ b/src/LinearDynamicalSystems.jl
@@ -76,7 +76,7 @@ Represents the observation model of a Linear Dynamical System with Poisson obser
 
 # Fields
 - `C::AbstractMatrix{T}`: Observation matrix of size `(obs_dim × latent_dim)`. Maps latent states into observation space.
-- `log_d::AbstractVector{T}`: Mean firing rate vector (log space) of size `(obs_dim × obs_dim)`. 
+- `log_d::AbstractVector{T}`: Mean firing rate vector (log space) of length `(obs_dim)`. 
 """
 Base.@kwdef mutable struct PoissonObservationModel{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}} <: AbstractObservationModel{T}
     C::M
@@ -84,7 +84,7 @@ Base.@kwdef mutable struct PoissonObservationModel{T<:Real, M<:AbstractMatrix{T}
 end
 
 function Base.show(io::IO, pom::PoissonObservationModel, gap = "")
-    nobs, nstate = size(gom.C)
+    nobs, nstate = size(pom.C)
 
     println(io, gap, "Poisson Observation Model:")
     println(io, gap, "--------------------------")

--- a/src/MixtureModels.jl
+++ b/src/MixtureModels.jl
@@ -13,22 +13,51 @@ mutable struct GaussianMixtureModel{T<:Real,M<:AbstractMatrix{T},V<:AbstractVect
     πₖ::V             # Mixing coefficients (K)
 end
 
-
-
-
-
-
-# ! finish
-
 function Base.show(io::IO, gmm::GaussianMixtureModel; gap = "")
+    D = size(gmm.μₖ,1)
 
+    println(io, gap, "Gaussian Mixture Model:")
+    println(io, gap, " dimension D = $D")
+    if D > 4
+        println(io, gap, " size(μₖ) = ($(size(gmm.μₖ,1)),)")
+        println(io, gap, " size(Σₖ) = ($(size(gmm.Σₖ[1],1)), $(size(gmm.Σₖ[1],2)))")
+    end
+    println(io, gap, "-----------------------")
 
+    if gmm.k > 4
+        for k in 1:3
+            println(io, gap, " Gaussian $k:")
+            println(io, gap, " -----------")
 
+            if D > 4
+                println(io, gap, "  πₖ = $(round(gmm.πₖ[k], digits=3))")
+            else
+                println(io, gap, "  μₖ = $(round.(gmm.μₖ[:, k], digits=3))")
+                println(io, gap, "  Σₖ = $(round.(gmm.Σₖ[k], digits=3))")
+                println(io, gap, "  πₖ = $(round(gmm.πₖ[k], digits=3))")
+            end
+            println(io, gap, " -----------")
+        end
+        println(io, gap, "  $(gmm.k - 3) more ...")
+    else
+        for k in 1:gmm.k
+            println(io, gap, " Gaussian $k:")
+            println(io, gap, " -----------")
+
+            if D > 4
+                println(io, gap, "  πₖ = $(round(gmm.πₖ[k], digits=3))")
+            else
+                println(io, gap, "  μₖ = $(round.(gmm.μₖ[:, k], digits=3))")
+                println(io, gap, "  Σₖ = $(round.(gmm.Σₖ[k], digits=3))")
+                println(io, gap, "  πₖ = $(round(gmm.πₖ[k], digits=3))")
+            end
+
+            if k < gmm.k
+                println(io, gap, " -----------")
+            end
+        end
+    end
 end
-
-
-
-
 
 """
     GaussianMixtureModel(k::Int, data_dim::Int)
@@ -198,12 +227,31 @@ end
 
 
 function Base.show(io::IO, pmm::PoissonMixtureModel; gap = "")
+    println(io, gap, "Poisson Mixture Model:")
+    println(io, gap, "----------------------")
 
+    if pmm.k > 4
+        for k in 1:3
+            println(io, gap, " Poisson $k:")
+            println(io, gap, " ----------")
+            println(io, gap, "  λₖ = $(round(pmm.λₖ[k], digits=2))")
+            println(io, gap, "  πₖ = $(round(pmm.πₖ[k], digits=3))")
+            println(io, gap, " ----------")
+        end
+        println(io, gap, "  $(pmm.k - 3) more ...")
+    else
+        for k in 1:pmm.k
+            println(io, gap, " Poisson $k:")
+            println(io, gap, " ----------")
+            println(io, gap, "  λₖ = $(round(pmm.λₖ[k], digits=2))")
+            println(io, gap, "  πₖ = $(round(pmm.πₖ[k], digits=3))")
+
+            if k < pmm.k
+                println(io, gap, " ----------")
+            end
+        end
+    end
 end
-
-
-
-
 
 """
     PoissonMixtureModel(k::Int)

--- a/src/MixtureModels.jl
+++ b/src/MixtureModels.jl
@@ -222,10 +222,6 @@ mutable struct PoissonMixtureModel{T<:Real,V<:AbstractVector{T}} <: MixtureModel
     πₖ::V
 end
 
-
-# ! finish
-
-
 function Base.show(io::IO, pmm::PoissonMixtureModel; gap = "")
     println(io, gap, "Poisson Mixture Model:")
     println(io, gap, "----------------------")

--- a/src/MixtureModels.jl
+++ b/src/MixtureModels.jl
@@ -13,6 +13,23 @@ mutable struct GaussianMixtureModel{T<:Real,M<:AbstractMatrix{T},V<:AbstractVect
     πₖ::V             # Mixing coefficients (K)
 end
 
+
+
+
+
+
+# ! finish
+
+function Base.show(io::IO, gmm::GaussianMixtureModel; gap = "")
+
+
+
+end
+
+
+
+
+
 """
     GaussianMixtureModel(k::Int, data_dim::Int)
     
@@ -175,6 +192,17 @@ mutable struct PoissonMixtureModel{T<:Real,V<:AbstractVector{T}} <: MixtureModel
     λₖ::V
     πₖ::V
 end
+
+
+# ! finish
+
+
+function Base.show(io::IO, pmm::PoissonMixtureModel; gap = "")
+
+end
+
+
+
 
 
 """

--- a/src/Preprocessing.jl
+++ b/src/Preprocessing.jl
@@ -1,5 +1,6 @@
 # Public API
 export ProbabilisticPCA, loglikelihood, fit!
+
 mutable struct ProbabilisticPCA{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}}
     W::M
     σ²::T

--- a/src/Preprocessing.jl
+++ b/src/Preprocessing.jl
@@ -15,6 +15,19 @@ mutable struct ProbabilisticPCA{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector
     end
 end
 
+
+
+# ! figure out what this is, then pretty print
+
+function Base.show(io::IO, ppca::ProbabilisticPCA; gap = "")
+
+
+
+end
+
+
+
+
 function estep(ppca::ProbabilisticPCA, X::Matrix{T}) where {T<:Real}
     D, N = size(X)
     E_z = zeros(T, ppca.k, N)

--- a/src/SLDS.jl
+++ b/src/SLDS.jl
@@ -17,22 +17,36 @@ mutable struct SwitchingLinearDynamicalSystem{T<:Real,M<:AbstractMatrix{T}, V<:A
     K::Int 
 end
 
-
-
-
-# ! finish
-
 function Base.show(io::IO, slds::SwitchingLinearDynamicalSystem; gap = "")
+    println(io, gap, "Switching Linear Dynamical System:")
+    println(io, gap, "----------------------------------")
+    
+    if slds.K > 3
+        println(io, gap, " size(A)  = ($(size(slds.A,1)), $(size(slds.A,2)))")
+        println(io, gap, " size(πₖ) = ($(size(slds.πₖ,1)),)")
+    else
+        println(io, gap, " A  = $(round.(slds.A, digits=4))")
+        println(io, gap, " πₖ = $(round.(slds.πₖ, digits=4))")
+    end
 
+    println(io, gap, " Switching Models:")
+    println(io, gap, " -----------------")
 
-
-
-
+    if slds.K > 3
+        for lds in slds.B[1:3]
+            Base.show(io, lds, gap = gap * "  ")
+            println(io, gap, "  --------------")
+        end
+        println(io, gap, "  ... $(slds.K-3) more")
+    else
+        for (i, lds) in enumerate(slds.B)
+            Base.show(io, lds; gap = gap * "  ")
+            if i < slds.K
+                println(io, gap, "  --------------")
+            end
+        end
+    end
 end
-
-
-
-
 
 """
     Random.rand(rng, slds, T)

--- a/src/SLDS.jl
+++ b/src/SLDS.jl
@@ -18,6 +18,22 @@ mutable struct SwitchingLinearDynamicalSystem{T<:Real,M<:AbstractMatrix{T}, V<:A
 end
 
 
+
+
+# ! finish
+
+function Base.show(io::IO, slds::SwitchingLinearDynamicalSystem; gap = "")
+
+
+
+
+
+end
+
+
+
+
+
 """
     Random.rand(rng, slds, T)
 

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -16,6 +16,8 @@ using StatsFuns
 using SpecialFunctions
 using Base.Threads: @threads
 
+import Base: show
+
 include("GlobalTypes.jl")
 include("Utilities.jl")
 include("LinearDynamicalSystems.jl")

--- a/test/PrettyPrinting/PrettyPrinting.jl
+++ b/test/PrettyPrinting/PrettyPrinting.jl
@@ -1,0 +1,4 @@
+function test_pretty_printing()
+
+
+end

--- a/test/PrettyPrinting/PrettyPrinting.jl
+++ b/test/PrettyPrinting/PrettyPrinting.jl
@@ -56,16 +56,16 @@ function test_pretty_printing()
 
     # poisson observation model 
 
-    pom1 = PoissonObservationModel(rand(5,5))
-    pom2 = PoissonObservationModel(rand(2,2))
+    pom1 = PoissonObservationModel(rand(5,5), rand(5))
+    pom2 = PoissonObservationModel(rand(2,2), rand(2))
 
     @test println(io, pom1) === nothing
     @test println(io, pom2) === nothing
 
     # linear dynamical system 
 
-    lds1 = LinearDynamicalSystem(gsm1, gom1, 5, 5, trues(6))
-    lds2 = LinearDynamicalSystem(gsm2, pom2, 2, 2, trues(5))
+    lds1 = LinearDynamicalSystem(gsm1, gom1, 5, 5, [true, true, true, true, true, true])
+    lds2 = LinearDynamicalSystem(gsm2, pom2, 2, 2, [true, true, true, true, true])
 
     @test println(io, lds1) === nothing
     @test println(io, lds2) === nothing
@@ -88,7 +88,7 @@ function test_pretty_printing()
 
     # Probabalistic PCA (incomplete)
 
-    ppca = ProbabilisticPCA()
+    ppca = ProbabilisticPCA(rand(5,5), 0.5, rand(5))
 
     @test println(io, ppca) === nothing
 
@@ -108,7 +108,7 @@ function test_pretty_printing()
     str = read(io, String)
 
     @test str isa String
-    @test length(str) > 1e4
+    @test length(str) > 5e3
 
     return nothing
 end

--- a/test/PrettyPrinting/PrettyPrinting.jl
+++ b/test/PrettyPrinting/PrettyPrinting.jl
@@ -1,4 +1,114 @@
 function test_pretty_printing()
+    io = IOBuffer()
+
+    # Gaussian Emission
+
+    ge1 = GaussianEmission(5, rand(5), rand(5,5))
+    ge2 = GaussianEmission(2, rand(2), rand(2,2))
+    @test println(io, ge1) === nothing
+    @test println(io, ge2) === nothing
+
+    # Gaussian Regression Emission
+
+    gre = GaussianRegressionEmission(3, 3, rand(3,3), rand(3,3), true, 0.5)
+    @test println(io, gre) === nothing
+
+    # AutoRegression Emission 
+
+    are = AutoRegressionEmission(3, 3, gre)
+    @test println(io, are) === nothing
+
+    # Bernoulli Regression Emission (incomplete)
+
+    bre = BernoulliRegressionEmission(5, 5, rand(5,5), false, 0.5)
+
+    @test println(io, bre) === nothing
+
+    # Poisson regression emission (incomplete)
+
+    pre = PoissonRegressionEmission(5, 5, rand(5,5), false, 0.5)
+    
+    @test println(io, pre) === nothing
+
+    # hidden markov model 
+
+    hmm1 = HiddenMarkovModel(rand(5,5), [gre, are, bre, pre, gre], rand(5), 5)
+    hmm2 = HiddenMarkovModel(rand(2,2), [gre, are], rand(2), 2)
+
+    @test println(io, hmm1) === nothing
+    @test println(io, hmm2) === nothing
+
+    # Gaussian State model 
+
+    gsm1 = GaussianStateModel(rand(5,5), rand(5,5), rand(5), rand(5,5))
+    gsm2 = GaussianStateModel(rand(2,2), rand(2,2), rand(2), rand(2,2))
+
+    @test println(io, gsm1) === nothing
+    @test println(io, gsm2) === nothing
+
+    # gaussian observation model 
+
+    gom1 = GaussianObservationModel(rand(5,5), rand(5,5))
+    gom2 = GaussianObservationModel(rand(3,3), rand(3,3))
+
+    @test println(io, gom1) === nothing
+    @test println(io, gom2) === nothing
+
+    # poisson observation model 
+
+    pom1 = PoissonObservationModel(rand(5,5))
+    pom2 = PoissonObservationModel(rand(2,2))
+
+    @test println(io, pom1) === nothing
+    @test println(io, pom2) === nothing
+
+    # linear dynamical system 
+
+    lds1 = LinearDynamicalSystem(gsm1, gom1, 5, 5, trues(6))
+    lds2 = LinearDynamicalSystem(gsm2, pom2, 2, 2, trues(5))
+
+    @test println(io, lds1) === nothing
+    @test println(io, lds2) === nothing
+
+    # gaussian mixture model 
+
+    gmm1 = GaussianMixtureModel(5, rand(5,5), [rand(5,5) for _ in 1:5], rand(5))
+    gmm2 = GaussianMixtureModel(2, rand(2,2), [rand(2,2) for _ in 1:2], rand(2))
+
+    @test println(io, gmm1) === nothing
+    @test println(io, gmm2) === nothing
+
+    # Poisson Mixture model 
+
+    pmm1 = PoissonMixtureModel(5, rand(5), rand(5))
+    pmm2 = PoissonMixtureModel(2, rand(2), rand(2))
+
+    @test println(io, pmm1) === nothing
+    @test println(io, pmm2) === nothing
+
+    # Probabalistic PCA (incomplete)
+
+    ppca = ProbabilisticPCA()
+
+    @test println(io, ppca) === nothing
 
 
+    # switching linear dynamical system 
+
+    slds1 = SwitchingLinearDynamicalSystem(rand(5,5), [lds1, lds2, lds1, lds2, lds1], rand(5), 5)
+    slds2 = SwitchingLinearDynamicalSystem(rand(2,2), [lds1, lds2], rand(2), 2)
+
+    @test println(io, slds1) === nothing
+    @test println(io, slds2) === nothing
+
+    # last two tests
+
+    seekstart(io)
+    
+    str = read(io, String)
+
+    @test str isa String
+    @test length(str) > 1e4
+
+    return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,6 +289,17 @@ include("Utilities/Utilities.jl")
     test_autoregressive_setters_and_getters()
 end
 
+
+"""
+Tests for PrettyPrinting.jl 
+"""
+
+include("PrettyPrinting/PrettyPrinting.jl")
+
+@testset "PrettyPrinting.jl Tests" begin
+    test_pretty_printing()
+end
+
 """
 Tests for Preprocessing.jl
 """


### PR DESCRIPTION
Hello, I talked with Zach at JuliaCon 2025 about contributing to your package with some ideas about oscillator models, which my lab uses in EEG! (see https://github.com/mh105/somata)

I also like to pretty print objects, so I figured I might start a collaboration by doing just that. I've implemented some version of pretty printing for all the objects I understood (all save bernoulli regression emission, poisson regression emission, and probabalistic PCA), where I introduced the function signatures but not a proper implementation.

I wrote a test for each model type and the tests pass (although some of the other tests in the package did not).

I also found a few random typos and such in documentation and fixed them.

Please let me know what you think! Happy to work more on it.

Some notes:
- The `gap` kwarg is to allow for nested levels of pretty printing.
- As things are, its best not to merge before implementing pretty printing for all the objects as the remaining objects will print nothing out as the functions are blank