### PR TITLE
Bug/fix slds flakyness

### DIFF
--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -725,7 +725,7 @@ function smooth!(
     )
 
     @views for t in 1:tsteps
-        fs.p_smooth[:, :, t] .= 0.5 .* (fs.p_smooth[:, :, t] .+ fs.p_smooth[:, :, t]')
+        fs.p_smooth[:, :, t] .= Symmetrize!(fs.p_smooth[:, :, t])
     end
 
     return fs

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -732,8 +732,8 @@ function compute_slds_constants!(
     # Wrap state-side covariances as PDMats. Observation R is wrapped further
     # below only on the Gaussian branch — Poisson leaves cc.R_PD on its
     # identity placeholder and `cc.cR` zero.
-    cc.Q_PD[] = PDMat(Symmetric(Q))
-    cc.P0_PD[] = PDMat(Symmetric(P0))
+    cc.Q_PD[] = PDMat(Symmetric(Symmetrize!(Q)))
+    cc.P0_PD[] = PDMat(Symmetric(Symmetrize!(P0)))
     Qchol = cc.Q_PD[].chol
     P0chol = cc.P0_PD[].chol
 

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -732,8 +732,8 @@ function compute_slds_constants!(
     # Wrap state-side covariances as PDMats. Observation R is wrapped further
     # below only on the Gaussian branch — Poisson leaves cc.R_PD on its
     # identity placeholder and `cc.cR` zero.
-    cc.Q_PD[] = PDMat(Symmetric(Symmetrize!(Q)))
-    cc.P0_PD[] = PDMat(Symmetric(Symmetrize!(P0)))
+    cc.Q_PD[] = PDMat(Symmetrize!(Q))
+    cc.P0_PD[] = PDMat(Symmetrize!(P0))
     Qchol = cc.Q_PD[].chol
     P0chol = cc.P0_PD[].chol
 
@@ -760,7 +760,7 @@ function compute_slds_constants!(
 
     # Observation terms only if Gaussian
     if lds.obs_model isa GaussianObservationModel{T}
-        cc.R_PD[] = PDMat(Symmetric(Symmetrize!(lds.obs_model.R)))
+        cc.R_PD[] = PDMat(Symmetrize!(lds.obs_model.R))
         Rchol = cc.R_PD[].chol
 
         # tmp_RC = R^{-1}C, C_inv_R = (R^{-1}C)'

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -760,7 +760,7 @@ function compute_slds_constants!(
 
     # Observation terms only if Gaussian
     if lds.obs_model isa GaussianObservationModel{T}
-        cc.R_PD[] = PDMat(Symmetric(lds.obs_model.R))
+        cc.R_PD[] = PDMat(Symmetric(Symmetrize!(lds.obs_model.R)))
         Rchol = cc.R_PD[].chol
 
         # tmp_RC = R^{-1}C, C_inv_R = (R^{-1}C)'

--- a/src/numerics/linalg.jl
+++ b/src/numerics/linalg.jl
@@ -108,12 +108,12 @@ end
 
 # Matrix utilities
 """
-    Symmetrize!(A::AbstractMatrix{T}) where {T<:Real}
+    Symmetrize!(A::AbstractMatrix{T})::Symmetric{T} where {T<:Real}
 
 In-place symmetrization of a square matrix `A` via averaging with its transpose:
 A <- 0.5*(A + A').
 """
-function Symmetrize!(A::AbstractMatrix{T}) where {T<:Real}
+function Symmetrize!(A::AbstractMatrix{T})::Symmetric{T} where {T<:Real}
     n, m = size(A)
     @boundscheck n == m || throw(
         DimensionMismatch("Matrix must be square for symmetrization, got $(n)×$(m)")
@@ -128,7 +128,7 @@ function Symmetrize!(A::AbstractMatrix{T}) where {T<:Real}
         end
     end
 
-    return A
+    return Symmetric(A)
 end
 
 """

--- a/test/LinearDynamicalSystems/SLDS.jl
+++ b/test/LinearDynamicalSystems/SLDS.jl
@@ -1,6 +1,11 @@
+function _stable_A(rng, n::Int; radius::Float64=0.99)
+    A = rand(rng, n, n)
+    return A .* (radius / maximum(abs.(eigvals(A))))
+end
+
 # Build a Gaussian LDS with given dims
-function _make_gaussian_lds(latent_dim::Int, obs_dim::Int)
-    A = rand(latent_dim, latent_dim)
+function _make_gaussian_lds(latent_dim::Int, obs_dim::Int; rng=Random.default_rng())
+    A = _stable_A(rng, latent_dim)
     Q = Matrix(0.1 * I(latent_dim))
     b = zeros(latent_dim)
     x0 = zeros(latent_dim)
@@ -22,8 +27,8 @@ function _make_gaussian_lds(latent_dim::Int, obs_dim::Int)
 end
 
 # Build a Poisson-observation LDS (Gaussian state model)
-function _make_poisson_lds(latent_dim::Int, obs_dim::Int)
-    A = rand(latent_dim, latent_dim)
+function _make_poisson_lds(latent_dim::Int, obs_dim::Int; rng=Random.default_rng())
+    A = _stable_A(rng, latent_dim)
     Q = Matrix(0.1 * I(latent_dim))
     b = zeros(latent_dim)
     x0 = zeros(latent_dim)


### PR DESCRIPTION
Hotfix into main to resolve #103.

Two basic sources of instability i found:

1. The tests for `SLDS` used random `A` matrices that occasionally had eigenvalues > 1 so no amount of numerical trickery could ever really fix this. We now enforce for both Poisson and Gaussian as I think its a reasonable expectation its basically impossible to learn such a truly degenerate system (these were _super_ unstable).
2. More standard numerical issues appearing in `_compute_SLDS_constants!`. Seems simple uses of `Symmetrize!` resolved it. But hard to say for sure. 

I ran 10k random seeds and could not reproduce but time will tell if there are other paths producing problematic behavior. I  will also say i added some defensive `Symmetrize!` where i may not have needed to, but as long as benchmark doesn't complain, i say we keep.