### PR TITLE
Feature/input basis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 authors = ["Ryan Senne rsenne@bu.edu"]
 
 [deps]
+BSplines = "488c2830-172b-11e9-1591-253b8a7df96d"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 HiddenMarkovModels = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,6 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
+BSplines = "0.3.3"
 Distributions = "0.25.109"
 HiddenMarkovModels = "0.7.0"
 LinearAlgebra = "1"

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -19,7 +19,7 @@ using Base.Threads: @threads, @spawn
 using Base.Iterators: partition
 using Base: show
 
-import BSplines
+using BSplines: BSplines
 
 # Model-agnostic numerical kernels (no package types — reusable primitives).
 include("numerics/linalg.jl")

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -19,6 +19,8 @@ using Base.Threads: @threads, @spawn
 using Base.Iterators: partition
 using Base: show
 
+import BSplines
+
 # Model-agnostic numerical kernels (no package types — reusable primitives).
 include("numerics/linalg.jl")
 include("numerics/optimization.jl")        # line search + Newton
@@ -34,6 +36,13 @@ include("lds/types.jl")                             # abstract types, Data, mode
 include("lds/workspaces.jl")                        # FilterSmooth / SufficientStatistics / workspaces
 include("utils/show.jl")
 include("utils/validation.jl")
+
+# Input basis library (B-spline, Fourier, raised cosine, polynomial)
+include("bases/Bases.jl")
+include("bases/BSpline.jl")
+include("bases/Fourier.jl")
+include("bases/RaisedCosine.jl")
+include("bases/Polynomial.jl")
 
 # Shared latent inference machinery.
 # kalman.jl is retained for the Kalman filter + marginal likelihood (and future
@@ -73,6 +82,11 @@ export valid_Σ, gaussian_entropy
 export random_rotation_matrix
 export print_full
 export info_update!
+
+# Input bases
+export AbstractInputBasis
+export BSpline, Fourier, RaisedCosineLinear, RaisedCosineLog, Polynomial
+export apply!, get_penalty, n_bases, evaluate_basis
 
 # Common functions
 export rand, smooth, fit!, loglikelihood, elbo!

--- a/src/bases/BSpline.jl
+++ b/src/bases/BSpline.jl
@@ -1,0 +1,63 @@
+"""
+    BSpline(num_bases::Int; order::Int=4, knots=:auto) <: AbstractInputBasis
+
+B-spline basis of `num_bases` functions with the given polynomial `order`
+(default `4` = cubic).
+
+# Knot placement
+- `knots = :auto` (default): breakpoints are placed by
+  `BSplines.averagebasis` (de Boor 1978, p. 219) on `num_bases`
+  equally-spaced sites in `[first(ts), last(ts)]`, resolved at evaluation
+  time. This yields a basis whose Schoenberg–Whitney conditions are
+  satisfied at the sites.
+- `knots::AbstractVector{<:Real}`: a sorted vector of breakpoints. The
+  resulting basis must have exactly `num_bases` functions, i.e.
+  `length(knots) == num_bases - order + 2`.
+"""
+struct BSpline{K} <: AbstractInputBasis
+    num_bases::Int
+    order::Int
+    knots::K
+end
+
+function BSpline(
+    num_bases::Integer;
+    order::Integer=4,
+    knots::Union{Symbol,AbstractVector{<:Real}}=:auto,
+)
+    num_bases >= order ||
+        throw(ArgumentError("num_bases ($num_bases) must be >= order ($order)."))
+    order >= 1 || throw(ArgumentError("order ($order) must be >= 1."))
+    knots_resolved = if knots isa AbstractVector
+        collect(Float64.(knots))
+    elseif knots === :auto
+        :auto
+    else
+        throw(
+            ArgumentError(
+                "knots must be :auto or an AbstractVector, got $(typeof(knots)).",
+            ),
+        )
+    end
+    return BSpline{typeof(knots_resolved)}(Int(num_bases), Int(order), knots_resolved)
+end
+
+n_bases(b::BSpline) = b.num_bases
+
+function evaluate_basis(b::BSpline, ts::AbstractVector{T}) where {T<:Real}
+    K = b.num_bases
+    basis = if b.knots === :auto
+        data_sites = collect(range(T(first(ts)), T(last(ts)); length=K))
+        BSplines.averagebasis(b.order, data_sites)
+    else
+        BSplines.BSplineBasis(b.order, collect(T.(b.knots)))
+    end
+    length(basis) == K || throw(
+        ArgumentError(
+            "constructed basis has length $(length(basis)) but num_bases=$K. " *
+            "With explicit knots, length(knots) must equal num_bases - order + 2.",
+        ),
+    )
+    B_raw = BSplines.basismatrix(basis, ts)
+    return eltype(B_raw) === T ? B_raw : convert(Matrix{T}, B_raw)
+end

--- a/src/bases/BSpline.jl
+++ b/src/bases/BSpline.jl
@@ -21,9 +21,7 @@ struct BSpline{K} <: AbstractInputBasis
 end
 
 function BSpline(
-    num_bases::Integer;
-    order::Integer=4,
-    knots::Union{Symbol,AbstractVector{<:Real}}=:auto,
+    num_bases::Integer; order::Integer=4, knots::Union{Symbol,AbstractVector{<:Real}}=:auto
 )
     num_bases >= order ||
         throw(ArgumentError("num_bases ($num_bases) must be >= order ($order)."))
