### PR TITLE
feature: SSID

### DIFF
--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -50,6 +50,9 @@ include("lds/continuous_latents.jl")                # state-model Q-term + state
 include("lds/gaussian_observations.jl")
 include("lds/poisson_observations.jl")
 
+# initialization using subspace ID (SSID)
+include("init/SubspaceID.jl")
+
 # Fitting Functions
 include("lds/fit_LDS.jl")
 include("lds/fit_PLDS.jl")
@@ -66,6 +69,7 @@ export AbstractStateModel, AbstractObservationModel
 export GaussianStateModel, GaussianObservationModel, PoissonObservationModel
 export IWPrior, MNPrior
 export CovUpdateCache
+export SSID
 
 # Utilities
 export block_tridgm

--- a/src/init/SubspaceID.jl
+++ b/src/init/SubspaceID.jl
@@ -1,0 +1,620 @@
+# =============================================================================
+# SSID.jl — subspace-identification (SSID) initializer
+#
+# Ports the HallM_NeSS `subspaceid_orig` driver and its `*_hr` helpers
+# (`find_PK_hr`, `find_BD_hr`, `reflectd`) — itself adapted from
+# ControlSystemIdentification.jl — into StateSpaceDynamics as an *initialization*
+# method for the Gaussian LTI LDS, invoked via `fit!(lds, y, SSID(); …)`.
+#
+# Recommended Algorithm: Canonical Variate Analysis (CVA) 
+# Produces a deterministic, data-driven estimate of (A, C, Q, R, b, d, x0, P0, B, D) 
+# that seeds EM. It does NOT run EM. Scope is intentionally limited to 
+# `GaussianStateModel` + `GaussianObservationModel`; other model types hit a 
+# fallback method that throws.
+#
+# Dependency-free port of ControlSystemsIdentification.jl: the reference 
+# uses ControlSystems (`lsim`/`ss`) and MatrixEquations (`ared`). 
+# Here those are replaced with pure-Julia kernels — `_ltisim` (discrete-time 
+# LTI simulation) and `_dlyap` (discrete Lyapunov solve for the stationary 
+# state covariance used as `P0`).
+# =============================================================================
+
+"""
+    SSID(; r=0, s1=0, s2=0, W=:CVA, zeroD=true, stable=true, scaleU=false,
+          cross_trial=true, new_init=false, ridge=true, λ=1e-3, order=0,
+          set_all=true, jitter=1e-8, verbose=false)
+
+Options controlling Canonical Variate Analysis (CVA) subspace identification used
+to initialize a Gaussian LTI `LinearDynamicalSystem`. Pass an instance as the
+algorithm argument to [`fit!`](@ref):
+
+```julia
+diag = fit!(lds, y, SSID())                 # autonomous LDS
+diag = fit!(lds, y, SSID(); latent_inputs=u)  # with dynamics inputs (estimates B)
+```
+
+`fit!` mutates `lds` in place and returns a `NamedTuple` `(; S, fve)` with the
+subspace singular values `S` and the fraction of variance explained `fve`.
+
+# Keyword arguments
+- `r`: prediction horizon (block-Hankel depth). `0` ⇒ data-adaptive.
+- `s1`, `s2`: past-output / past-input horizons. `0` ⇒ equal to `r`.
+- `W`: weighting scheme, one of `:CVA` (default), `:MOESP`, `:N4SID`, `:IVM`.
+- `zeroD`: force the observation feed-through `D` to zero.
+- `stable`: reflect unstable eigenvalues of `A` into the unit disk (`reflectd`).
+- `scaleU`: rescale dynamics-input channels by their std for the subspace step.
+- `cross_trial`: if `true`, concatenate trials into one sequence so the delay
+    embedding spans epoch boundaries (matches HallM `subspaceid_orig`); if
+    `false`, build per-trial Hankel blocks and pool their columns.
+- `new_init`: if `false` (default), estimate `B, D, x0` by regression
+    (`find_BD_hr` with Kalman gain `K=0`); if `true`, use HallM placeholder
+    `B = ones(n,m)/sum`, `x0 = ones(n)/n`, `D = 0`.
+- `ridge`, `λ`: use a ridge estimator with strength `λ` for the `A`/`B`/`D`
+    regressions (else plain least squares `\\`).
+- `order`: subspace model order; `0` ⇒ `lds.latent_dim`. Must equal
+    `lds.latent_dim` (the result is written into the model's fields).
+- `set_all`: if `true`, write every Gaussian parameter regardless of
+    `lds.fit_bool`; if `false`, only write parameter groups whose `fit_bool`
+    entry is `true` (Gaussian layout `[x0, P0, A&b&B, Q, C&d&D, R]`).
+- `jitter`: eigenvalue floor used when projecting `Q`, `R`, `P0` to be
+    symmetric positive-definite.
+- `verbose`: print progress information.
+
+# Notes
+- Identified `A`, `C` are only defined up to a similarity transform; compare
+    invariants (eigenvalues of `A`, Markov parameters `C Aᵏ B`) rather than raw
+    matrices.
+- Supports `Float32`/`Float64` (uses LAPACK `lq!`/`svd!`).
+- Observations are demeaned internally; the empirical mean is placed in the
+    observation bias `d`, with state bias `b = 0`.
+"""
+Base.@kwdef struct SSID
+    r::Int = 0
+    s1::Int = 0
+    s2::Int = 0
+    W::Symbol = :CVA
+    zeroD::Bool = true
+    stable::Bool = true
+    scaleU::Bool = false
+    cross_trial::Bool = true
+    new_init::Bool = false
+    ridge::Bool = true
+    λ::Float64 = 1e-3
+    order::Int = 0
+    set_all::Bool = true
+    jitter::Float64 = 1e-8
+    verbose::Bool = false
+end
+
+# -----------------------------------------------------------------------------
+# Low-level numerical helpers (pure Julia)
+# -----------------------------------------------------------------------------
+
+# Per-column standard deviation over rows (dim 1), avoiding a Statistics.std import.
+function _colstd(X::AbstractMatrix{T}) where {T}
+    μ = mean(X; dims=1)
+    nrow = size(X, 1)
+    denom = max(nrow - 1, 1)
+    return sqrt.(vec(sum(abs2, X .- μ; dims=1)) ./ denom)
+end
+
+# Ridge / Tikhonov least squares: argmin ||x*β - y||² + λ||β||².
+function _ridge(x::AbstractMatrix{T}, y::AbstractVector{T}, λ::T) where {T}
+    k = size(x, 2)
+    xr = vcat(x, sqrt(λ) * Matrix{T}(I, k, k))
+    yr = vcat(y, zeros(T, k))
+    return xr \ yr
+end
+function _ridge(x::AbstractMatrix{T}, y::AbstractMatrix{T}, λ::T) where {T}
+    k = size(x, 2)
+    xr = vcat(x, sqrt(λ) * Matrix{T}(I, k, k))
+    yr = vcat(y, zeros(T, k, size(y, 2)))
+    return xr \ yr
+end
+
+# Reflect a scalar eigenvalue with |λ|>~1 back inside the unit circle. Returns a
+# complex value (the matrix variant takes `real` once at the end); `thr` is typed
+# from `abs(x)` so element types (e.g. Float32) are preserved.
+function _reflectd(x::Number)
+    a = abs(x)
+    thr = oftype(a, 0.9999)
+    a < thr && return oftype(cis(angle(x)), x)
+    return (thr / a) * cis(angle(x))
+end
+
+# Stabilize a matrix by reflecting its unstable eigenvalues (HallM `reflectd`).
+function _reflectd(A::AbstractMatrix)
+    vals, vecs = eigen(A)
+    vals = _reflectd.(vals)
+    A2 = vecs * Diagonal(vals) / vecs
+    return eltype(A) <: Real ? real(A2) : A2
+end
+
+# Symmetrize and project a matrix to be symmetric positive-definite. The
+# returned matrix satisfies `issymmetric` exactly (via the (M+M')/2 idiom, which
+# is exactly symmetric in IEEE arithmetic) and `isposdef` (eigenvalue floor).
+function _make_pd(M::AbstractMatrix, ::Type{T}; jitter) where {T}
+    Ms = (M .+ M') ./ 2
+    E = eigen(Symmetric(Matrix(Ms)))
+    λmax = isempty(E.values) ? one(real(T)) : maximum(E.values)
+    floorλ = max(T(jitter), T(jitter) * (λmax > 0 ? λmax : one(real(T))))
+    vals = max.(E.values, floorλ)
+    P = E.vectors * Diagonal(vals) * E.vectors'
+    P = (P .+ P') ./ 2
+    return Matrix{T}(P)
+end
+
+# Discrete-time LTI simulation: x_{t+1} = A x_t + E u_t,  y_t = C x_t  (D = 0).
+# Replaces `lsim(ss(A,E,C,0,1), u; x0)`. `E` may have zero columns (free run).
+function _ltisim(
+    A::AbstractMatrix{T},
+    E::AbstractMatrix{T},
+    C::AbstractMatrix{T},
+    u::AbstractMatrix{T},
+    x0::AbstractVector{T},
+) where {T}
+    n = size(A, 1)
+    p = size(C, 1)
+    N = size(u, 2)
+    Y = Matrix{T}(undef, p, N)
+    x = Vector{T}(undef, n);
+    copyto!(x, x0)
+    xn = Vector{T}(undef, n)
+    has_input = size(E, 2) > 0
+    @inbounds for t in 1:N
+        mul!(view(Y, :, t), C, x)
+        mul!(xn, A, x)
+        if has_input
+            mul!(xn, E, view(u, :, t), one(T), one(T))
+        end
+        x, xn = xn, x
+    end
+    return Y
+end
+
+# Discrete Lyapunov solve A P A' + Q = P for the stationary state covariance,
+# used as P0. Replaces the `ared`-based P in HallM `find_PK_hr`. Falls back to Q
+# when A is not (numerically) stable. Always returned symmetric positive-definite.
+function _dlyap(A::AbstractMatrix{T}, Q::AbstractMatrix{T}; jitter, stable::Bool) where {T}
+    n = size(A, 1)
+    P = copy(Q)
+    if stable && n * n <= 10_000
+        M = Matrix{T}(I, n * n, n * n) - kron(A, A)
+        local Pv
+        solved = true
+        try
+            Pv = M \ vec(Q)
+        catch
+            solved = false
+        end
+        if solved
+            Pc = reshape(Pv, n, n)
+            if all(isfinite, Pc)
+                P = Pc
+            end
+        end
+    end
+    return _make_pd(P, T; jitter=jitter)
+end
+
+# -----------------------------------------------------------------------------
+# SSID subspace machinery (block-Hankel construction + weighting + recovery)
+# -----------------------------------------------------------------------------
+
+# Forward block-Hankel matrix (r*d × N) from time-major data (t × d).
+function _ssid_hankel(data::AbstractMatrix{T}, t0::Int, r::Int, N::Int) where {T}
+    d = size(data, 2)
+    H = zeros(T, r * d, N)
+    @inbounds for ri in 1:r, Ni in 1:N
+        H[((ri - 1) * d + 1):(ri * d), Ni] = @view data[t0 + ri + Ni - 2, :]
+    end
+    return H
+end
+
+# Past regressor Φ (s × N), s = s1*p + s2*m. Block layout [past-outputs;
+# past-inputs], each block column-major over (lag, channel) to match the
+# reference `vec(y[t-1:-1:t-s1, :])`.
+function _ssid_phi(
+    y::AbstractMatrix{T},
+    u::AbstractMatrix{T},
+    t0::Int,
+    N::Int,
+    s1::Int,
+    s2::Int,
+    p::Int,
+    m::Int,
+) where {T}
+    s = s1 * p + s2 * m
+    Φ = zeros(T, s, N)
+    @inbounds for (idx, t) in enumerate(t0:(t0 + N - 1))
+        Φ[1:(s1 * p), idx] = vec(@view y[(t - 1):-1:(t - s1), :])
+        if m > 0 && s2 > 0
+            Φ[(s1 * p + 1):(s1 * p + s2 * m), idx] = vec(@view u[(t - 1):-1:(t - s2), :])
+        end
+    end
+    return Φ
+end
+
+# Oblique projection helper used by the IVM weighting (HallM `proj_hr`).
+function _proj_hr(UY::AbstractMatrix, Yinds)
+    fact = lq!(copy(UY))
+    L = fact.L
+    Qm = Matrix(fact.Q)
+    return L[Yinds, Yinds] * Qm[Yinds, :]
+end
+
+# Form the extended observability matrix `Or`, singular values `sv`, fraction of
+# variance explained `fve`, and the L-blocks (L1, L2) needed by `_find_PK_ssid`.
+function _ssid_subspace(
+    Y::AbstractMatrix{T},
+    U::AbstractMatrix{T},
+    Φ::AbstractMatrix{T},
+    r::Int,
+    s1::Int,
+    s2::Int,
+    p::Int,
+    m::Int,
+    W::Symbol,
+    n::Int,
+) where {T}
+    nU, nΦ, nY = size(U, 1), size(Φ, 1), size(Y, 1)
+    fact = lq!(vcat(U, Φ, Y))
+    L = fact.L
+
+    Uinds = 1:nU
+    Φinds = (1:nΦ) .+ nU
+    Yinds = (1:nY) .+ (nU + nΦ)
+
+    L1 = L[Uinds, Uinds]
+    L2 = L[(s1 * p + (r + s2) * m + 1):end, 1:(s1 * p + (r + s2) * m + p)]
+
+    local Or, sv
+    if W === :MOESP || W === :N4SID
+        Qm = Matrix(fact.Q)
+        L21 = L[Φinds, Uinds]
+        L22 = L[Φinds, Φinds]
+        L32 = L[Yinds, Φinds]
+        Q1 = Qm[Uinds, :]
+        Q2 = Qm[Φinds, :]
+        Ĝ = L32 * (L22 \ hcat(L21, L22)) * vcat(Q1, Q2)
+        G = W === :MOESP ? L32 * Q2 : Ĝ
+        sv = svd(G)
+        Rsv = Diagonal(sqrt.(sv.S[1:n]))
+        Or = sv.U[:, 1:n] * Rsv            # W1 = I for both
+    elseif W === :IVM
+        Ncols = size(Y, 2)
+        UY = vcat(U, Y)
+        Yi = (1:nY) .+ nU
+        YΠUt = _proj_hr(UY, Yi)
+        G = YΠUt * Φ'
+        W1 = real(sqrt(Symmetric(pinv((one(T) / Ncols) * (YΠUt * Y')))))
+        W2 = real(sqrt(Symmetric(pinv((one(T) / Ncols) * (Φ * Φ')))))
+        G = W1 * G * W2
+        sv = svd(G)
+        Rsv = Diagonal(sqrt.(sv.S[1:n]))
+        Or = W1 \ (sv.U[:, 1:n] * Rsv)
+    elseif W === :CVA
+        L32 = L[Yinds, Φinds]
+        W1 = L[Yinds, vcat(Φinds, Yinds)]
+        ull1, sll1 = svd(W1)
+        sll1d = Diagonal(sll1[1:(r * p)])
+        cva = svd(sll1d \ (ull1' * L32))
+        Or = ull1 * sll1d * cva.U
+        sv = svd(L32)
+    else
+        throw(
+            ArgumentError(
+                "SSID: unknown weighting W=:$(W); expected :CVA, :MOESP, :N4SID, or :IVM"
+            ),
+        )
+    end
+
+    fve = sum(sv.S[1:n]) / sum(sv.S)
+    return Or, sv, fve, L1, L2
+end
+
+# Recover C (first block-row of Or) and A (shift-invariance least squares),
+# stabilizing A by eigenvalue reflection when requested.
+function _ssid_AC(Or, p::Int, r::Int, n::Int, Aestimator, stable::Bool)
+    C = Or[1:p, 1:n]
+    A = Aestimator(Or[1:(p * (r - 1)), 1:n], Or[(p + 1):(p * r), 1:n])
+    if !all(e -> abs(e) <= 1, eigvals(A)) && stable
+        A = _reflectd(A)
+    end
+    return Matrix(A), Matrix(C)
+end
+
+# Process / observation noise covariances from the residual of the one-step
+# predictor regression (HallM `find_PK_hr` / CSI `find_PK`, normalized by the
+# effective sample count). The cross-covariance S and Kalman gain K are not
+# needed (SSD has no field for them) and are discarded.
+function _find_PK_ssid(
+    L1, L2, Or, n::Int, p::Int, m::Int, r::Int, s1::Int, s2::Int, ::Type{T}; jitter
+) where {T}
+    X1 = L2[(p + 1):(r * p), 1:(m * (s2 + r) + p * s1 + p)]
+    X2 = hcat(L2[1:(r * p), 1:(m * (s2 + r) + p * s1)], zeros(T, r * p, p))
+    vl = vcat(Or[1:((r - 1) * p), 1:n] \ X1, L2[1:p, 1:(m * (s2 + r) + p * s1 + p)])
+    hl = vcat(Or[:, 1:n] \ X2, hcat(L1, zeros(T, m * r, (m * s2 + p * s1) + p)))
+
+    K0 = vl * pinv(hl)
+    resid = vl - K0 * hl
+    dof = max(size(vl, 2) - size(K0, 2), 1)
+    Wcov = (resid * resid') ./ dof
+
+    Q = _make_pd(Wcov[1:n, 1:n], T; jitter=jitter)
+    R = _make_pd(Wcov[(n + 1):(n + p), (n + 1):(n + p)], T; jitter=jitter)
+    return Q, R
+end
+
+# Estimate B, D, x0 by regressing the (demeaned) output onto the simulated
+# responses of the deterministic system, using Kalman gain K = 0 (so the
+# innovation sequence vanishes and this reduces to ordinary least squares).
+# Port of HallM `find_BD_hr`, with `lsim` replaced by `_ltisim`. `U` (m × N)
+# carries the dynamics inputs (→ B); `V` (mD × N) the observation inputs (→ D).
+function _find_BD_ssid(
+    A::AbstractMatrix{T},
+    C::AbstractMatrix{T},
+    U::AbstractMatrix{T},
+    V::AbstractMatrix{T},
+    Y::AbstractMatrix{T},
+    zeroD::Bool,
+    estimator,
+    ::Type{T},
+) where {T}
+    n = size(A, 1)
+    p = size(C, 1)
+    N = size(Y, 2)
+    m = size(U, 1)
+    mD = size(V, 1)
+
+    ncolB = m * n
+    ncolD = zeroD ? 0 : p * mD
+    ncol = ncolB + n + ncolD
+    Φ = Matrix{T}(undef, p * N, ncol)
+
+    zx = zeros(T, n)
+    Ej = zeros(T, n, 1)
+    emptyE = zeros(T, n, 0)
+    emptyu = zeros(T, 0, N)
+    col = 0
+    # B blocks: response to a unit input on channel k entering state j.
+    @inbounds for k in 1:m, j in 1:n
+        fill!(Ej, zero(T));
+        Ej[j, 1] = one(T)
+        uf = _ltisim(A, Ej, C, reshape(view(U, k, :), 1, N), zx)
+        col += 1
+        Φ[:, col] = vec(uf)
+    end
+    # x0 blocks: free decay from each canonical initial state.
+    x0b = zeros(T, n)
+    @inbounds for j in 1:n
+        fill!(x0b, zero(T));
+        x0b[j] = one(T)
+        uf = _ltisim(A, emptyE, C, emptyu, x0b)
+        col += 1
+        Φ[:, col] = vec(uf)
+    end
+    # D blocks: static feed-through of obs-input channel k into output row j.
+    if !zeroD
+        @inbounds for k in 1:mD, j in 1:p
+            block = zeros(T, p, N)
+            block[j, :] = @view V[k, :]
+            col += 1
+            Φ[:, col] = vec(block)
+        end
+    end
+
+    BD = estimator(Φ, vec(Y))
+    B = m == 0 ? zeros(T, n, 0) : copy(reshape(BD[1:ncolB], n, m))
+    x0 = copy(BD[ncolB .+ (1:n)])
+    D = zeroD ? zeros(T, p, mD) : copy(reshape(BD[(ncolB + n + 1):end], p, mD))
+    return B, D, x0
+end
+
+# Data-adaptive prediction horizon when `r == 0`. Keeps r below half the record
+# length (with s1=s2=r the effective sample count is Ttot - 2r) and at least n+1.
+function _auto_r(Ttot::Int, n::Int)
+    rmax = max(1, (Ttot - 2) ÷ 4)
+    return clamp(min(Ttot ÷ 20, 50), n + 1, max(n + 1, rmax))
+end
+
+# -----------------------------------------------------------------------------
+# Driver
+# -----------------------------------------------------------------------------
+
+function _ssid_fit!(
+    lds::LinearDynamicalSystem{T,S,O},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    u_seq::AbstractVector{<:AbstractMatrix{T}},
+    v_seq::AbstractVector{<:AbstractMatrix{T}},
+    alg::SSID,
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    p = lds.obs_dim
+    m = lds.state_input_dim
+    mD = lds.obs_input_dim
+    zeroD = alg.zeroD || mD == 0
+
+    n = alg.order == 0 ? lds.latent_dim : alg.order
+    n == lds.latent_dim || throw(
+        ArgumentError("SSID: order ($n) must equal lds.latent_dim ($(lds.latent_dim))")
+    )
+
+    # Concatenate + demean observations.
+    Ycat = reduce(hcat, y)
+    Ttot = size(Ycat, 2)
+    ȳ = vec(mean(Ycat; dims=2))
+    Ydm = Ycat .- ȳ
+
+    # Resolve horizons.
+    r = alg.r == 0 ? _auto_r(Ttot, n) : alg.r
+    s1 = alg.s1 == 0 ? r : alg.s1
+    s2 = alg.s2 == 0 ? r : alg.s2
+    r >= n + 1 || throw(
+        ArgumentError("SSID: prediction horizon r=$r must be ≥ model order n+1=$(n + 1)"),
+    )
+    alg.verbose &&
+        @info "SSID: r=$r, s1=$s1, s2=$s2, W=:$(alg.W), n=$n, cross_trial=$(alg.cross_trial)"
+
+    t0 = max(s1, s2) + 1
+
+    # Build block-Hankel matrices Y, U and past regressor Φ.
+    local Yh, Uh, Φh
+    if alg.cross_trial
+        ytm = permutedims(Ydm)                                   # Ttot × p
+        utm = m > 0 ? permutedims(reduce(hcat, u_seq)) : zeros(T, Ttot, 0)
+        if alg.scaleU && m > 0
+            utm = utm ./ _colstd(utm)'
+        end
+        N = Ttot - r + 1 - t0
+        N > 0 || throw(
+            ArgumentError(
+                "SSID: not enough data (Ttot=$Ttot) for r=$r; need Ttot > $(r - 1 + t0)"
+            ),
+        )
+        Yh = _ssid_hankel(ytm, t0, r, N)
+        Uh = _ssid_hankel(utm, t0, r, N)
+        Φh = _ssid_phi(ytm, utm, t0, N, s1, s2, p, m)
+    else
+        Yblocks = Matrix{T}[]
+        Ublocks = Matrix{T}[]
+        Φblocks = Matrix{T}[]
+        col0 = 0
+        for (i, yi) in enumerate(y)
+            Ti = size(yi, 2)
+            Ni = Ti - r + 1 - t0
+            Ni > 0 || throw(
+                ArgumentError(
+                    "SSID: trial $i too short (T=$Ti) for r=$r with cross_trial=false; need T > $(r - 1 + t0)",
+                ),
+            )
+            ytm = permutedims(yi .- ȳ)
+            utm = m > 0 ? permutedims(u_seq[i]) : zeros(T, Ti, 0)
+            if alg.scaleU && m > 0
+                utm = utm ./ _colstd(utm)'
+            end
+            push!(Yblocks, _ssid_hankel(ytm, t0, r, Ni))
+            push!(Ublocks, _ssid_hankel(utm, t0, r, Ni))
+            push!(Φblocks, _ssid_phi(ytm, utm, t0, Ni, s1, s2, p, m))
+            col0 += Ni
+        end
+        col0 > 0 || throw(ArgumentError("SSID: no usable Hankel columns (data too short)"))
+        Yh = reduce(hcat, Yblocks)
+        Uh = reduce(hcat, Ublocks)
+        Φh = reduce(hcat, Φblocks)
+    end
+
+    # The LQ factor is square only when there are at least as many Hankel
+    # columns as stacked block-rows; otherwise the L-block indexing is invalid.
+    block_rows = size(Uh, 1) + size(Φh, 1) + size(Yh, 1)
+    size(Yh, 2) >= block_rows || throw(
+        ArgumentError(
+            "SSID: too few Hankel columns ($(size(Yh, 2))) for r=$r, s1=$s1, s2=$s2; " *
+            "need ≥ $block_rows. Reduce r/s1/s2 or provide more data.",
+        ),
+    )
+
+    # Subspace identification → Or, A, C, Q, R.
+    Or, sv, fve, L1, L2 = _ssid_subspace(Yh, Uh, Φh, r, s1, s2, p, m, alg.W, n)
+    n <= size(Or, 2) || throw(
+        ArgumentError(
+            "SSID: model order n=$n exceeds identifiable subspace dimension $(size(Or, 2))",
+        ),
+    )
+
+    Aestimator = alg.ridge ? ((x, yy) -> _ridge(x, yy, T(alg.λ))) : ((x, yy) -> x \ yy)
+    A, C = _ssid_AC(Or, p, r, n, Aestimator, alg.stable)
+    Q, R = _find_PK_ssid(L1, L2, Or, n, p, m, r, s1, s2, T; jitter=T(alg.jitter))
+
+    # Inputs / initial state.
+    local B, D, x0
+    if alg.new_init
+        B = m == 0 ? zeros(T, n, 0) : fill(one(T) / (n * m), n, m)
+        x0 = fill(one(T) / n, n)
+        D = zeros(T, p, mD)
+    else
+        Uorig = m > 0 ? reduce(hcat, u_seq) : zeros(T, 0, Ttot)
+        Vorig = mD > 0 ? reduce(hcat, v_seq) : zeros(T, 0, Ttot)
+        BDest = alg.ridge ? ((x, yy) -> _ridge(x, yy, T(alg.λ))) : ((x, yy) -> x \ yy)
+        B, D, x0 = _find_BD_ssid(A, C, Uorig, Vorig, Ydm, zeroD, BDest, T)
+    end
+
+    # Initial-state covariance (stationary) and biases.
+    P0 = _dlyap(A, Q; jitter=T(alg.jitter), stable=alg.stable)
+    b = zeros(T, n)
+    d = Vector{T}(ȳ)
+
+    # Write parameters in place (respecting set_all / fit_bool groups).
+    fb = lds.fit_bool
+    sm = lds.state_model
+    om = lds.obs_model
+    if alg.set_all || fb[3]
+        sm.A .= A
+        sm.b .= b
+        m > 0 && (sm.B .= B)
+    end
+    (alg.set_all || fb[4]) && (sm.Q .= Q)
+    (alg.set_all || fb[1]) && (sm.x0 .= x0)
+    (alg.set_all || fb[2]) && (sm.P0 .= P0)
+    if alg.set_all || fb[5]
+        om.C .= C
+        om.d .= d
+        (!zeroD && mD > 0) && (om.D .= D)
+    end
+    (alg.set_all || fb[6]) && (om.R .= R)
+
+    validate_LDS(lds)
+    return (; S=sv.S, fve=fve)
+end
+
+# -----------------------------------------------------------------------------
+# `fit!` methods
+# -----------------------------------------------------------------------------
+
+"""
+    fit!(lds, y, alg::SSID; latent_inputs=nothing, obs_inputs=nothing)
+
+Initialize a Gaussian LTI `LinearDynamicalSystem` in place via Canonical Variate
+Analysis subspace identification. `y` may be a vector of per-trial
+`(obs_dim, Tᵢ)` matrices, a single `(obs_dim, T)` matrix, or an
+`(obs_dim, T, ntrials)` array. Returns `(; S, fve)`. See [`SubspaceID`](@ref).
+"""
+function fit!(
+    lds::LinearDynamicalSystem{T,S,O},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    alg::SSID;
+    latent_inputs::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    obs_inputs::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    tsteps_per_trial = [size(yt, 2) for yt in y]
+    u_seq = _normalize_multitrial_latent_inputs(
+        latent_inputs, lds.state_input_dim, tsteps_per_trial, T, "latent_inputs"
+    )
+    v_seq = _normalize_multitrial_obs_inputs(
+        obs_inputs, lds.obs_input_dim, tsteps_per_trial, T, lds.obs_model
+    )
+    return _ssid_fit!(lds, y, u_seq, v_seq, alg)
+end
+
+function fit!(
+    lds::LinearDynamicalSystem{T,S,O}, y::AbstractArray{T}, alg::SSID; kwargs...
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    if ndims(y) == 3
+        return fit!(lds, [view(y,:,:,i) for i in 1:size(y, 3)], alg; kwargs...)
+    elseif ndims(y) == 2
+        return fit!(lds, [y], alg; kwargs...)
+    else
+        throw(ArgumentError("SSID: input array y must be 2D or 3D, got ndims=$(ndims(y))."))
+    end
+end
+
+# Fallback for unsupported model types (Poisson, stitched, …) — narrower Gaussian
+# methods above take precedence when applicable.
+function fit!(lds::LinearDynamicalSystem, y, alg::SSID; kwargs...)
+    throw(
+        ArgumentError(
+            "SSID initialization currently supports only Gaussian LTI LDS " *
+            "(GaussianStateModel + GaussianObservationModel); got " *
+            "state=$(typeof(lds.state_model)), obs=$(typeof(lds.obs_model)).",
+        ),
+    )
+end

--- a/test/LinearDynamicalSystems/SSID.jl
+++ b/test/LinearDynamicalSystems/SSID.jl
@@ -1,0 +1,439 @@
+# Tests for the CVA subspace-identification initializer (src/init/SSID.jl).
+#
+# CVA identifies (A, C) only up to a similarity transform, so recovery tests
+# compare invariants (eigenvalues of A, Markov parameters C·Aᵏ·B, reconstructed
+# output) rather than raw matrices. The bulk of the suite exercises mechanics:
+# shapes, in-place mutation, PD covariances, error paths, dispatch, determinism.
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Build a stable Gaussian LDS with a chosen (real) eigenvalue spectrum, random
+# observation matrix, small process/observation noise, and a nonzero observation
+# bias (to exercise demeaning). Optionally include dynamics/obs input matrices.
+function ssid_make_lds(
+    ::Type{T}=Float64;
+    rng=StableRNG(11),
+    eigs=T[0.9, 0.7, 0.4],
+    obs::Int=6,
+    q::Real=1e-6,
+    r::Real=1e-4,
+    uin::Int=0,
+    vin::Int=0,
+) where {T<:Real}
+    latent = length(eigs)
+    V = randn(rng, T, latent, latent)
+    A = Matrix{T}(real(V * Diagonal(T.(eigs)) * inv(V)))
+    C = randn(rng, T, obs, latent)
+    Q = Matrix{T}(T(q) * I(latent))
+    R = Matrix{T}(T(r) * I(obs))
+    b = zeros(T, latent)
+    d = T(2) .* randn(rng, T, obs)                # nonzero obs bias
+    x0 = zeros(T, latent)
+    P0 = Matrix{T}(T(0.05) * I(latent))
+    B = uin > 0 ? randn(rng, T, latent, uin) : zeros(T, latent, 0)
+    D = vin > 0 ? randn(rng, T, obs, vin) : zeros(T, obs, 0)
+    sm = GaussianStateModel(; A=A, Q=Q, b=b, x0=x0, P0=P0, B=B)
+    om = GaussianObservationModel(; C=C, R=R, d=d, D=D)
+    return LinearDynamicalSystem(sm, om)
+end
+
+# Fresh model + copies of the original parameters, for mutation checks.
+function ssid_param_snapshot(lds)
+    sm, om = lds.state_model, lds.obs_model
+    return (
+        A=copy(sm.A),
+        Q=copy(sm.Q),
+        b=copy(sm.b),
+        x0=copy(sm.x0),
+        P0=copy(sm.P0),
+        B=copy(sm.B),
+        C=copy(om.C),
+        R=copy(om.R),
+        d=copy(om.d),
+        D=copy(om.D),
+    )
+end
+
+# Markov parameters C·Aᵏ·B, k = 0:K (similarity invariant).
+function ssid_markov(A, B, C, K)
+    out = Vector{Matrix{eltype(A)}}(undef, K + 1)
+    M = copy(B)
+    for k in 0:K
+        out[k + 1] = C * M
+        M = A * M
+    end
+    return out
+end
+
+# ---------------------------------------------------------------------------
+# Mechanics
+# ---------------------------------------------------------------------------
+
+function test_ssid_shapes_and_mutation()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(2), lds, 2000)
+    orig = ssid_param_snapshot(lds)
+
+    diag = fit!(lds, y, SSID(; r=12))
+
+    sm, om = lds.state_model, lds.obs_model
+    @test size(sm.A) == (lds.latent_dim, lds.latent_dim)
+    @test size(sm.Q) == (lds.latent_dim, lds.latent_dim)
+    @test size(sm.x0) == (lds.latent_dim,)
+    @test size(sm.P0) == (lds.latent_dim, lds.latent_dim)
+    @test size(sm.b) == (lds.latent_dim,)
+    @test size(om.C) == (lds.obs_dim, lds.latent_dim)
+    @test size(om.R) == (lds.obs_dim, lds.obs_dim)
+    @test size(om.d) == (lds.obs_dim,)
+
+    # Something actually changed.
+    @test sm.A != orig.A
+    @test om.C != orig.C
+    @test sm.Q != orig.Q
+
+    # Diagnostics.
+    @test haskey(diag, :S) && haskey(diag, :fve)
+    @test diag.S isa AbstractVector
+    @test diag.fve isa Real
+end
+
+function test_ssid_fve_and_singular_values()
+    lds = ssid_make_lds(; eigs=[0.9, 0.6, 0.3])
+    _, y = StateSpaceDynamics.rand(StableRNG(3), lds, 3000)
+    diag = fit!(lds, y, SSID(; r=15))
+    @test 0 <= diag.fve <= 1 + 1e-8
+    @test all(>=(-1e-10), diag.S)
+    @test issorted(diag.S; rev=true)
+end
+
+function test_ssid_pd_covariances_and_validation()
+    lds = ssid_make_lds(; eigs=[0.8, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(4), lds, 2500)
+    fit!(lds, y, SSID(; r=12))
+    for M in (lds.state_model.Q, lds.state_model.P0, lds.obs_model.R)
+        @test issymmetric(M)
+        @test isposdef(M)
+    end
+    @test validate_LDS(lds) === nothing
+end
+
+function test_ssid_stability_enforced()
+    lds = ssid_make_lds(; eigs=[0.95, 0.6, 0.2])
+    _, y = StateSpaceDynamics.rand(StableRNG(5), lds, 3000)
+    fit!(lds, y, SSID(; r=15, stable=true))
+    @test all(abs.(eigvals(lds.state_model.A)) .<= 1 + 1e-6)
+end
+
+function test_ssid_weightings_run()
+    lds0 = ssid_make_lds(; eigs=[0.85, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(6), lds0, 3000)
+    for W in (:CVA, :MOESP, :N4SID, :IVM)
+        lds = ssid_make_lds(; eigs=[0.85, 0.5])
+        diag = fit!(lds, y, SSID(; r=12, W=W))
+        @test isposdef(lds.state_model.Q)
+        @test isposdef(lds.obs_model.R)
+        @test 0 <= diag.fve <= 1 + 1e-8
+        @test validate_LDS(lds) === nothing
+    end
+end
+
+function test_ssid_ridge_vs_backslash()
+    lds0 = ssid_make_lds(; eigs=[0.85, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(7), lds0, 3000)
+    for ridge in (true, false)
+        lds = ssid_make_lds(; eigs=[0.85, 0.5])
+        fit!(lds, y, SSID(; r=12, ridge=ridge))
+        @test validate_LDS(lds) === nothing
+    end
+end
+
+function test_ssid_reproducibility()
+    lds_a = ssid_make_lds(; eigs=[0.85, 0.5, 0.3])
+    lds_b = ssid_make_lds(; eigs=[0.85, 0.5, 0.3])
+    _, y = StateSpaceDynamics.rand(StableRNG(8), lds_a, 2500)
+    da = fit!(lds_a, y, SSID(; r=14))
+    db = fit!(lds_b, y, SSID(; r=14))
+    @test lds_a.state_model.A == lds_b.state_model.A
+    @test lds_a.obs_model.C == lds_b.obs_model.C
+    @test lds_a.state_model.Q == lds_b.state_model.Q
+    @test lds_a.obs_model.R == lds_b.obs_model.R
+    @test lds_a.state_model.x0 == lds_b.state_model.x0
+    @test da.fve == db.fve
+end
+
+# ---------------------------------------------------------------------------
+# Recovery (similarity-invariant)
+# ---------------------------------------------------------------------------
+
+function test_ssid_eigenvalue_recovery()
+    true_eigs = [0.9, 0.6, 0.3]
+    lds = ssid_make_lds(; eigs=true_eigs, obs=8, q=1e-7, r=1e-5)
+    _, y = StateSpaceDynamics.rand(StableRNG(9), lds, 6000)
+    fit!(lds, y, SSID(; r=20))
+    est = sort(real.(eigvals(lds.state_model.A)))
+    @test isapprox(est, sort(true_eigs); atol=0.1)
+end
+
+function test_ssid_markov_recovery_with_input()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5], obs=6, q=1e-7, r=1e-5, uin=2)
+    rng = StableRNG(10)
+    u = [randn(rng, Float64, 2, 4000)]
+    _, y = StateSpaceDynamics.rand(rng, lds, [4000];latent_inputs=u)
+    A0, B0, C0 = lds.state_model.A, lds.state_model.B, lds.obs_model.C
+    M_true = ssid_markov(A0, B0, C0, 4)
+
+    fit!(lds, y, SSID(; r=15, zeroD=true);latent_inputs=u)
+    M_est = ssid_markov(lds.state_model.A, lds.state_model.B, lds.obs_model.C, 4)
+
+    # Low noise + 4000 samples: the leading Markov parameters should recover.
+    for k in 1:3
+        @test isapprox(M_true[k], M_est[k]; atol=0.2, rtol=0.2)
+    end
+end
+
+function test_ssid_input_BD_shapes()
+    # zeroD = true: D stays empty.
+    lds = ssid_make_lds(; eigs=[0.8, 0.5], uin=2)
+    rng = StableRNG(12)
+    u = [randn(rng, Float64, 2, 3000)]
+    _, y = StateSpaceDynamics.rand(rng, lds, [3000];latent_inputs=u)
+    fit!(lds, y, SSID(; r=12, zeroD=true);latent_inputs=u)
+    @test size(lds.state_model.B) == (lds.latent_dim, 2)
+    @test size(lds.obs_model.D) == (lds.obs_dim, 0)
+
+    # zeroD = false with obs inputs: D is estimated.
+    lds2 = ssid_make_lds(; eigs=[0.8, 0.5], uin=2, vin=1)
+    rng2 = StableRNG(13)
+    u2 = [randn(rng2, Float64, 2, 3000)]
+    v2 = [randn(rng2, Float64, 1, 3000)]
+    _, y2 = StateSpaceDynamics.rand(rng2, lds2, [3000];latent_inputs=u2, obs_inputs=v2)
+    fit!(lds2, y2, SSID(; r=12, zeroD=false);latent_inputs=u2, obs_inputs=v2)
+    @test size(lds2.state_model.B) == (lds2.latent_dim, 2)
+    @test size(lds2.obs_model.D) == (lds2.obs_dim, 1)
+end
+
+function test_ssid_bias_reconstructs_mean()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5], obs=5)
+    _, y = StateSpaceDynamics.rand(StableRNG(14), lds, 3000)
+    ymean = vec(sum(y; dims=2)) ./ size(y, 2)
+    fit!(lds, y, SSID(; r=12))
+    @test isapprox(lds.obs_model.d, ymean; atol=1e-8)
+    @test all(iszero, lds.state_model.b)
+end
+
+function test_ssid_cross_trial_paths()
+    lds0 = ssid_make_lds(; eigs=[0.9, 0.5, 0.3])
+    _, y = StateSpaceDynamics.rand(StableRNG(15), lds0, fill(1500, 4))
+    for ct in (true, false)
+        lds = ssid_make_lds(; eigs=[0.9, 0.5, 0.3])
+        diag = fit!(lds, y, SSID(; r=12, cross_trial=ct))
+        @test isfinite(diag.fve)
+        @test validate_LDS(lds) === nothing
+    end
+end
+
+function test_ssid_new_init_placeholder()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5], uin=2)
+    rng = StableRNG(16)
+    u = [randn(rng, Float64, 2, 2500)]
+    _, y = StateSpaceDynamics.rand(rng, lds, [2500];latent_inputs=u)
+    fit!(lds, y, SSID(; r=12, new_init=true);latent_inputs=u)
+    # placeholder x0 = ones(n)/n
+    @test isapprox(lds.state_model.x0, fill(1 / lds.latent_dim, lds.latent_dim); atol=1e-10)
+    @test validate_LDS(lds) === nothing
+end
+
+function test_ssid_init_then_EM_improves()
+    lds = ssid_make_lds(; eigs=[0.9, 0.5], obs=5, q=1e-3, r=1e-2)
+    _, y = StateSpaceDynamics.rand(StableRNG(17), lds, fill(400, 3))
+
+    # CVA-initialized model.
+    lds_ssid = ssid_make_lds(; eigs=[0.9, 0.5], obs=5, q=1e-3, r=1e-2)
+    fit!(lds_ssid, y, SSID(; r=12))
+    elbos = fit!(lds_ssid, y; max_iter=25, progress=false)
+    @test issorted(elbos; rev=false) || all(>=(-1e-6), diff(elbos))
+    @test elbos[end] >= elbos[1] - 1e-6
+end
+
+# ---------------------------------------------------------------------------
+# Internal-kernel unit tests
+# ---------------------------------------------------------------------------
+
+function test_ssid_dlyap_identity_and_fallback()
+    rng = StableRNG(18)
+    A = randn(rng, 4, 4)
+    A .*= 0.8 / maximum(abs.(eigvals(A)))
+    Q = let M = randn(rng, 4, 4);
+        Matrix(M * M' + I)
+    end
+    P0 = StateSpaceDynamics._dlyap(A, Q; jitter=1e-8, stable=true)
+    @test isposdef(P0)
+    @test isapprox(A * P0 * A' + Q, P0; atol=1e-6, rtol=1e-6)
+
+    # Fallback path (stable=false) → returns a PD projection of Q.
+    Pf = StateSpaceDynamics._dlyap(A, Q; jitter=1e-8, stable=false)
+    @test isposdef(Pf)
+    @test issymmetric(Pf)
+end
+
+function test_ssid_reflectd_stabilizes()
+    rng = StableRNG(19)
+    A = randn(rng, 3, 3)
+    A .*= 1.5 / maximum(abs.(eigvals(A)))     # spectral radius 1.5 (unstable)
+    Ar = StateSpaceDynamics._reflectd(A)
+    @test maximum(abs.(eigvals(Ar))) <= 1 + 1e-8
+    @test eltype(Ar) <: Real
+end
+
+function test_ssid_ltisim_matches_recursion()
+    rng = StableRNG(20)
+    n, p, N = 3, 2, 25
+    A = 0.5 .* randn(rng, n, n)
+    E = randn(rng, n, 1)
+    C = randn(rng, p, n)
+    u = randn(rng, 1, N)
+    x0 = randn(rng, n)
+    Y = StateSpaceDynamics._ltisim(A, E, C, u, x0)
+    # reference recursion
+    Yref = zeros(p, N)
+    x = copy(x0)
+    for t in 1:N
+        Yref[:, t] = C * x
+        x = A * x + E * u[:, t]
+    end
+    @test isapprox(Y, Yref; atol=1e-12)
+end
+
+function test_ssid_findBD_recovers_known_system()
+    rng = StableRNG(21)
+    n, p, m, N = 3, 4, 2, 600
+    A = randn(rng, n, n);
+    A .*= 0.7 / maximum(abs.(eigvals(A)))
+    C = randn(rng, p, n)
+    Btrue = randn(rng, n, m)
+    x0true = randn(rng, n)
+    U = randn(rng, m, N)
+    # Noiseless output of the deterministic system.
+    Y = StateSpaceDynamics._ltisim(A, Btrue, C, U, x0true)
+    V = zeros(Float64, 0, N)
+    ols = (x, yy) -> x \ yy
+    B, D, x0 = StateSpaceDynamics._find_BD_ssid(A, C, U, V, Y, true, ols, Float64)
+    # Reconstructed output should match (B, x0 identified exactly up to noise).
+    Yhat = StateSpaceDynamics._ltisim(A, B, C, U, x0)
+    @test isapprox(Yhat, Y; atol=1e-6)
+    @test size(D) == (p, 0)
+end
+
+# ---------------------------------------------------------------------------
+# Error paths & dispatch
+# ---------------------------------------------------------------------------
+
+function test_ssid_errors_wrong_model_type()
+    # Poisson LDS → fallback method throws.
+    latent, obs = 2, 4
+    A = Matrix{Float64}(0.5 * I(latent))
+    Q = Matrix{Float64}(0.1 * I(latent))
+    sm = GaussianStateModel(;
+        A=A, Q=Q, b=zeros(latent), x0=zeros(latent), P0=Matrix{Float64}(0.1 * I(latent))
+    )
+    pom = PoissonObservationModel(; C=randn(obs, latent), d=zeros(obs))
+    plds = LinearDynamicalSystem(sm, pom)
+    y = [abs.(randn(obs, 50))]
+    @test_throws ArgumentError fit!(plds, y, SSID())
+end
+
+function test_ssid_errors_bad_inputs()
+    lds = ssid_make_lds(; eigs=[0.8, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(22), lds, 1000)
+
+    # r smaller than model order + 1.
+    @test_throws ArgumentError fit!(ssid_make_lds(; eigs=[0.8, 0.5]), y, SSID(; r=2))
+
+    # insufficient data for the requested horizon.
+    short = [randn(StableRNG(23), lds.obs_dim, 8)]
+    @test_throws ArgumentError fit!(ssid_make_lds(; eigs=[0.8, 0.5]), short, SSID(; r=20))
+
+    # unknown weighting.
+    @test_throws ArgumentError fit!(
+        ssid_make_lds(; eigs=[0.8, 0.5]), y, SSID(; r=12, W=:BOGUS)
+    )
+
+    # input-dim mismatch (model has no input, butlatent_inputs supplied).
+    badu = [randn(StableRNG(24), 2, size(y, 2))]
+    @test_throws Exception fit!(
+        ssid_make_lds(; eigs=[0.8, 0.5]), y, SSID(; r=12);latent_inputs=badu
+    )
+
+    # order must equal latent_dim.
+    @test_throws ArgumentError fit!(
+        ssid_make_lds(; eigs=[0.8, 0.5]), y, SSID(; r=12, order=5)
+    )
+end
+
+function test_ssid_2d_3d_overloads()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5])
+    _, ymat = StateSpaceDynamics.rand(StableRNG(25), lds, 2000)   # (obs, T)
+
+    lds2 = ssid_make_lds(; eigs=[0.85, 0.5])
+    d_mat = fit!(lds2, ymat, SSID(; r=12))                        # 2D path
+    lds3 = ssid_make_lds(; eigs=[0.85, 0.5])
+    d_vec = fit!(lds3, [ymat], SSID(; r=12))                      # vector path
+    @test lds2.state_model.A == lds3.state_model.A
+    @test d_mat.fve == d_vec.fve
+
+    # 3D array path.
+    y3 = reshape(ymat, size(ymat, 1), size(ymat, 2), 1)
+    lds4 = ssid_make_lds(; eigs=[0.85, 0.5])
+    d_3d = fit!(lds4, y3, SSID(; r=12))
+    @test d_3d.fve == d_mat.fve
+
+    # 1D / 4D arrays rejected.
+    @test_throws ArgumentError fit!(
+        ssid_make_lds(; eigs=[0.85, 0.5]), randn(StableRNG(26), 10), SSID()
+    )
+end
+
+function test_ssid_fit_bool_respected()
+    lds = ssid_make_lds(; eigs=[0.85, 0.5])
+    _, y = StateSpaceDynamics.rand(StableRNG(27), lds, 2500)
+    # Freeze C&d&D (index 5) and R (index 6) via fit_bool, with set_all=false.
+    fb = [true, true, true, true, false, false]
+    lds_frozen = ssid_make_lds(; eigs=[0.85, 0.5])
+    lds_frozen = LinearDynamicalSystem(
+        lds_frozen.state_model, lds_frozen.obs_model; fit_bool=fb
+    )
+    C_orig = copy(lds_frozen.obs_model.C)
+    R_orig = copy(lds_frozen.obs_model.R)
+    A_orig = copy(lds_frozen.state_model.A)
+    fit!(lds_frozen, y, SSID(; r=12, set_all=false))
+    @test lds_frozen.obs_model.C == C_orig          # frozen
+    @test lds_frozen.obs_model.R == R_orig          # frozen
+    @test lds_frozen.state_model.A != A_orig         # updated
+
+    # set_all=true writes everything.
+    lds_all = LinearDynamicalSystem(
+        ssid_make_lds(; eigs=[0.85, 0.5]).state_model,
+        ssid_make_lds(; eigs=[0.85, 0.5]).obs_model;
+        fit_bool=fb,
+    )
+    C_all = copy(lds_all.obs_model.C)
+    fit!(lds_all, y, SSID(; r=12, set_all=true))
+    @test lds_all.obs_model.C != C_all
+end
+
+function test_ssid_type_preservation()
+    for T in (Float32, Float64)
+        lds = ssid_make_lds(T; eigs=T[0.85, 0.5])
+        _, y = StateSpaceDynamics.rand(StableRNG(28), lds, 2500)
+        diag = fit!(lds, y, SSID(; r=12))
+        @test eltype(lds.state_model.A) === T
+        @test eltype(lds.state_model.Q) === T
+        @test eltype(lds.obs_model.C) === T
+        @test eltype(lds.obs_model.R) === T
+        @test eltype(lds.state_model.x0) === T
+        @test eltype(diag.S) === T
+        @test diag.fve isa T
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,6 +249,43 @@ using SSDTest
         end
     end
 
+    @testset "SSID" begin
+
+        include("LinearDynamicalSystems/SSID.jl")
+        @testset "Mechanics" begin
+            test_ssid_shapes_and_mutation()
+            test_ssid_fve_and_singular_values()
+            test_ssid_pd_covariances_and_validation()
+            test_ssid_stability_enforced()
+            test_ssid_weightings_run()
+            test_ssid_ridge_vs_backslash()
+            test_ssid_reproducibility()
+        end
+        @testset "Recovery" begin
+            test_ssid_eigenvalue_recovery()
+            test_ssid_markov_recovery_with_input()
+            test_ssid_input_BD_shapes()
+            test_ssid_bias_reconstructs_mean()
+            test_ssid_cross_trial_paths()
+            test_ssid_new_init_placeholder()
+            test_ssid_init_then_EM_improves()
+        end
+        @testset "Internal kernels" begin
+            test_ssid_dlyap_identity_and_fallback()
+            test_ssid_reflectd_stabilizes()
+            test_ssid_ltisim_matches_recursion()
+            test_ssid_findBD_recovers_known_system()
+        end
+        @testset "Errors & dispatch" begin
+            test_ssid_errors_wrong_model_type()
+            test_ssid_errors_bad_inputs()
+            test_ssid_2d_3d_overloads()
+            test_ssid_fit_bool_respected()
+            test_ssid_type_preservation()
+        end
+    end
+
+
     # Optimization primitives (line search + Newton)
     @testset verbose = true "Optimization" begin
         include("Optimization/Optimization.jl")


### PR DESCRIPTION
This pull request adds support for initialization of state-space models using Subspace System Identification (SSID) methods. It introduces the new `SSID` module, exports the `SSID` type, and adds comprehensive tests to ensure correct functionality and robustness.

New SSID initialization support:

* Added inclusion of the `init/SubspaceID.jl` file in `src/StateSpaceDynamics.jl` to provide SSID-based initialization methods.
* Exported the `SSID` type from `src/StateSpaceDynamics.jl` for public use.

Testing improvements:

* Added a new testset for SSID in `test/runtests.jl`, covering mechanics, recovery, internal kernels, and error handling for the SSID module.


Addresses Issue https://github.com/depasquale-lab/StateSpaceDynamics.jl/issues/99