@@ -33,11 +31,7 @@ function BSpline(
     elseif knots === :auto
         :auto
     else
-        throw(
-            ArgumentError(
-                "knots must be :auto or an AbstractVector, got $(typeof(knots)).",
-            ),
-        )
+        throw(ArgumentError("knots must be :auto or an AbstractVector, got $(typeof(knots))."))
     end
     return BSpline{typeof(knots_resolved)}(Int(num_bases), Int(order), knots_resolved)
 end

--- a/src/bases/Bases.jl
+++ b/src/bases/Bases.jl
@@ -1,0 +1,173 @@
+"""
+    AbstractInputBasis
+
+Abstract supertype for time-varying input bases. A concrete subtype
+`B <: AbstractInputBasis` describes a set of basis functions
+`{φ_1, …, φ_K}` over the time domain `1:tsteps`, and is used to construct
+the `(P*K, tsteps, ntrials)` input array stored in `data.u` (dynamics) or
+`data.d` (observation).
+
+# Required interface
+
+Each concrete subtype must implement two methods:
+
+- [`n_bases`](@ref): `n_bases(b) -> Int` — number of basis functions `K`.
+- [`evaluate_basis`](@ref): `evaluate_basis(b, ts) -> Matrix` — returns a
+  `(length(ts) × K)` matrix `Φ` with `Φ[i, k] = φ_k(ts[i])`. The element
+  type of the returned matrix should match `eltype(ts)`.
+
+The generic [`apply!`](@ref) and [`get_penalty`](@ref) methods are written
+in terms of those two primitives. Concrete bases may override
+`get_penalty` to provide an analytic closed form (see [`Fourier`](@ref)).
+"""
+abstract type AbstractInputBasis end
+
+"""
+    n_bases(b::AbstractInputBasis) -> Int
+
+Number of basis functions in `b`. Every concrete `AbstractInputBasis` must
+implement this method.
+"""
+function n_bases end
+
+"""
+    evaluate_basis(b::AbstractInputBasis, ts::AbstractVector{<:Real}) -> Matrix
+
+Evaluate the basis at the points `ts`. Returns a `(length(ts), n_bases(b))`
+matrix `Φ` with `Φ[i, k] = φ_k(ts[i])`. Every concrete `AbstractInputBasis`
+must implement this method.
+"""
+function evaluate_basis end
+
+"""
+    apply!(data::Data{T}, basis::AbstractInputBasis; target::Symbol=:u) where {T<:Real}
+
+Construct the time-varying input array
+`kron(data.trial_pred[n, :], B')` per trial, where `B` is the
+`(tsteps × n_bases(basis))` basis matrix obtained by evaluating `basis` at
+the integer timesteps `1:tsteps`, and write it in place into `data.u`
+(when `target=:u`) or `data.d` (when `target=:d`) via `copyto!`.
+
+When `data.trial_pred` is empty, a single all-ones predictor is used so
+the per-trial input is just `B'`.
+
+The caller must pre-allocate `data.<target>` with shape
+`(P*K, tsteps, ntrials)` where `P = size(data.trial_pred, 2)` (or `1` when
+empty) and `K = n_bases(basis)`. A `DimensionMismatch` is thrown otherwise.
+
+Returns `nothing`.
+"""
+function apply!(
+    data::Data{T}, basis::AbstractInputBasis; target::Symbol=:u
+) where {T<:Real}
+    target in (:u, :d) ||
+        throw(ArgumentError("target must be :u or :d, got $(repr(target))."))
+
+    tsteps = size(data.y, 2)
+    ntrials = size(data.y, 3)
+
+    trial_pred = if isempty(data.trial_pred)
+        ones(T, ntrials, 1)
+    else
+        size(data.trial_pred, 1) == ntrials || throw(
+            DimensionMismatch(
+                "data.trial_pred has $(size(data.trial_pred, 1)) rows but data.y " *
+                "has $ntrials trials. trial_pred must be shape (ntrials, npredictors).",
+            ),
+        )
+        data.trial_pred
+    end
+    P = size(trial_pred, 2)
+    K = n_bases(basis)
+
+    target_arr = getfield(data, target)
+    size(target_arr) == (P * K, tsteps, ntrials) || throw(
+        DimensionMismatch(
+            "data.$target has shape $(size(target_arr)) but inputs require " *
+            "$((P * K, tsteps, ntrials)). Pre-allocate data.$target before calling.",
+        ),
+    )
+
+    ts = collect(T(1):T(tsteps))
+    B_raw = evaluate_basis(basis, ts)
+    B = eltype(B_raw) === T ? B_raw : convert(Matrix{T}, B_raw)
+    Bt = transpose(B)
+
+    @inbounds for n in 1:ntrials
+        for p in 1:P
+            row_start = (p - 1) * K + 1
+            row_end = p * K
+            coeff = trial_pred[n, p]
+            @views target_arr[row_start:row_end, :, n] .= coeff .* Bt
+        end
+    end
+    return nothing
+end
+
+"""
+    get_penalty(
+        basis::AbstractInputBasis,
+        tsteps::Integer;
+        P::Int=1,
+        eltype::Type{T}=Float64,
+        n_grid::Int=max(20 * tsteps, 200),
+    ) -> Matrix{T}
+
+Time-domain curvature penalty `kron(I_P, Ω_K)` for `basis` on the window
+`[1, tsteps]`. `Ω_K ≈ ∫ φ''(τ) φ''(τ)ᵀ dτ` is estimated on a fine grid of
+`n_grid` points via a centred second difference:
+
+```
+Φ  = evaluate_basis(basis, range(1, tsteps; length=n_grid))
+d² = diff(diff(Φ; dims=1); dims=1) ./ Δτ²
+Ω_K = Δτ · (d²)ᵀ d²
+```
+
+The penalty captures roughness in **time** (independent of how the basis
+indexes its coefficients), and so applies uniformly across bases — in
+particular it remains well-behaved for unequally-spaced bases such as the
+B-spline knot averaging.
+
+Concrete bases may specialise this method to return an analytic form
+instead; see [`get_penalty(::Fourier, ...)`](@ref).
+"""
+function get_penalty(
+    basis::AbstractInputBasis,
+    tsteps::Integer;
+    P::Int=1,
+    eltype::Type=Float64,
+    n_grid::Int=max(20 * Int(tsteps), 200),
+)
+    return _generic_curvature_penalty(basis, Int(tsteps), P, eltype, n_grid)
+end
+
+"""
+    get_penalty(data::Data{T}, basis::AbstractInputBasis; kwargs...) where {T} -> Matrix{T}
+
+Convenience overload that reads `tsteps` from `data.y`, `P` from
+`data.trial_pred` (or `1` when empty), and `eltype` from `T`. All keyword
+arguments are forwarded to the underlying `get_penalty(basis, tsteps; …)`
+method, so basis-specific keywords (e.g. `use_analytic=true` for
+[`Fourier`](@ref)) work transparently.
+"""
+function get_penalty(
+    data::Data{T}, basis::AbstractInputBasis; kwargs...
+) where {T<:Real}
+    tsteps = size(data.y, 2)
+    P = isempty(data.trial_pred) ? 1 : size(data.trial_pred, 2)
+    return get_penalty(basis, tsteps; P=P, eltype=T, kwargs...)
+end
+
+function _generic_curvature_penalty(
+    basis::AbstractInputBasis, tsteps::Int, P::Int, ::Type{T}, n_grid::Int
+) where {T<:Real}
+    n_grid >= 3 ||
+        throw(ArgumentError("n_grid ($n_grid) must be >= 3 for a 2nd difference."))
+    τ = collect(range(T(1), T(tsteps); length=n_grid))
+    Δτ = (T(tsteps) - one(T)) / T(n_grid - 1)
+    Φ_raw = evaluate_basis(basis, τ)
+    Φ = eltype(Φ_raw) === T ? Φ_raw : convert(Matrix{T}, Φ_raw)
+    d2 = diff(diff(Φ; dims=1); dims=1) ./ (Δτ * Δτ)
+    Ωk = Δτ .* (transpose(d2) * d2)
+    return kron(Matrix{T}(I, P, P), Ωk)
+end

--- a/src/bases/Bases.jl
+++ b/src/bases/Bases.jl
@@ -150,9 +150,7 @@ arguments are forwarded to the underlying `get_penalty(basis, tsteps; …)`
 method, so basis-specific keywords (e.g. `use_analytic=true` for
 [`Fourier`](@ref)) work transparently.
 """
-function get_penalty(
-    data::Data{T}, basis::AbstractInputBasis; kwargs...
-) where {T<:Real}
+function get_penalty(data::Data{T}, basis::AbstractInputBasis; kwargs...) where {T<:Real}
     tsteps = size(data.y, 2)
     P = isempty(data.epoch_pred) ? 1 : size(data.epoch_pred, 2)
     return get_penalty(basis, tsteps; P=P, eltype=T, kwargs...)
@@ -163,6 +161,10 @@ function _generic_curvature_penalty(
 ) where {T<:Real}
     n_grid >= 3 ||
         throw(ArgumentError("n_grid ($n_grid) must be >= 3 for a 2nd difference."))
+    if tsteps == 1
+        # return a zero penalty matrix
+        return zeros(T, P * n_bases(basis), P * n_bases(basis))
+    end
     τ = collect(range(T(1), T(tsteps); length=n_grid))
     Δτ = (T(tsteps) - one(T)) / T(n_grid - 1)
     Φ_raw = evaluate_basis(basis, τ)

--- a/src/bases/Bases.jl
+++ b/src/bases/Bases.jl
@@ -4,8 +4,8 @@
 Abstract supertype for time-varying input bases. A concrete subtype
 `B <: AbstractInputBasis` describes a set of basis functions
 `{φ_1, …, φ_K}` over the time domain `1:tsteps`, and is used to construct
-the `(P*K, tsteps, ntrials)` input array stored in `data.u` (dynamics) or
-`data.d` (observation).
+the `(P*K, tsteps, ntrials)` input array stored in `data.ux` (dynamics) or
+`data.uy` (observation).
 
 # Required interface
 
@@ -40,44 +40,44 @@ must implement this method.
 function evaluate_basis end
 
 """
-    apply!(data::Data{T}, basis::AbstractInputBasis; target::Symbol=:u) where {T<:Real}
+    apply!(data::Data{T}, basis::AbstractInputBasis; target::Symbol=:ux) where {T<:Real}
 
 Construct the time-varying input array
-`kron(data.trial_pred[n, :], B')` per trial, where `B` is the
+`kron(data.epoch_pred[n, :], B')` per trial, where `B` is the
 `(tsteps × n_bases(basis))` basis matrix obtained by evaluating `basis` at
-the integer timesteps `1:tsteps`, and write it in place into `data.u`
-(when `target=:u`) or `data.d` (when `target=:d`) via `copyto!`.
+the integer timesteps `1:tsteps`, and write it in place into `data.ux`
+(when `target=:ux`) or `data.uy` (when `target=:uy`) via `copyto!`.
 
-When `data.trial_pred` is empty, a single all-ones predictor is used so
+When `data.epoch_pred` is empty, a single all-ones predictor is used so
 the per-trial input is just `B'`.
 
 The caller must pre-allocate `data.<target>` with shape
-`(P*K, tsteps, ntrials)` where `P = size(data.trial_pred, 2)` (or `1` when
+`(P*K, tsteps, ntrials)` where `P = size(data.epoch_pred, 2)` (or `1` when
 empty) and `K = n_bases(basis)`. A `DimensionMismatch` is thrown otherwise.
 
 Returns `nothing`.
 """
 function apply!(
-    data::Data{T}, basis::AbstractInputBasis; target::Symbol=:u
+    data::Data{T}, basis::AbstractInputBasis; target::Symbol=:ux
 ) where {T<:Real}
-    target in (:u, :d) ||
-        throw(ArgumentError("target must be :u or :d, got $(repr(target))."))
+    target in (:ux, :uy) ||
+        throw(ArgumentError("target must be :ux or :uy, got $(repr(target))."))
 
     tsteps = size(data.y, 2)
     ntrials = size(data.y, 3)
 
-    trial_pred = if isempty(data.trial_pred)
+    epoch_pred = if isempty(data.epoch_pred)
         ones(T, ntrials, 1)
     else
-        size(data.trial_pred, 1) == ntrials || throw(
+        size(data.epoch_pred, 1) == ntrials || throw(
             DimensionMismatch(
-                "data.trial_pred has $(size(data.trial_pred, 1)) rows but data.y " *
-                "has $ntrials trials. trial_pred must be shape (ntrials, npredictors).",
+                "data.epoch_pred has $(size(data.epoch_pred, 1)) rows but data.y " *
+                "has $ntrials trials. epoch_pred must be shape (ntrials, npredictors).",
             ),
         )
-        data.trial_pred
+        data.epoch_pred
     end
-    P = size(trial_pred, 2)
+    P = size(epoch_pred, 2)
     K = n_bases(basis)
 
     target_arr = getfield(data, target)
@@ -97,7 +97,7 @@ function apply!(
         for p in 1:P
             row_start = (p - 1) * K + 1
             row_end = p * K
-            coeff = trial_pred[n, p]
+            coeff = epoch_pred[n, p]
             @views target_arr[row_start:row_end, :, n] .= coeff .* Bt
         end
     end
@@ -145,7 +145,7 @@ end
     get_penalty(data::Data{T}, basis::AbstractInputBasis; kwargs...) where {T} -> Matrix{T}
 
 Convenience overload that reads `tsteps` from `data.y`, `P` from
-`data.trial_pred` (or `1` when empty), and `eltype` from `T`. All keyword
+`data.epoch_pred` (or `1` when empty), and `eltype` from `T`. All keyword
 arguments are forwarded to the underlying `get_penalty(basis, tsteps; …)`
 method, so basis-specific keywords (e.g. `use_analytic=true` for
 [`Fourier`](@ref)) work transparently.
@@ -154,7 +154,7 @@ function get_penalty(
     data::Data{T}, basis::AbstractInputBasis; kwargs...
 ) where {T<:Real}
     tsteps = size(data.y, 2)
-    P = isempty(data.trial_pred) ? 1 : size(data.trial_pred, 2)
+    P = isempty(data.epoch_pred) ? 1 : size(data.epoch_pred, 2)
     return get_penalty(basis, tsteps; P=P, eltype=T, kwargs...)
 end
 

--- a/src/bases/Fourier.jl
+++ b/src/bases/Fourier.jl
@@ -1,0 +1,99 @@
+"""
+    Fourier(num_bases::Int; period=nothing) <: AbstractInputBasis
+
+Fourier basis of `num_bases` functions. The first function is the DC term
+(constant `1`), followed by alternating cosine/sine pairs at increasing
+integer multiples of the fundamental frequency `2π / period`:
+
+    φ_1(t)       = 1                              (DC, freq = 0)
+    φ_{2k}(t)    = cos(2π · k · t / period)
+    φ_{2k+1}(t)  = sin(2π · k · t / period)       for k = 1, 2, …
+
+For odd `num_bases = 2m+1` the basis includes the full `[cos(k), sin(k)]`
+pair up through `k = m`. For even `num_bases = 2m`, the last function is
+an extra `cos((m)·…)` (no matching `sin`).
+
+`period === nothing` (default) → `period = last(ts) - first(ts) + 1` at
+evaluation time, which equals `tsteps` for the standard `1:tsteps` grid.
+"""
+struct Fourier <: AbstractInputBasis
+    num_bases::Int
+    period::Union{Nothing,Float64}
+end
+
+function Fourier(num_bases::Integer; period::Union{Nothing,Real}=nothing)
+    num_bases >= 1 || throw(ArgumentError("num_bases ($num_bases) must be >= 1."))
+    if period !== nothing
+        period > 0 || throw(ArgumentError("period must be > 0, got $period."))
+    end
+    return Fourier(Int(num_bases), period === nothing ? nothing : Float64(period))
+end
+
+n_bases(b::Fourier) = b.num_bases
+
+# Frequency index per basis function: [0, 1, 1, 2, 2, 3, 3, …].
+_fourier_freqs(N::Int) = Int[j == 1 ? 0 : div(j, 2) for j in 1:N]
+
+function _resolve_period(b::Fourier, ts::AbstractVector{T}) where {T<:Real}
+    return b.period === nothing ? T(last(ts) - first(ts) + 1) : T(b.period)
+end
+
+function evaluate_basis(b::Fourier, ts::AbstractVector{T}) where {T<:Real}
+    N = b.num_bases
+    M = length(ts)
+    Tp = _resolve_period(b, ts)
+    ω = T(2π) / Tp
+
+    Φ = Matrix{T}(undef, M, N)
+    @inbounds for i in 1:M
+        Φ[i, 1] = one(T)
+    end
+    @inbounds for j in 2:N
+        k = div(j, 2)
+        is_cos = iseven(j)
+        for i in 1:M
+            arg = ω * T(k) * T(ts[i])
+            Φ[i, j] = is_cos ? cos(arg) : sin(arg)
+        end
+    end
+    return Φ
+end
+
+"""
+    get_penalty(
+        basis::Fourier,
+        tsteps::Integer;
+        P::Int=1,
+        eltype::Type=Float64,
+        use_analytic::Bool=true,
+        n_grid::Int=max(20*tsteps, 200),
+    ) -> Matrix
+
+Fourier-specialised curvature penalty.
+
+When `use_analytic = true` (default), returns the closed-form diagonal
+`kron(I_P, Diagonal((2π · freq / Tp).^4))` with `freq = [0, 1, 1, 2, 2, …]`
+and `Tp` equal to `basis.period` (or `tsteps` when auto). The DC entry is
+exactly zero, so the constant direction lies in the penalty's nullspace.
+
+When `use_analytic = false`, falls back to the generic finite-difference
+curvature penalty on `n_grid` points.
+"""
+function get_penalty(
+    basis::Fourier,
+    tsteps::Integer;
+    P::Int=1,
+    eltype::Type=Float64,
+    use_analytic::Bool=true,
+    n_grid::Int=max(20 * Int(tsteps), 200),
+)
+    if !use_analytic
+        return _generic_curvature_penalty(basis, Int(tsteps), P, eltype, n_grid)
+    end
+    T = eltype
+    Tp = basis.period === nothing ? T(tsteps) : T(basis.period)
+    freqs = _fourier_freqs(basis.num_bases)
+    diag_entries = T[(T(2π) * T(f) / Tp)^4 for f in freqs]
+    Ωk = Matrix{T}(Diagonal(diag_entries))
+    return kron(Matrix{T}(I, P, P), Ωk)
+end

--- a/src/bases/Polynomial.jl
+++ b/src/bases/Polynomial.jl
@@ -1,0 +1,43 @@
+"""
+    Polynomial(num_bases::Int) <: AbstractInputBasis
+
+Monomial polynomial basis on the time window normalised to `[0, 1]`:
+
+    φ_k(t) = ((t - first(ts)) / (last(ts) - first(ts)))^(k - 1)
+             for k = 1, …, num_bases.
+
+The first basis function is the constant `1` and the second is the
+normalised linear ramp; both lie in the nullspace of the curvature
+penalty. For `num_bases ≳ 10` the monomial basis becomes ill-conditioned
+— consider [`BSpline`](@ref) or [`Fourier`](@ref) for smoother fits at
+high `num_bases`.
+"""
+struct Polynomial <: AbstractInputBasis
+    num_bases::Int
+end
+
+function Polynomial(num_bases::Integer)
+    num_bases >= 1 || throw(ArgumentError("num_bases ($num_bases) must be >= 1."))
+    return Polynomial(Int(num_bases))
+end
+
+n_bases(b::Polynomial) = b.num_bases
+
+function evaluate_basis(b::Polynomial, ts::AbstractVector{T}) where {T<:Real}
+    K = b.num_bases
+    M = length(ts)
+    tmin = T(first(ts))
+    tmax = T(last(ts))
+    span = tmax - tmin
+    span = iszero(span) ? one(T) : span
+
+    Φ = Matrix{T}(undef, M, K)
+    @inbounds for i in 1:M
+        x = (T(ts[i]) - tmin) / span
+        Φ[i, 1] = one(T)
+        for k in 2:K
+            Φ[i, k] = Φ[i, k - 1] * x
+        end
+    end
+    return Φ
+end

--- a/src/bases/Polynomial.jl
+++ b/src/bases/Polynomial.jl
@@ -17,7 +17,7 @@ struct Polynomial <: AbstractInputBasis
 
     function Polynomial(num_bases::Int)
         num_bases >= 1 || throw(ArgumentError("num_bases ($num_bases) must be >= 1."))
-        new(num_bases)
+        return new(num_bases)
     end
 end
 

--- a/src/bases/Polynomial.jl
+++ b/src/bases/Polynomial.jl
@@ -14,11 +14,11 @@ high `num_bases`.
 """
 struct Polynomial <: AbstractInputBasis
     num_bases::Int
-end
 
-function Polynomial(num_bases::Integer)
-    num_bases >= 1 || throw(ArgumentError("num_bases ($num_bases) must be >= 1."))
-    return Polynomial(Int(num_bases))
+    function Polynomial(num_bases::Int)
+        num_bases >= 1 || throw(ArgumentError("num_bases ($num_bases) must be >= 1."))
+        new(num_bases)
+    end
 end
 
 n_bases(b::Polynomial) = b.num_bases

--- a/src/bases/RaisedCosine.jl
+++ b/src/bases/RaisedCosine.jl
@@ -1,0 +1,87 @@
+abstract type AbstractRaisedCosineBasis <: AbstractInputBasis end
+
+"""
+    RaisedCosineLinear(num_bases::Int; width_factor::Real=2.0) <: AbstractInputBasis
+
+Raised-cosine bumps with centres equally spaced on
+`[first(ts), last(ts)]`. With spacing `dc = (last - first) / (K - 1)`,
+the half-width is `w = width_factor · dc`:
+
+    φ_k(t) = 0.5 · (1 + cos((t - c_k) · π / w))   for |t - c_k| ≤ w,
+             0                                       otherwise.
+
+The default `width_factor = 2.0` makes adjacent bumps overlap at
+half-amplitude (Pillow / nemos convention). Requires `num_bases ≥ 2`.
+"""
+struct RaisedCosineLinear <: AbstractRaisedCosineBasis
+    num_bases::Int
+    width_factor::Float64
+end
+
+function RaisedCosineLinear(num_bases::Integer; width_factor::Real=2.0)
+    num_bases >= 2 || throw(
+        ArgumentError("RaisedCosineLinear requires num_bases >= 2, got $num_bases.")
+    )
+    width_factor > 0 ||
+        throw(ArgumentError("width_factor must be > 0, got $width_factor."))
+    return RaisedCosineLinear(Int(num_bases), Float64(width_factor))
+end
+
+"""
+    RaisedCosineLog(num_bases::Int; width_factor::Real=2.0, offset::Real=1.0) <: AbstractInputBasis
+
+Like [`RaisedCosineLinear`](@ref), but centres are equally spaced in
+`log(t + offset)` space rather than in `t`. Bumps are narrow near the
+start of the window and broad near the end — useful for spike-history
+filters and other responses whose dynamics evolve on a log time scale
+(Pillow 2005, nemos `RaisedCosineLog`). `offset > 0` keeps `log` finite
+when `t = 0`. Requires `num_bases ≥ 2`.
+"""
+struct RaisedCosineLog <: AbstractRaisedCosineBasis
+    num_bases::Int
+    width_factor::Float64
+    offset::Float64
+end
+
+function RaisedCosineLog(
+    num_bases::Integer; width_factor::Real=2.0, offset::Real=1.0
+)
+    num_bases >= 2 ||
+        throw(ArgumentError("RaisedCosineLog requires num_bases >= 2, got $num_bases."))
+    width_factor > 0 ||
+        throw(ArgumentError("width_factor must be > 0, got $width_factor."))
+    offset > 0 || throw(ArgumentError("offset must be > 0, got $offset."))
+    return RaisedCosineLog(Int(num_bases), Float64(width_factor), Float64(offset))
+end
+
+n_bases(b::AbstractRaisedCosineBasis) = b.num_bases
+
+_rc_transform(::RaisedCosineLinear, ts::AbstractVector{T}) where {T<:Real} = T.(ts)
+function _rc_transform(b::RaisedCosineLog, ts::AbstractVector{T}) where {T<:Real}
+    return log.(T.(ts) .+ T(b.offset))
+end
+
+function evaluate_basis(
+    b::AbstractRaisedCosineBasis, ts::AbstractVector{T}
+) where {T<:Real}
+    K = b.num_bases
+    M = length(ts)
+    gt = _rc_transform(b, ts)
+    gmin, gmax = first(gt), last(gt)
+    centers = collect(range(gmin, gmax; length=K))
+    dc = (gmax - gmin) / T(K - 1)
+    w = T(b.width_factor) * dc
+    π_T = T(π)
+
+    Φ = zeros(T, M, K)
+    @inbounds for k in 1:K
+        c = centers[k]
+        for i in 1:M
+            arg = (gt[i] - c) * π_T / w
+            if -π_T <= arg <= π_T
+                Φ[i, k] = T(0.5) * (one(T) + cos(arg))
+            end
+        end
+    end
+    return Φ
+end

--- a/src/bases/RaisedCosine.jl
+++ b/src/bases/RaisedCosine.jl
@@ -19,11 +19,9 @@ struct RaisedCosineLinear <: AbstractRaisedCosineBasis
 end
 
 function RaisedCosineLinear(num_bases::Integer; width_factor::Real=2.0)
-    num_bases >= 2 || throw(
-        ArgumentError("RaisedCosineLinear requires num_bases >= 2, got $num_bases.")
-    )
-    width_factor > 0 ||
-        throw(ArgumentError("width_factor must be > 0, got $width_factor."))
+    num_bases >= 2 ||
+        throw(ArgumentError("RaisedCosineLinear requires num_bases >= 2, got $num_bases."))
+    width_factor > 0 || throw(ArgumentError("width_factor must be > 0, got $width_factor."))
     return RaisedCosineLinear(Int(num_bases), Float64(width_factor))
 end
 
@@ -43,13 +41,10 @@ struct RaisedCosineLog <: AbstractRaisedCosineBasis
     offset::Float64
 end
 
-function RaisedCosineLog(
-    num_bases::Integer; width_factor::Real=2.0, offset::Real=1.0
-)
+function RaisedCosineLog(num_bases::Integer; width_factor::Real=2.0, offset::Real=1.0)
     num_bases >= 2 ||
         throw(ArgumentError("RaisedCosineLog requires num_bases >= 2, got $num_bases."))
-    width_factor > 0 ||
-        throw(ArgumentError("width_factor must be > 0, got $width_factor."))
+    width_factor > 0 || throw(ArgumentError("width_factor must be > 0, got $width_factor."))
     offset > 0 || throw(ArgumentError("offset must be > 0, got $offset."))
     return RaisedCosineLog(Int(num_bases), Float64(width_factor), Float64(offset))
 end
@@ -61,9 +56,7 @@ function _rc_transform(b::RaisedCosineLog, ts::AbstractVector{T}) where {T<:Real
     return log.(T.(ts) .+ T(b.offset))
 end
 
-function evaluate_basis(
-    b::AbstractRaisedCosineBasis, ts::AbstractVector{T}
-) where {T<:Real}
+function evaluate_basis(b::AbstractRaisedCosineBasis, ts::AbstractVector{T}) where {T<:Real}
     K = b.num_bases
     M = length(ts)
     gt = _rc_transform(b, ts)

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -13,9 +13,21 @@ dynamics (latent) inputs `ux`, and observation inputs `uy`, each `(dim, tsteps, 
 """
 Base.@kwdef struct Data{T<:Real}
     y::Array{T,3}
-    ux::Array{T,3}
-    uy::Array{T,3}
+    ux::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
+    uy::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
+    epoch_pred::Matrix{T} = Matrix{Float64}(undef, 0, 0)
 end
+
+# ensure that epoch_pred type matches input types
+function Data(
+    y::Array{T,3}, 
+    ux::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)), 
+    uy::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)), 
+    epoch_pred::Matrix{Any}=Matrix{T}(undef, 0, 0)) where {T<:Real}
+    return Data{T}(y, ux, uy, convert(Matrix{T}, epoch_pred))
+end
+
+
 
 """
     GaussianStateModel{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}}

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -15,19 +15,18 @@ Base.@kwdef struct Data{T<:Real}
     y::Array{T,3}
     ux::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
     uy::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
-    epoch_pred::Matrix{T} = Matrix{Float64}(undef, 0, 0)
+    epoch_pred::Matrix{T} = Matrix{T}(undef, 0, 0)
 end
 
 # ensure that epoch_pred type matches input types
 function Data(
-    y::Array{T,3}, 
-    ux::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)), 
-    uy::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)), 
-    epoch_pred::Matrix{Any}=Matrix{T}(undef, 0, 0)) where {T<:Real}
+    y::Array{T,3},
+    ux::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)),
+    uy::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)),
+    epoch_pred::AbstractMatrix=Matrix{T}(undef, 0, 0),
+) where {T<:Real}
     return Data{T}(y, ux, uy, convert(Matrix{T}, epoch_pred))
 end
-
-
 
 """
     GaussianStateModel{T<:Real, M<:AbstractMatrix{T}, V<:AbstractVector{T}}

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -13,19 +13,24 @@ dynamics (latent) inputs `ux`, and observation inputs `uy`, each `(dim, tsteps, 
 """
 Base.@kwdef struct Data{T<:Real}
     y::Array{T,3}
-    ux::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
-    uy::Array{T,3} = zeros(T, 0, size(y, 2), size(y, 3))
-    epoch_pred::Matrix{T} = Matrix{T}(undef, 0, 0)
+    ux::Array{T,3} = zeros(eltype(y), 0, size(y, 2), size(y, 3))
+    uy::Array{T,3} = zeros(eltype(y), 0, size(y, 2), size(y, 3))
+    epoch_pred::Matrix{T} = Matrix{eltype(y)}(undef, 0, 1)
 end
 
 # ensure that epoch_pred type matches input types
+_epoch_matrix(::Type{T}, A::AbstractMatrix{<:Real}) where {T<:Real} = convert(Matrix{T}, A)
+function _epoch_matrix(::Type{T}, v::AbstractVector{<:Real}) where {T<:Real}
+    return isempty(v) ? Matrix{T}(undef, 0, 0) : convert(Matrix{T}, reshape(v, :, 1))
+end
+
 function Data(
     y::Array{T,3},
     ux::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)),
     uy::Array{T,3}=zeros(T, 0, size(y, 2), size(y, 3)),
-    epoch_pred::AbstractMatrix=Matrix{T}(undef, 0, 0),
+    epoch_pred::AbstractVecOrMat{<:Real}=Matrix{T}(undef, 0, 0),
 ) where {T<:Real}
-    return Data{T}(y, ux, uy, convert(Matrix{T}, epoch_pred))
+    return Data{T}(y, ux, uy, _epoch_matrix(T, epoch_pred))
 end
 
 """

--- a/test/Bases/Bases.jl
+++ b/test/Bases/Bases.jl
@@ -1,0 +1,390 @@
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+# Construct one basis of each concrete type, all with the same number of
+# functions, suitable for the generic tests that work over any basis.
+function _example_bases(K::Int)
+    return [
+        BSpline(K; order=4),
+        Fourier(K),
+        RaisedCosineLinear(K),
+        RaisedCosineLog(K),
+        Polynomial(K),
+    ]
+end
+
+# Build a Data struct with pre-allocated `u` (or `d`) sized for P predictors
+# × K basis functions × tsteps × ntrials. Pass `P=0` for an empty
+# `trial_pred` (apply! then uses the default single all-ones predictor, so
+# the target field is sized as if `P=1`).
+function _make_data(
+    ::Type{T}, K::Int, tsteps::Int, ntrials::Int, P::Int; field::Symbol=:u
+) where {T<:Real}
+    P_eff = max(P, 1)
+    y = randn(MersenneTwister(0), T, 1, tsteps, ntrials)
+    u = if field == :u
+        zeros(T, P_eff * K, tsteps, ntrials)
+    else
+        zeros(T, 1, tsteps, ntrials)
+    end
+    d = if field == :d
+        zeros(T, P_eff * K, tsteps, ntrials)
+    else
+        zeros(T, 1, tsteps, ntrials)
+    end
+    trial_pred = P == 0 ? Matrix{T}(undef, 0, 0) : ones(T, ntrials, P)
+    return Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+end
+
+# ---------------------------------------------------------------------------
+# Generic apply!/get_penalty
+# ---------------------------------------------------------------------------
+
+function test_apply_shape_and_kron_structure()
+    T = Float64
+    tsteps, ntrials, K, P = 30, 4, 6, 3
+    rng = MersenneTwister(123)
+    trial_pred = randn(rng, T, ntrials, P)
+
+    for basis in _example_bases(K)
+        y = randn(rng, T, 2, tsteps, ntrials)
+        u = zeros(T, P * K, tsteps, ntrials)
+        d = zeros(T, 1, tsteps, ntrials)
+        data = Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+
+        apply!(data, basis; target=:u)
+        @test size(data.u) == (P * K, tsteps, ntrials)
+        @test eltype(data.u) === T
+
+        # Per-predictor block within a single trial = trial_pred[n,p] × B'.
+        coeff_ref = trial_pred[1, 1]
+        @assert abs(coeff_ref) > 1e-6
+        Bt_recovered = data.u[1:K, :, 1] ./ coeff_ref
+        for n in 1:ntrials, p in 1:P
+            rows = ((p - 1) * K + 1):(p * K)
+            @test data.u[rows, :, n] ≈ trial_pred[n, p] .* Bt_recovered atol = 1e-10
+        end
+    end
+end
+
+function test_apply_default_trial_pred_broadcasts_across_trials()
+    T = Float64
+    tsteps, ntrials, K = 25, 5, 5
+    for basis in _example_bases(K)
+        data = _make_data(T, K, tsteps, ntrials, 0)  # empty trial_pred
+        apply!(data, basis)
+        for n in 2:ntrials
+            @test data.u[:, :, n] ≈ data.u[:, :, 1] atol = 1e-14
+        end
+    end
+end
+
+function test_apply_target_d()
+    T = Float64
+    tsteps, ntrials, K, P = 20, 3, 4, 2
+    basis = Fourier(K)
+    data = _make_data(T, K, tsteps, ntrials, P; field=:d)
+    @test size(data.d) == (P * K, tsteps, ntrials)
+    apply!(data, basis; target=:d)
+    @test !all(iszero, data.d)
+    @test all(iszero, data.u)  # u was 1-row, untouched
+end
+
+function test_apply_size_mismatch_throws()
+    T = Float64
+    tsteps, ntrials, K, P = 20, 2, 4, 2
+    basis = BSpline(K)
+    y = randn(T, 1, tsteps, ntrials)
+    # P*K = 8, but allocate 5 rows.
+    u = zeros(T, 5, tsteps, ntrials)
+    d = zeros(T, 1, tsteps, ntrials)
+    data = Data(; y=y, u=u, d=d, trial_pred=ones(T, ntrials, P))
+    @test_throws DimensionMismatch apply!(data, basis)
+end
+
+function test_apply_trial_pred_row_mismatch_throws()
+    T = Float64
+    tsteps, ntrials, K = 20, 4, 4
+    basis = BSpline(K)
+    y = randn(T, 1, tsteps, ntrials)
+    u = zeros(T, K, tsteps, ntrials)
+    d = zeros(T, 1, tsteps, ntrials)
+    data = Data(; y=y, u=u, d=d, trial_pred=ones(T, 3, 1))  # 3 ≠ 4
+    @test_throws DimensionMismatch apply!(data, basis)
+end
+
+function test_apply_invalid_target_throws()
+    T = Float64
+    data = _make_data(T, 4, 20, 2, 1)
+    @test_throws ArgumentError apply!(data, BSpline(4); target=:bogus)
+end
+
+function test_get_penalty_data_convenience_overload()
+    T = Float64
+    tsteps, ntrials, K, P = 30, 2, 5, 3
+    basis = BSpline(K)
+    data = _make_data(T, K, tsteps, ntrials, P)
+
+    Ω_direct = get_penalty(basis, tsteps; P=P, eltype=T)
+    Ω_data = get_penalty(data, basis)
+    @test size(Ω_data) == (P * K, P * K)
+    @test eltype(Ω_data) === T
+    @test Ω_data ≈ Ω_direct
+end
+
+function test_get_penalty_kron_block_structure()
+    T = Float64
+    tsteps, K, P = 30, 6, 4
+    basis = BSpline(K)
+    Ω = get_penalty(basis, tsteps; P=P, eltype=T)
+    Ω_single = get_penalty(basis, tsteps; P=1, eltype=T)
+
+    @test size(Ω) == (P * K, P * K)
+    @test size(Ω_single) == (K, K)
+    for i in 1:P, j in 1:P
+        rows = ((i - 1) * K + 1):(i * K)
+        cols = ((j - 1) * K + 1):(j * K)
+        block = Ω[rows, cols]
+        if i == j
+            @test block ≈ Ω_single atol = 1e-12
+        else
+            @test all(iszero, block)
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+# BSpline specifics
+# ---------------------------------------------------------------------------
+
+function test_bspline_partition_of_unity()
+    T = Float64
+    tsteps, K = 25, 6
+    basis = BSpline(K)
+    B = evaluate_basis(basis, collect(T(1):T(tsteps)))
+    row_sums = vec(sum(B; dims=2))
+    @test all(abs.(row_sums .- one(T)) .< 1e-10)
+end
+
+function test_bspline_manual_knots()
+    T = Float64
+    tsteps, K, order = 40, 8, 4
+    knots = collect(range(T(1), T(tsteps); length=K - order + 2))
+    basis = BSpline(K; order=order, knots=knots)
+    B = evaluate_basis(basis, collect(T(1):T(tsteps)))
+    @test size(B) == (tsteps, K)
+    row_sums = vec(sum(B; dims=2))
+    @test all(abs.(row_sums .- one(T)) .< 1e-10)
+end
+
+function test_bspline_manual_knots_wrong_length_throws()
+    bad_knots = collect(1.0:5.0)  # need K-order+2 = 4; pass 5
+    basis = BSpline(6; order=4, knots=bad_knots)
+    @test_throws ArgumentError evaluate_basis(basis, collect(1.0:20.0))
+end
+
+function test_bspline_invalid_args()
+    @test_throws ArgumentError BSpline(3; order=4)        # num_bases < order
+    @test_throws ArgumentError BSpline(4; order=0)        # order < 1
+    @test_throws ArgumentError BSpline(4; knots=:bogus)   # bad knots symbol
+end
+
+# ---------------------------------------------------------------------------
+# Fourier specifics
+# ---------------------------------------------------------------------------
+
+function test_fourier_basis_values()
+    T = Float64
+    tsteps, K = 32, 5
+    basis = Fourier(K)
+    ts = collect(T(1):T(tsteps))
+    Φ = evaluate_basis(basis, ts)
+    @test size(Φ) == (tsteps, K)
+
+    # Column 1: DC, all ones.
+    @test all(Φ[:, 1] .≈ one(T))
+
+    # Column 2/3 = cos/sin at freq 1; column 4/5 = cos/sin at freq 2.
+    Tp = T(tsteps)
+    @test Φ[:, 2] ≈ cos.(T(2π) .* ts ./ Tp)
+    @test Φ[:, 3] ≈ sin.(T(2π) .* ts ./ Tp)
+    @test Φ[:, 4] ≈ cos.(T(2π) .* T(2) .* ts ./ Tp)
+    @test Φ[:, 5] ≈ sin.(T(2π) .* T(2) .* ts ./ Tp)
+end
+
+function test_fourier_analytic_penalty_dc_nullspace()
+    T = Float64
+    tsteps, K = 50, 7
+    basis = Fourier(K)
+    Ω = get_penalty(basis, tsteps; eltype=T, use_analytic=true)
+
+    @test issymmetric(Ω)
+    @test isdiag(Ω)
+    # DC entry is zero.
+    @test Ω[1, 1] == zero(T)
+    # Frequency 1 entries (cos, sin) are equal and positive.
+    @test Ω[2, 2] > 0
+    @test Ω[2, 2] ≈ Ω[3, 3] atol = 1e-14
+    # Frequency 2 > frequency 1 (higher curvature for higher freq).
+    @test Ω[4, 4] > Ω[2, 2]
+end
+
+function test_fourier_analytic_vs_discrete_ordering()
+    # The analytic-vs-discrete penalties differ by a basis-dependent scale,
+    # but both should rank-order the diagonal the same way (higher freq →
+    # larger penalty).
+    T = Float64
+    tsteps, K = 60, 7
+    basis = Fourier(K)
+    Ω_an = get_penalty(basis, tsteps; eltype=T, use_analytic=true)
+    Ω_di = get_penalty(basis, tsteps; eltype=T, use_analytic=false)
+
+    diag_an = diag(Ω_an)
+    diag_di = diag(Ω_di)
+    @test diag_an[1] == 0
+    @test all(diag_an[2:end] .> 0)
+    @test all(diag_di[2:end] .> 0)
+    # Both penalties should rank cos₂ above cos₁.
+    @test diag_an[4] > diag_an[2]
+    @test diag_di[4] > diag_di[2]
+end
+
+function test_fourier_period_kwarg()
+    T = Float64
+    tsteps, K = 40, 3
+    period = 100.0  # explicit override
+    basis = Fourier(K; period=period)
+    Φ = evaluate_basis(basis, collect(T(1):T(tsteps)))
+    @test Φ[:, 2] ≈ cos.(T(2π) .* collect(T(1):T(tsteps)) ./ T(period))
+end
+
+# ---------------------------------------------------------------------------
+# RaisedCosine specifics
+# ---------------------------------------------------------------------------
+
+function test_raised_cosine_linear_bumps()
+    T = Float64
+    tsteps, K = 50, 6
+    basis = RaisedCosineLinear(K; width_factor=2.0)
+    ts = collect(T(1):T(tsteps))
+    Φ = evaluate_basis(basis, ts)
+
+    @test size(Φ) == (tsteps, K)
+    @test all(Φ .>= 0)
+    @test all(Φ .<= 1.0 + 1e-12)
+
+    # At each centre c_k, basis k attains the maximum value 1.
+    centers = range(T(1), T(tsteps); length=K)
+    for k in 1:K
+        c = centers[k]
+        # The nearest grid point to c should give Φ near 1 for basis k.
+        i = argmin(abs.(ts .- c))
+        @test Φ[i, k] > 0.99
+    end
+end
+
+function test_raised_cosine_log_bumps()
+    T = Float64
+    tsteps, K = 50, 5
+    basis = RaisedCosineLog(K; width_factor=2.0, offset=1.0)
+    ts = collect(T(1):T(tsteps))
+    Φ = evaluate_basis(basis, ts)
+
+    @test size(Φ) == (tsteps, K)
+    @test all(Φ .>= 0)
+    @test all(Φ .<= 1.0 + 1e-12)
+
+    # Log spacing → bumps narrower near the start, wider near the end.
+    # First basis has a narrower support (in t) than the last basis.
+    support_first = count(Φ[:, 1] .> 1e-6)
+    support_last = count(Φ[:, end] .> 1e-6)
+    @test support_first < support_last
+end
+
+function test_raised_cosine_invalid_args()
+    @test_throws ArgumentError RaisedCosineLinear(1)
+    @test_throws ArgumentError RaisedCosineLinear(4; width_factor=-1.0)
+    @test_throws ArgumentError RaisedCosineLog(1)
+    @test_throws ArgumentError RaisedCosineLog(4; offset=0.0)
+end
+
+# ---------------------------------------------------------------------------
+# Polynomial specifics
+# ---------------------------------------------------------------------------
+
+function test_polynomial_values()
+    T = Float64
+    tsteps, K = 20, 4
+    basis = Polynomial(K)
+    ts = collect(T(1):T(tsteps))
+    Φ = evaluate_basis(basis, ts)
+
+    @test size(Φ) == (tsteps, K)
+    @test all(Φ[:, 1] .≈ one(T))
+    x = (ts .- one(T)) ./ T(tsteps - 1)
+    @test Φ[:, 2] ≈ x
+    @test Φ[:, 3] ≈ x .^ 2
+    @test Φ[:, 4] ≈ x .^ 3
+end
+
+function test_polynomial_invalid_args()
+    @test_throws ArgumentError Polynomial(0)
+end
+
+# ---------------------------------------------------------------------------
+# Curvature penalty properties
+# ---------------------------------------------------------------------------
+
+function test_curvature_penalty_symmetric_psd_all_bases()
+    T = Float64
+    tsteps, K = 40, 6
+    for basis in _example_bases(K)
+        Ω = get_penalty(basis, tsteps; P=1, eltype=T)
+        @test issymmetric(Ω)
+        eigs = eigvals(Symmetric(Ω))
+        @test all(eigs .>= -1e-8)
+    end
+end
+
+function test_curvature_penalty_nullspace_bspline()
+    # B-spline basis has partition of unity → all-ones coefficient vector
+    # gives a constant function in time, which is in the curvature nullspace.
+    T = Float64
+    tsteps, K = 40, 7
+    Ω = get_penalty(BSpline(K), tsteps; eltype=T)
+    @test maximum(abs.(Ω * ones(T, K))) < 1e-8
+end
+
+function test_curvature_penalty_nullspace_polynomial()
+    # Polynomial basis: constant (e_1) and linear (e_2) are both in nullspace.
+    T = Float64
+    tsteps, K = 40, 5
+    Ω = get_penalty(Polynomial(K), tsteps; eltype=T)
+    e1 = zeros(T, K)
+    e1[1] = one(T)
+    e2 = zeros(T, K)
+    e2[2] = one(T)
+    @test maximum(abs.(Ω * e1)) < 1e-8
+    @test maximum(abs.(Ω * e2)) < 1e-8
+end
+
+# ---------------------------------------------------------------------------
+# Type preservation
+# ---------------------------------------------------------------------------
+
+function test_float32_type_preservation_all_bases()
+    T = Float32
+    tsteps, ntrials, K, P = 25, 2, 4, 2
+    trial_pred = randn(MersenneTwister(7), T, ntrials, P)
+    for basis in _example_bases(K)
+        y = randn(MersenneTwister(8), T, 1, tsteps, ntrials)
+        u = zeros(T, P * K, tsteps, ntrials)
+        d = zeros(T, 1, tsteps, ntrials)
+        data = Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+        apply!(data, basis)
+        Ω = get_penalty(data, basis)
+        @test eltype(data.u) === T
+        @test eltype(Ω) === T
+    end
+end

--- a/test/Bases/Bases.jl
+++ b/test/Bases/Bases.jl
@@ -14,27 +14,27 @@ function _example_bases(K::Int)
     ]
 end
 
-# Build a Data struct with pre-allocated `u` (or `d`) sized for P predictors
+# Build a Data struct with pre-allocated `ux` (or `uy`) sized for P predictors
 # × K basis functions × tsteps × ntrials. Pass `P=0` for an empty
-# `trial_pred` (apply! then uses the default single all-ones predictor, so
+# `epoch_pred` (apply! then uses the default single all-ones predictor, so
 # the target field is sized as if `P=1`).
 function _make_data(
-    ::Type{T}, K::Int, tsteps::Int, ntrials::Int, P::Int; field::Symbol=:u
+    ::Type{T}, K::Int, tsteps::Int, ntrials::Int, P::Int; field::Symbol=:ux
 ) where {T<:Real}
     P_eff = max(P, 1)
     y = randn(MersenneTwister(0), T, 1, tsteps, ntrials)
-    u = if field == :u
+    ux = if field == :ux
         zeros(T, P_eff * K, tsteps, ntrials)
     else
         zeros(T, 1, tsteps, ntrials)
     end
-    d = if field == :d
+    uy = if field == :uy
         zeros(T, P_eff * K, tsteps, ntrials)
     else
         zeros(T, 1, tsteps, ntrials)
     end
-    trial_pred = P == 0 ? Matrix{T}(undef, 0, 0) : ones(T, ntrials, P)
-    return Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+    epoch_pred = P == 0 ? Matrix{T}(undef, 0, 0) : ones(T, ntrials, P)
+    return Data(; y=y, ux=ux, uy=uy, epoch_pred=epoch_pred)
 end
 
 # ---------------------------------------------------------------------------
@@ -45,25 +45,25 @@ function test_apply_shape_and_kron_structure()
     T = Float64
     tsteps, ntrials, K, P = 30, 4, 6, 3
     rng = MersenneTwister(123)
-    trial_pred = randn(rng, T, ntrials, P)
+    epoch_pred = randn(rng, T, ntrials, P)
 
     for basis in _example_bases(K)
         y = randn(rng, T, 2, tsteps, ntrials)
-        u = zeros(T, P * K, tsteps, ntrials)
-        d = zeros(T, 1, tsteps, ntrials)
-        data = Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+        ux = zeros(T, P * K, tsteps, ntrials)
+        uy = zeros(T, 1, tsteps, ntrials)
+        data = Data(; y=y, ux=ux, uy=uy, epoch_pred=epoch_pred)
 
-        apply!(data, basis; target=:u)
-        @test size(data.u) == (P * K, tsteps, ntrials)
-        @test eltype(data.u) === T
+        apply!(data, basis; target=:ux)
+        @test size(data.ux) == (P * K, tsteps, ntrials)
+        @test eltype(data.ux) === T
 
-        # Per-predictor block within a single trial = trial_pred[n,p] × B'.
-        coeff_ref = trial_pred[1, 1]
+        # Per-predictor block within a single trial = epoch_pred[n,p] × B'.
+        coeff_ref = epoch_pred[1, 1]
         @assert abs(coeff_ref) > 1e-6
-        Bt_recovered = data.u[1:K, :, 1] ./ coeff_ref
+        Bt_recovered = data.ux[1:K, :, 1] ./ coeff_ref
         for n in 1:ntrials, p in 1:P
             rows = ((p - 1) * K + 1):(p * K)
-            @test data.u[rows, :, n] ≈ trial_pred[n, p] .* Bt_recovered atol = 1e-10
+            @test data.ux[rows, :, n] ≈ epoch_pred[n, p] .* Bt_recovered atol = 1e-10
         end
     end
 end
@@ -72,10 +72,10 @@ function test_apply_default_trial_pred_broadcasts_across_trials()
     T = Float64
     tsteps, ntrials, K = 25, 5, 5
     for basis in _example_bases(K)
-        data = _make_data(T, K, tsteps, ntrials, 0)  # empty trial_pred
+        data = _make_data(T, K, tsteps, ntrials, 0)  # empty epoch_pred
         apply!(data, basis)
         for n in 2:ntrials
-            @test data.u[:, :, n] ≈ data.u[:, :, 1] atol = 1e-14
+            @test data.ux[:, :, n] ≈ data.ux[:, :, 1] atol = 1e-14
         end
     end
 end
@@ -84,11 +84,11 @@ function test_apply_target_d()
     T = Float64
     tsteps, ntrials, K, P = 20, 3, 4, 2
     basis = Fourier(K)
-    data = _make_data(T, K, tsteps, ntrials, P; field=:d)
-    @test size(data.d) == (P * K, tsteps, ntrials)
-    apply!(data, basis; target=:d)
-    @test !all(iszero, data.d)
-    @test all(iszero, data.u)  # u was 1-row, untouched
+    data = _make_data(T, K, tsteps, ntrials, P; field=:uy)
+    @test size(data.uy) == (P * K, tsteps, ntrials)
+    apply!(data, basis; target=:uy)
+    @test !all(iszero, data.uy)
+    @test all(iszero, data.ux)  # ux was 1-row, untouched
 end
 
 function test_apply_size_mismatch_throws()
@@ -97,9 +97,9 @@ function test_apply_size_mismatch_throws()
     basis = BSpline(K)
     y = randn(T, 1, tsteps, ntrials)
     # P*K = 8, but allocate 5 rows.
-    u = zeros(T, 5, tsteps, ntrials)
-    d = zeros(T, 1, tsteps, ntrials)
-    data = Data(; y=y, u=u, d=d, trial_pred=ones(T, ntrials, P))
+    ux = zeros(T, 5, tsteps, ntrials)
+    uy = zeros(T, 1, tsteps, ntrials)
+    data = Data(; y=y, ux=ux, uy=uy, epoch_pred=ones(T, ntrials, P))
     @test_throws DimensionMismatch apply!(data, basis)
 end
 
@@ -108,9 +108,9 @@ function test_apply_trial_pred_row_mismatch_throws()
     tsteps, ntrials, K = 20, 4, 4
     basis = BSpline(K)
     y = randn(T, 1, tsteps, ntrials)
-    u = zeros(T, K, tsteps, ntrials)
-    d = zeros(T, 1, tsteps, ntrials)
-    data = Data(; y=y, u=u, d=d, trial_pred=ones(T, 3, 1))  # 3 ≠ 4
+    ux = zeros(T, K, tsteps, ntrials)
+    uy = zeros(T, 1, tsteps, ntrials)
+    data = Data(; y=y, ux=ux, uy=uy, epoch_pred=ones(T, 3, 1))  # 3 ≠ 4
     @test_throws DimensionMismatch apply!(data, basis)
 end
 
@@ -376,15 +376,15 @@ end
 function test_float32_type_preservation_all_bases()
     T = Float32
     tsteps, ntrials, K, P = 25, 2, 4, 2
-    trial_pred = randn(MersenneTwister(7), T, ntrials, P)
+    epoch_pred = randn(MersenneTwister(7), T, ntrials, P)
     for basis in _example_bases(K)
         y = randn(MersenneTwister(8), T, 1, tsteps, ntrials)
-        u = zeros(T, P * K, tsteps, ntrials)
-        d = zeros(T, 1, tsteps, ntrials)
-        data = Data(; y=y, u=u, d=d, trial_pred=trial_pred)
+        ux = zeros(T, P * K, tsteps, ntrials)
+        uy = zeros(T, 1, tsteps, ntrials)
+        data = Data(; y=y, ux=ux, uy=uy, epoch_pred=epoch_pred)
         apply!(data, basis)
         Ω = get_penalty(data, basis)
-        @test eltype(data.u) === T
+        @test eltype(data.ux) === T
         @test eltype(Ω) === T
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,6 +278,52 @@ using SSDTest
         end
     end
 
+
+
+    # Input Basis Tests
+    @testset verbose=true "Input Bases" begin
+        include("Bases/Bases.jl")
+
+        @testset "Generic apply!/get_penalty" begin
+            test_apply_shape_and_kron_structure()
+            test_apply_default_trial_pred_broadcasts_across_trials()
+            test_apply_target_d()
+            test_apply_size_mismatch_throws()
+            test_apply_trial_pred_row_mismatch_throws()
+            test_apply_invalid_target_throws()
+            test_get_penalty_data_convenience_overload()
+            test_get_penalty_kron_block_structure()
+        end
+
+        @testset "Per-basis sanity" begin
+            test_bspline_partition_of_unity()
+            test_bspline_manual_knots()
+            test_bspline_manual_knots_wrong_length_throws()
+            test_bspline_invalid_args()
+            test_fourier_basis_values()
+            test_fourier_analytic_penalty_dc_nullspace()
+            test_fourier_analytic_vs_discrete_ordering()
+            test_fourier_period_kwarg()
+            test_raised_cosine_linear_bumps()
+            test_raised_cosine_log_bumps()
+            test_raised_cosine_invalid_args()
+            test_polynomial_values()
+            test_polynomial_invalid_args()
+        end
+
+        @testset "Curvature penalty properties" begin
+            test_curvature_penalty_symmetric_psd_all_bases()
+            test_curvature_penalty_nullspace_bspline()
+            test_curvature_penalty_nullspace_polynomial()
+        end
+
+        @testset "Type preservation" begin
+            test_float32_type_preservation_all_bases()
+        end
+    end
+
+
+
     # Conjugate-prior helpers (IW / MN MAP + log-prior terms)
     @testset verbose = true "Priors" begin
         include("Priors/Priors.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,10 +278,8 @@ using SSDTest
         end
     end
 
-
-
     # Input Basis Tests
-    @testset verbose=true "Input Bases" begin
+    @testset verbose = true "Input Bases" begin
         include("Bases/Bases.jl")
 
         @testset "Generic apply!/get_penalty" begin
@@ -321,8 +319,6 @@ using SSDTest
             test_float32_type_preservation_all_bases()
         end
     end
-
-
 
     # Conjugate-prior helpers (IW / MN MAP + log-prior terms)
     @testset verbose = true "Priors" begin


### PR DESCRIPTION
This pull request introduces a comprehensive input basis library for time-varying bases, such as B-spline, Fourier, raised cosine, and polynomial bases, to the codebase. It adds a new abstract interface for input bases, implements several concrete basis types, and integrates these bases into the main package. Additionally, it updates the `Data` structure to better support input predictors and provides utility functions for applying bases and computing curvature penalties.

The most important changes are:

### Input Basis Library and Interface

* Introduced the `AbstractInputBasis` interface in `src/bases/Bases.jl`, specifying required methods `n_bases` and `evaluate_basis`, and implemented generic utility functions such as `apply!` and `get_penalty` for use with any input basis.
* Added concrete basis types:
  - `BSpline` (B-spline basis with flexible knot placement) in `src/bases/BSpline.jl`
  - `Fourier` (Fourier basis with analytic curvature penalty) in `src/bases/Fourier.jl`
  - `RaisedCosineLinear` and `RaisedCosineLog` (raised cosine bases with linear/log spacing) in `src/bases/RaisedCosine.jl`
  - `Polynomial` (monomial polynomial basis) in `src/bases/Polynomial.jl`

### Integration and Exports

* Registered and exported the new basis types and their interface methods in `src/StateSpaceDynamics.jl`, and included the new basis source files.

### Data Structure Improvements

* Updated the `Data` struct in `src/lds/types.jl` to provide default zero-filled arrays for `ux` and `uy` and added an `epoch_pred` field for input predictors, with a constructor ensuring type consistency.

These changes collectively provide a flexible, extensible framework for handling time-varying input bases in state space models, enabling advanced input representations and regularization.


Addresses https://github.com/depasquale-lab/StateSpaceDynamics.jl/issues/118