### PR TITLE
Fix/131 dedupe lds likelihoods

### DIFF
--- a/benchmark/profiling/bt_solve_bench.jl
+++ b/benchmark/profiling/bt_solve_bench.jl
@@ -62,9 +62,12 @@ println(
     "  t=$(round(median(b2).time / 1e6; digits=3)) ms allocs=$(b2.allocs) mem=$(b2.memory) B",
 )
 
-# Time _loglikelihood_ws (the per-eval cost in the line search)
-println("\n=== _loglikelihood_ws (one phi-eval) ===")
-b3 = @benchmark StateSpaceDynamics._loglikelihood_ws($x0_mat, $lds, $y, $sws)
+# Time the workspace joint_loglikelihood! (the per-eval cost in the line search)
+println("\n=== sum(joint_loglikelihood!(ws, x, lds, y, lognorm_t)) (one phi-eval) ===")
+lognorm_t = StateSpaceDynamics._poisson_lognorm_t(y)
+b3 = @benchmark sum(
+    StateSpaceDynamics.joint_loglikelihood!($sws, $x0_mat, $lds, $y, $lognorm_t)
+)
 println(
     "  t=$(round(median(b3).time / 1e6; digits=3)) ms allocs=$(b3.allocs) mem=$(b3.memory) B",
 )

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -1,6 +1,10 @@
 #=============================================================================
 Continuous (Linear Gaussian) latents
 
+    Log-Likelihood kernels: stateloglikelihood!(cc, dxt, tmp, x, t, lds[, ux])
+                            observationloglikelihood!(cc, b1, b2, x, y, t, lds[, uy])
+                            joint_loglikelihood!(ll, ws, cc, lds, x, y)
+
     E-Step: Q_state!(sws, lds, suf)
 
     M-Step: update_initial_state_mean!(lds, suf)
@@ -8,6 +12,132 @@ Continuous (Linear Gaussian) latents
             update_A_b!(lds, suf, sws)
             update_Q!(lds, suf, sws)
 =============================================================================#
+
+"""
+    LDSLikelihoodCache{T}
+
+Any container of Cholesky-wrapped covariances (`Q_PD` / `P0_PD` / `R_PD`) and
+cached log-likelihood normalizers (`cP0` / `cQ` / `cR`) that the likelihood
+kernels can consume: a per-trial `SmoothWorkspace` (filled by
+`compute_smooth_constants!`) or a per-SLDS-component `LDSConstantCache`
+(filled by `compute_slds_constants!`).
+"""
+const LDSLikelihoodCache{T} = Union{LDSConstantCache{T},SmoothWorkspace{T}}
+
+# Normalizer accessors — `LDSConstantCache` stores plain scalars (mutable
+# struct), `SmoothWorkspace` stores RefValues (immutable struct).
+_cP0(cc::LDSConstantCache) = cc.cP0
+_cQ(cc::LDSConstantCache) = cc.cQ
+_cR(cc::LDSConstantCache) = cc.cR
+_cP0(ws::SmoothWorkspace) = ws.cP0[]
+_cQ(ws::SmoothWorkspace) = ws.cQ[]
+_cR(ws::SmoothWorkspace) = ws.cR[]
+
+"""
+    stateloglikelihood!(cc, dxt, tmp, x, t, lds[, ux])
+
+State-model (prior/transition) contribution to the complete-data log-likelihood
+at timestep `t`:
+
+- `t == 1`: `cP0 - 0.5‖P0^{-1/2}(x_1 - x_0)‖²`
+- `t ≥ 2`:  `cQ - 0.5‖Q^{-1/2}(x_t - A x_{t-1} - b - B u_{t-1})‖²`
+
+This term is identical for every observation model (Gaussian, Poisson, ...);
+only the emission term differs, so `joint_loglikelihood!` implementations share
+this helper instead of duplicating the prior/transition math.
+
+`cc` is an [`LDSLikelihoodCache`](@ref) holding the Cholesky factors and
+normalizers; `dxt` and `tmp` are `latent_dim` scratch vectors (overwritten).
+Pass `ux` (state inputs, `t`-indexed like `x`) to include the `B u_{t-1}`
+term; `nothing` (default) or a zero-row matrix skips it.
+"""
+function stateloglikelihood!(
+    cc::LDSLikelihoodCache{T},
+    dxt::AbstractVector{T},
+    tmp::AbstractVector{T},
+    x::AbstractMatrix{T},
+    t::Int,
+    lds::LinearDynamicalSystem{T0,S,O},
+    ux::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:AbstractObservationModel{T0}}
+    A = lds.state_model.A
+    b = lds.state_model.b
+    x0 = lds.state_model.x0
+
+    if t == 1
+        @views dxt .= x[:, 1] .- x0
+        ldiv!(cc.P0_PD[].chol.U', dxt)
+        return _cP0(cc) - T(0.5) * sum(abs2, dxt)
+    else
+        @views mul!(tmp, A, x[:, t - 1])
+        if ux !== nothing
+            @views mul!(tmp, lds.state_model.B, ux[:, t - 1], one(T), one(T))
+        end
+        @views tmp .= x[:, t] .- tmp .- b
+        ldiv!(cc.Q_PD[].chol.U', tmp)
+        return _cQ(cc) - T(0.5) * sum(abs2, tmp)
+    end
+end
+
+"""
+    observationloglikelihood!(cc, buf1, buf2, x, y, t, lds[, uy])
+
+Emission-model contribution `log p(y_t | x_t)` to the complete-data
+log-likelihood at timestep `t`. Dispatches on the observation model type `O`
+(via `lds::LinearDynamicalSystem{T,S,O}`) — a custom observation model plugs
+into `joint_loglikelihood!` by adding a method here, without having to
+reimplement (or duplicate) the shared `stateloglikelihood!` term.
+
+Uniform interface for all observation models:
+- `cc`: an [`LDSLikelihoodCache`](@ref) with Cholesky factors / normalizers
+  (unused by models whose emission term needs no covariance, e.g. Poisson).
+- `buf1`, `buf2`: two `obs_dim` scratch vectors (overwritten); each model uses
+  what it needs (Gaussian: residual; Poisson: linear predictor + rate).
+- `uy` (optional): observation inputs, `t`-indexed like `y`; `nothing` or a
+  zero-row matrix skips the `D u_t` term.
+
+See the `GaussianObservationModel` / `PoissonObservationModel` methods in
+`fit_LDS.jl` / `fit_PLDS.jl` for the pattern to follow.
+"""
+function observationloglikelihood! end
+
+"""
+    joint_loglikelihood!(ll, ws, cc, lds, x, y)
+
+Per-timestep complete-data log-likelihood for a single SLDS component:
+`ll[t] = log p(y_t | x_t) + log p(x_t | x_{t-1})` (or `+ log p(x_1)` at
+`t == 1`). Generic over the observation model — the emission term comes from
+`observationloglikelihood!`, so supporting a new observation model here only
+requires a new `observationloglikelihood!` method, not a new
+`joint_loglikelihood!` method.
+
+Notes:
+- Normalization terms (logdet + log(2π)) are included. These are constant w.r.t.
+  `x`, but **not** constant across SLDS discrete states when `Q`/`R` differ by
+  state.
+"""
+function joint_loglikelihood!(
+    ll::AbstractVector{T},
+    ws::SLDSSmoothWorkspace{T},
+    cc::LDSConstantCache{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    x::AbstractMatrix{T},
+    y::AbstractMatrix{T},
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    tsteps = size(y, 2)
+    @assert length(ll) == tsteps
+
+    dxt = ws.dxt
+    tmp = ws.tmp1
+
+    for t in 1:tsteps
+        ll_t = observationloglikelihood!(cc, ws.z, ws.λ, x, y, t, lds)
+        ll_t += stateloglikelihood!(cc, dxt, tmp, x, t, lds)
+        ll[t] = ll_t
+    end
+
+    return ll
+end
 
 """
     Q_state!(ws, lds, E_z, E_zz, E_zz_prev, ux)

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -33,6 +33,20 @@ _cP0(ws::SmoothWorkspace) = ws.cP0[]
 _cQ(ws::SmoothWorkspace) = ws.cQ[]
 _cR(ws::SmoothWorkspace) = ws.cR[]
 
+# In-place whitening solve `v := U⁻ᵀ v` against a Cholesky Σ = U'U, so that
+# `sum(abs2, v)` afterwards is the quadratic form `v'Σ⁻¹v`. 
+@inline function _whiten!(
+    chol::Cholesky{T,Matrix{T}}, v::StridedVector{T}
+) where {T<:LinearAlgebra.BlasFloat}
+    if chol.uplo === 'U'
+        LinearAlgebra.LAPACK.trtrs!('U', 'T', 'N', chol.factors, v)
+    else
+        LinearAlgebra.LAPACK.trtrs!('L', 'N', 'N', chol.factors, v)
+    end
+    return v
+end
+_whiten!(chol::Cholesky, v::AbstractVector) = ldiv!(chol.U', v)
+
 """
     stateloglikelihood!(cc, dxt, tmp, x, t, lds[, ux])
 
@@ -66,7 +80,7 @@ function stateloglikelihood!(
 
     if t == 1
         @views dxt .= x[:, 1] .- x0
-        ldiv!(cc.P0_PD[].chol.U', dxt)
+        _whiten!(cc.P0_PD[].chol, dxt)
         return _cP0(cc) - T(0.5) * sum(abs2, dxt)
     else
         @views mul!(tmp, A, x[:, t - 1])
@@ -74,7 +88,7 @@ function stateloglikelihood!(
             @views mul!(tmp, lds.state_model.B, ux[:, t - 1], one(T), one(T))
         end
         @views tmp .= x[:, t] .- tmp .- b
-        ldiv!(cc.Q_PD[].chol.U', tmp)
+        _whiten!(cc.Q_PD[].chol, tmp)
         return _cQ(cc) - T(0.5) * sum(abs2, tmp)
     end
 end

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -50,16 +50,31 @@ function joint_loglikelihood!(
     ux::Union{Nothing,AbstractMatrix{T0}}=nothing,
     uy::Union{Nothing,AbstractMatrix{T0}}=nothing,
 ) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:GaussianObservationModel{T0}}
-    tsteps = size(y, 2)
     ll_vec = ws.ll_vec
 
-    for t in 1:tsteps
-        ll_t = observationloglikelihood!(ws, ws.temp_dy, ws.temp_solve_R, x, y, t, lds, uy)
-        ll_t += stateloglikelihood!(ws, ws.temp_dx, ws.temp_solve_Q, x, t, lds, ux)
-        ll_vec[t] = ll_t
+    for t in eachindex(ll_vec)
+        ll_vec[t] = observationloglikelihood!(
+            ws, ws.temp_dy, ws.temp_solve_R, x, y, t, lds, uy
+        )
+        ll_vec[t] += stateloglikelihood!(ws, ws.temp_dx, ws.temp_solve_Q, x, t, lds, ux)
     end
 
     return ll_vec
+end
+
+# type promotion wrapper for the common case of mixed-type inputs (e.g. Float32 latent states, Float64 observations)
+function joint_loglikelihood(
+    x::AbstractMatrix{XT},
+    lds::LinearDynamicalSystem{T,S,O},
+    y::AbstractMatrix{YT},
+    ux::Union{Nothing,AbstractMatrix{YT}}=nothing,
+    uy::Union{Nothing,AbstractMatrix{YT}}=nothing,
+) where {T<:Real,YT<:Real,XT<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    tsteps = size(y, 2)
+    WT = promote_type(T, YT, XT)
+    ws = SmoothWorkspace(WT, lds.latent_dim, lds.obs_dim, tsteps)
+    compute_smooth_constants!(ws, lds)
+    return joint_loglikelihood!(ws, x, lds, y, ux, uy)
 end
 
 """
@@ -502,15 +517,15 @@ function _precompute_shared_cov!(
     neg_sub_v = view(btd.neg_sub, 1:(tsteps - 1))
     neg_super_v = view(btd.neg_super, 1:(tsteps - 1))
 
-    p_smooth_v = view(p_smooth_shared, :, :, (1:tsteps))
-    p_smooth_tt1_v = view((sws.p_smooth_tt1_shared::Array{T,3}), :, :, (1:tsteps))
+    p_smooth_v = view(p_smooth_shared,:,:,(1:tsteps))
+    p_smooth_tt1_v = view((sws.p_smooth_tt1_shared::Array{T,3}),:,:,(1:tsteps))
 
     logdet_precision = block_tridiagonal_inverse_logdet!(
         p_smooth_v, p_smooth_tt1_v, neg_sub_v, neg_diag_v, neg_super_v, btd
     )
 
     for i in 1:tsteps
-        Symmetrize!(tview(p_smooth_shared, :, :, i))
+        Symmetrize!(tview(p_smooth_shared,:,:,i))
     end
 
     return gaussian_entropy_from_logdet(logdet_precision, D * tsteps)
@@ -1010,7 +1025,7 @@ function fit!(
     # reshape y from [obs_dim, tsteps, trials] to vector of matrices if needed
     if ndims(y) == 3
         obs_dim, tsteps, ntrials = size(y)
-        y_vec = [view(y, :, :, i) for i in 1:ntrials]
+        y_vec = [view(y,:,:,i) for i in 1:ntrials]
         return fit!(lds, y_vec; kwargs...)
     elseif ndims(y) == 2
         # single trial case, wrap in vector
@@ -1029,16 +1044,6 @@ function smooth!(
     npool = Threads.maxthreadid()
     sws_pool = [SmoothWorkspace(T, lds.latent_dim, lds.obs_dim, T_max) for _ in 1:npool]
     return smooth!(lds, tfs, y, sws_pool)
-end
-
-function joint_loglikelihood(
-    x::AbstractMatrix{XT}, lds::LinearDynamicalSystem{T,S,O}, y::AbstractMatrix{YT}
-) where {T<:Real,YT<:Real,XT<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    tsteps = size(y, 2)
-    WT = promote_type(T, YT, XT)
-    ws = SmoothWorkspace(WT, lds.latent_dim, lds.obs_dim, tsteps)
-    compute_smooth_constants!(ws, lds)
-    return joint_loglikelihood!(ws, x, lds, y)
 end
 
 """

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -29,158 +29,67 @@ performance, with careful attention to memory allocation and multi-threading.
 """
 
 """
-    joint_loglikelihood!(ws, x, lds, y)
+    joint_loglikelihood!(ws, x, lds, y[, ux, uy])
 
-In-place version of `joint_loglikelihood` that uses pre-computed Cholesky factors from
-`ws::SmoothWorkspace` and writes into `ws.ll_vec`. Returns the sum of log-likelihoods.
+Per-timestep complete-data log-likelihood of a Gaussian LDS, written into
+`ws.ll_vec` (returned):
+
+- `ll[1]` includes: log p(x₁) + log p(y₁ | x₁)
+- `ll[t]` for t≥2 includes: log p(x_t | x_{t-1}, u_{t-1}) + log p(y_t | x_t, uy_t)
+
+Built from the shared `stateloglikelihood!` / `observationloglikelihood!`
+kernels; requires `compute_smooth_constants!(ws, lds)` to have been called.
+`ux` / `uy` are optional control inputs (`nothing` or zero-row matrices skip
+the `B u` / `D uy` terms).
 """
 function joint_loglikelihood!(
     ws::SmoothWorkspace{T},
     x::AbstractMatrix{T},
     lds::LinearDynamicalSystem{T0,S,O},
     y::AbstractMatrix{T0},
-    ux::AbstractMatrix{T0},
-    uy::AbstractMatrix{T0},
+    ux::Union{Nothing,AbstractMatrix{T0}}=nothing,
+    uy::Union{Nothing,AbstractMatrix{T0}}=nothing,
 ) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:GaussianObservationModel{T0}}
     tsteps = size(y, 2)
-
-    A = lds.state_model.A
-    b = lds.state_model.b
-    B = lds.state_model.B
-    x0 = lds.state_model.x0
-    d = lds.obs_model.d
-    D_obs = lds.obs_model.D
-
-    R_U = ws.R_PD[].chol.U
-    Q_U = ws.Q_PD[].chol.U
-    P0_U = ws.P0_PD[].chol.U
-
     ll_vec = ws.ll_vec
-    temp_dx = ws.temp_dx
-    temp_dy = ws.temp_dy
-    temp_solve_Q = ws.temp_solve_Q
-    temp_solve_R = ws.temp_solve_R
-
-    latent_dim = lds.latent_dim
-    obs_dim = lds.obs_dim
-
-    cP0 = -T(0.5) * (T(latent_dim) * log(T(2π)) + logdet(ws.P0_PD[]))
-    cQ = -T(0.5) * (T(latent_dim) * log(T(2π)) + logdet(ws.Q_PD[]))
-    cR = -T(0.5) * (T(obs_dim) * log(T(2π)) + logdet(ws.R_PD[]))
 
     for t in 1:tsteps
-        ll_t = zero(T)
-
-        # Initial state (t=1): log p(x1)
-        if t == 1
-            @views temp_dx .= x[:, 1] .- x0
-            ldiv!(temp_solve_Q, P0_U, temp_dx)
-            ll_t += cP0 - T(0.5) * sum(abs2, temp_solve_Q)
-        end
-
-        # Dynamics (t>1): log p(x_t | x_{t-1}, u_{t-1}) where mean = A x_{t-1} + b + B u_{t-1}.
-        # `B*ux` is a no-op when `ux` has zero rows (size(B,2) == size(ux,1) == 0).
-        if t > 1
-            @views mul!(temp_dx, A, x[:, t - 1])
-            @views mul!(temp_dx, B, ux[:, t - 1], one(T0), one(T0))
-            @views temp_dx .= x[:, t] .- temp_dx .- b
-            ldiv!(temp_solve_Q, Q_U, temp_dx)
-            ll_t += cQ - T(0.5) * sum(abs2, temp_solve_Q)
-        end
-
-        # Emission: log p(y_t | x_t, uy_t) where mean = C x_t + d + D uy_t.
-        @views mul!(temp_dy, lds.obs_model.C, x[:, t])
-        @views mul!(temp_dy, D_obs, uy[:, t], one(T0), one(T0))
-        @views temp_dy .= y[:, t] .- temp_dy .- d
-        ldiv!(temp_solve_R, R_U, temp_dy)
-        ll_t += cR - T(0.5) * sum(abs2, temp_solve_R)
-
+        ll_t = observationloglikelihood!(ws, ws.temp_dy, ws.temp_solve_R, x, y, t, lds, uy)
+        ll_t += stateloglikelihood!(ws, ws.temp_dx, ws.temp_solve_Q, x, t, lds, ux)
         ll_vec[t] = ll_t
     end
 
     return ll_vec
 end
 
-# Backward-compatible 4-arg overload: no inputs. Forwards to the 6-arg form
-# with zero-row ux/uy matrices, so callers that don't use inputs don't have
-# to pass them.
-function joint_loglikelihood!(
-    ws::SmoothWorkspace{T},
+"""
+    observationloglikelihood!(cc, dyt, _, x, y, t, lds[, uy])
+
+Gaussian emission term: `cR - 0.5*||R^{-1/2}(y_t - Cx_t - d - D uy_t)||^2`.
+Method of the generic `observationloglikelihood!` dispatch point (see
+`continuous_latents.jl`); `dyt` is the `obs_dim` residual scratch, the second
+buffer is unused.
+"""
+function observationloglikelihood!(
+    cc::LDSLikelihoodCache{T},
+    dyt::AbstractVector{T},
+    ::AbstractVector{T},
     x::AbstractMatrix{T},
-    lds::LinearDynamicalSystem{T0,S,O},
     y::AbstractMatrix{T0},
+    t::Int,
+    lds::LinearDynamicalSystem{T0,S,O},
+    uy::Union{Nothing,AbstractMatrix}=nothing,
 ) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:GaussianObservationModel{T0}}
-    tsteps = size(y, 2)
-    ux = zeros(T0, 0, tsteps)
-    uy = zeros(T0, 0, tsteps)
-    return joint_loglikelihood!(ws, x, lds, y, ux, uy)
-end
-
-"""
-    joint_loglikelihood!(ws, x, lds, y)
-
-Compute per-timestep complete-data log-likelihood contributions for a Gaussian LDS:
-
-- `ll[1]` includes: log p(x₁) + log p(y₁ | x₁)
-- `ll[t]` for t≥2 includes: log p(x_t | x_{t-1}) + log p(y_t | x_t)
-
-Writes into `ws.ll_vec` and returns it.
-
-Notes:
-- Normalization terms (logdet + log(2π)) are included. These are constant w.r.t. `x`,
-  but **not** constant across SLDS discrete states when `Q`/`R` differ by state.
-"""
-function joint_loglikelihood!(
-    ll::AbstractVector{T},
-    ws::SLDSSmoothWorkspace{T},
-    cc::LDSConstantCache{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    x::AbstractMatrix{T},
-    y::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    tsteps = size(y, 2)
-    @assert length(ll) == tsteps
-
-    A = lds.state_model.A
-    b = lds.state_model.b
-    x0 = lds.state_model.x0
     C = lds.obs_model.C
     d = lds.obs_model.d
 
-    Q_U = cc.Q_PD[].chol.U
-    P0_U = cc.P0_PD[].chol.U
-    R_U = cc.R_PD[].chol.U
-
-    dxt = ws.dxt
-    dyt = ws.dyt
-    tmp = ws.tmp1  # latent_dim work vector (used as transition residual)
-
-    for t in 1:tsteps
-        ll_t = zero(T)
-
-        # emission: cR - 0.5*||R^{-1/2}(y_t - Cx_t - d)||^2
-        @views mul!(dyt, C, x[:, t])
-        @views dyt .= y[:, t] .- dyt .- d
-        ldiv!(dyt, R_U, dyt)
-        ll_t += cc.cR - T(0.5) * sum(abs2, dyt)
-
-        if t == 1
-            # prior: cP0 - 0.5*||P0^{-1/2}(x1 - x0)||^2
-            @views dxt .= x[:, 1] .- x0
-            ldiv!(dxt, P0_U, dxt)
-            ll_t += cc.cP0 - T(0.5) * sum(abs2, dxt)
-        else
-            # transition: cQ - 0.5*||Q^{-1/2}(x_t - A x_{t-1} - b)||^2
-            @views mul!(tmp, A, x[:, t - 1])
-            @views tmp .= x[:, t] .- tmp .- b
-            ldiv!(tmp, Q_U, tmp)
-            ll_t += cc.cQ - T(0.5) * sum(abs2, tmp)
-        end
-
-        ll[t] = ll_t
+    @views mul!(dyt, C, x[:, t])
+    if uy !== nothing
+        @views mul!(dyt, lds.obs_model.D, uy[:, t], one(T), one(T))
     end
-
-    return ll
+    @views dyt .= y[:, t] .- dyt .- d
+    ldiv!(cc.R_PD[].chol.U', dyt)
+    return _cR(cc) - T(0.5) * sum(abs2, dyt)
 end
 
 """

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -517,15 +517,15 @@ function _precompute_shared_cov!(
     neg_sub_v = view(btd.neg_sub, 1:(tsteps - 1))
     neg_super_v = view(btd.neg_super, 1:(tsteps - 1))
 
-    p_smooth_v = view(p_smooth_shared,:,:,(1:tsteps))
-    p_smooth_tt1_v = view((sws.p_smooth_tt1_shared::Array{T,3}),:,:,(1:tsteps))
+    p_smooth_v = view(p_smooth_shared, :, :, (1:tsteps))
+    p_smooth_tt1_v = view((sws.p_smooth_tt1_shared::Array{T,3}), :, :, (1:tsteps))
 
     logdet_precision = block_tridiagonal_inverse_logdet!(
         p_smooth_v, p_smooth_tt1_v, neg_sub_v, neg_diag_v, neg_super_v, btd
     )
 
     for i in 1:tsteps
-        Symmetrize!(tview(p_smooth_shared,:,:,i))
+        Symmetrize!(tview(p_smooth_shared, :, :, i))
     end
 
     return gaussian_entropy_from_logdet(logdet_precision, D * tsteps)
@@ -1025,7 +1025,7 @@ function fit!(
     # reshape y from [obs_dim, tsteps, trials] to vector of matrices if needed
     if ndims(y) == 3
         obs_dim, tsteps, ntrials = size(y)
-        y_vec = [view(y,:,:,i) for i in 1:ntrials]
+        y_vec = [view(y, :, :, i) for i in 1:ntrials]
         return fit!(lds, y_vec; kwargs...)
     elseif ndims(y) == 2
         # single trial case, wrap in vector

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -88,7 +88,7 @@ function observationloglikelihood!(
         @views mul!(dyt, lds.obs_model.D, uy[:, t], one(T), one(T))
     end
     @views dyt .= y[:, t] .- dyt .- d
-    ldiv!(cc.R_PD[].chol.U', dyt)
+    _whiten!(cc.R_PD[].chol, dyt)
     return _cR(cc) - T(0.5) * sum(abs2, dyt)
 end
 

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -1,7 +1,8 @@
 #=============================================================================
 Poisson LDS
 
-    Log-Likelihood: joint_loglikelihood(x, plds, y)
+    Log-Likelihood: joint_loglikelihood!(ws, x, plds, y[, lognorm_t])
+                    joint_loglikelihood(x, plds, y)
 
     Gradient:       Gradient!(ws, lds, y, x)
                     gradient_observation_model!(grad, C, d, tfs, y, sws_pool)
@@ -21,18 +22,67 @@ Poisson LDS
 =============================================================================#
 
 """
-    joint_loglikelihood(x, plds, y)
+    _poisson_lognorm_t(y)
 
-Per-timestep complete-data log-likelihood of a Poisson Linear Dynamical System
-for a single trial (allocating convenience wrapper; mirrors the Gaussian
-`joint_loglikelihood`). The rate follows the canonical Poisson GLM
-`λ_t = exp(C x_t + d)`.
+Per-timestep Poisson emission normalizer `lognorm_t[t] = Σᵢ log(y[i,t]!)`;
+constant in the latents. Computed once per trial and handed to `joint_loglikelihood!`
+"""
+function _poisson_lognorm_t(y::AbstractMatrix{T}) where {T<:Real}
+    return vec(sum(yi -> loggamma(yi + one(T)), y; dims=1))
+end
+
+"""
+    joint_loglikelihood!(ws, x, plds, y[, lognorm_t])
+
+Per-timestep complete-data log-likelihood of a Poisson LDS, written into
+`ws.ll_vec` (an active-length view is returned — the workspace may be
+pool-oversized). Mirrors the Gaussian `joint_loglikelihood!`; requires
+`compute_smooth_constants!(ws, plds)` to have been called. The rate follows
+the canonical Poisson GLM `λ_t = exp(C x_t + d)`.
 
 - `ll[1]` includes: log p(x₁) + log p(y₁ | x₁)
 - `ll[t]` for t≥2 includes: log p(x_t | x_{t-1}) + log p(y_t | x_t)
 
 Normalization terms (Gaussian logdet + log(2π) and Poisson `-log(y!)`) are
 included, so `sum(ll)` is the exact complete-data log-density `log p(x, y)`.
+"""
+function joint_loglikelihood!(
+    ws::SmoothWorkspace{T},
+    x::AbstractMatrix{T},
+    plds::LinearDynamicalSystem{TM,S,O},
+    y::AbstractMatrix{TM},
+    lognorm_t::AbstractVector{<:Real}=_poisson_lognorm_t(y),
+) where {T<:Real,TM<:Real,S<:GaussianStateModel{TM},O<:PoissonObservationModel{TM}}
+    tsteps = size(y, 2)
+
+    C = plds.obs_model.C
+    d = plds.obs_model.d
+
+    ll_vec = view(ws.ll_vec, 1:tsteps)
+    η = ws.temp_dy                      # length obs_dim
+    dx = ws.temp_dx                     # length latent_dim
+    tmp = ws.temp_solve_Q               # length latent_dim
+
+    @views for t in 1:tsteps
+        # Emission (with -log(y!)): y_t'η_t - sum(exp(η_t)),
+        # with η_t = Cx_t + d
+        mul!(η, C, x[:, t])
+        @. η = η + d
+        ll_vec[t] = dot(y[:, t], η) - sum(exp, η) - lognorm_t[t]
+
+        # Prior (t = 1) / transition (t ≥ 2)
+        ll_vec[t] += stateloglikelihood!(ws, dx, tmp, x, t, plds)
+    end
+
+    return ll_vec
+end
+
+"""
+    joint_loglikelihood(x, plds, y)
+
+Per-timestep complete-data log-likelihood of a Poisson LDS for a single trial
+(allocating convenience wrapper around `joint_loglikelihood!`; mirrors the
+Gaussian `joint_loglikelihood`).
 
 # Arguments
 - `x::AbstractMatrix`: latent states, (latent_dim × tsteps)
@@ -49,58 +99,7 @@ function joint_loglikelihood(
     compute_smooth_constants!(ws, plds)
     x_R = convert(AbstractMatrix{R}, x)
 
-    ll = zeros(R, tsteps)
-    for t in 1:tsteps
-        ll_t = observationloglikelihood!(ws, ws.temp_dy, ws.dyt, x_R, y, t, plds)
-        ll_t += stateloglikelihood!(ws, ws.temp_dx, ws.temp_solve_Q, x_R, t, plds)
-        ll[t] = ll_t
-    end
-
-    return ll
-end
-
-"""
-    _loglikelihood_ws(x, lds, y, ws)
-
-Efficient log-likelihood computation using cached Cholesky factors from SmoothWorkspace.
-Returns the total log-likelihood (scalar), not per-timestep.
-Used in the Newton line search to avoid repeated Cholesky factorizations.
-
-The state side is the shared `stateloglikelihood!` kernel; the Poisson emission
-term stays inline because it deliberately omits the `-sum(log(y!))` normalizer —
-constant in `x`, so irrelevant to the line search and too expensive (a
-`loggamma` per observation per timestep) for this hot path. Use
-`observationloglikelihood!` when the full emission density is needed.
-"""
-function _loglikelihood_ws(
-    x::AbstractMatrix{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    y::AbstractMatrix{T},
-    ws::SmoothWorkspace{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    tsteps = size(y, 2)
-
-    C = lds.obs_model.C
-    d = lds.obs_model.d
-
-    ll = zero(T)
-
-    η = ws.temp_dy                      # length obs_dim
-    dx = ws.temp_dx                     # length latent_dim
-    tmp = ws.temp_solve_Q               # length latent_dim
-
-    @views for t in 1:tsteps
-        # Emission (up to the x-constant -log(y!)): y_t'η_t - sum(exp(η_t)),
-        # with η_t = Cx_t + d
-        mul!(η, C, x[:, t])
-        @. η = η + d
-        ll += dot(y[:, t], η) - sum(exp, η)
-
-        # Prior (t = 1) / transition (t ≥ 2)
-        ll += stateloglikelihood!(ws, dx, tmp, x, t, lds)
-    end
-
-    return ll
+    return joint_loglikelihood!(ws, x_R, plds, y)
 end
 
 """
@@ -748,7 +747,10 @@ function smooth!(
     g = grad_active
     p = reshape(X0, D, tsteps)
 
-    ϕ!() = _loglikelihood_ws(x, lds, y, sws)
+    # The line-search objective is the exact complete-data log-likelihood;
+    # hoisting the data-only normalizer makes that free per evaluation.
+    lognorm_t = _poisson_lognorm_t(y)
+    ϕ!() = sum(joint_loglikelihood!(sws, x, lds, y, lognorm_t))
 
     compute_grad! = (gcur, xcur) -> begin
         _compute_gradient_poisson!(gcur, sws, lds, y, xcur)

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -21,73 +21,39 @@ Poisson LDS
 =============================================================================#
 
 """
-    joint_loglikelihood(
-        x::AbstractMatrix{U},
-        plds::LinearDynamicalSystem{T,S,O},
-        y::AbstractMatrix{T}
-    )
+    joint_loglikelihood(x, plds, y)
 
-Calculate the complete-data log-likelihood of a Poisson Linear Dynamical System model for a
-single trial.
+Per-timestep complete-data log-likelihood of a Poisson Linear Dynamical System
+for a single trial (allocating convenience wrapper; mirrors the Gaussian
+`joint_loglikelihood`). The rate follows the canonical Poisson GLM
+`λ_t = exp(C x_t + d)`.
+
+- `ll[1]` includes: log p(x₁) + log p(y₁ | x₁)
+- `ll[t]` for t≥2 includes: log p(x_t | x_{t-1}) + log p(y_t | x_t)
+
+Normalization terms (Gaussian logdet + log(2π) and Poisson `-log(y!)`) are
+included, so `sum(ll)` is the exact complete-data log-density `log p(x, y)`.
 
 # Arguments
-- `x::AbstractMatrix{T}`: The latent state variables. Dimensions: (latent_dim, tsteps)
-- `lds::LinearDynamicalSystem{T,S,O}`: The Linear Dynamical System model.
-- `y::AbstractMatrix{T}`: The observed data. Dimensions: (obs_dim, tsteps)
-- `w::Vector{T}`: Weights for each observation in the log-likelihood calculation. Not
-    currently used.
-
-# Returns
-- `ll::Vector{T}`: The log-likelihood value.
-
-# Ref
-- joint_loglikelihood(
-    x::AbstractArray{T,3},
-    plds::LinearDynamicalSystem{T,S,O},
-    y::AbstractArray{T,3}
-)
+- `x::AbstractMatrix`: latent states, (latent_dim × tsteps)
+- `plds::LinearDynamicalSystem`: the Poisson LDS model
+- `y::AbstractMatrix`: observed counts, (obs_dim × tsteps)
 """
 function joint_loglikelihood(
     x::AbstractMatrix{U}, plds::LinearDynamicalSystem{T,S,O}, y::AbstractMatrix{T}
 ) where {U<:Real,T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-
-    # Result type and setup
     R = promote_type(T, U)
     tsteps = size(y, 2)
+
+    ws = SmoothWorkspace(R, plds.latent_dim, plds.obs_dim, tsteps)
+    compute_smooth_constants!(ws, plds)
+    x_R = convert(AbstractMatrix{R}, x)
+
     ll = zeros(R, tsteps)
-
-    # Canonical Poisson GLM: λ_t = exp(C x_t + d), where `d` is the
-    # log-link intercept (free in ℝ; positivity is provided by exp).
-    d = plds.obs_model.d
-
-    # Pre-compute Cholesky factorizations
-    P0_chol = cholesky(Symmetric(plds.state_model.P0))
-    Q_chol = cholesky(Symmetric(plds.state_model.Q))
-
-    # Get dimensions
-    C = plds.obs_model.C
-    A = plds.state_model.A
-    x0 = plds.state_model.x0
-    obs_dim, latent_dim = size(C)
-    obs_tmp = Vector{eltype(x)}(undef, obs_dim)
-
-    @views for t in 1:tsteps
-        obs_tmp .= C * x[:, t] .+ d
-        ll[t] += (dot(y[:, t], obs_tmp) - sum(exp, obs_tmp))
-    end
-
-    # Prior term p(x₁) goes to t = 1
-    dx1 = @view(x[:, 1]) .- plds.state_model.x0
-    ll[1] += -R(0.5) * dot(dx1, P0_chol \ dx1)
-
-    # Transition terms p(xₜ|xₜ₋₁) go to their respective t (t ≥ 2)
-    A = plds.state_model.A
-    b = plds.state_model.b
-    trans_tmp = Vector{eltype(x)}(undef, latent_dim)
-
-    @views for t in 2:tsteps
-        trans_tmp .= x[:, t] .- (A * x[:, t - 1] .+ b)
-        ll[t] += -R(0.5) * dot(trans_tmp, Q_chol \ trans_tmp)
+    for t in 1:tsteps
+        ll_t = observationloglikelihood!(ws, ws.temp_dy, ws.dyt, x_R, y, t, plds)
+        ll_t += stateloglikelihood!(ws, ws.temp_dx, ws.temp_solve_Q, x_R, t, plds)
+        ll[t] = ll_t
     end
 
     return ll
@@ -99,6 +65,12 @@ end
 Efficient log-likelihood computation using cached Cholesky factors from SmoothWorkspace.
 Returns the total log-likelihood (scalar), not per-timestep.
 Used in the Newton line search to avoid repeated Cholesky factorizations.
+
+The state side is the shared `stateloglikelihood!` kernel; the Poisson emission
+term stays inline because it deliberately omits the `-sum(log(y!))` normalizer —
+constant in `x`, so irrelevant to the line search and too expensive (a
+`loggamma` per observation per timestep) for this hot path. Use
+`observationloglikelihood!` when the full emission density is needed.
 """
 function _loglikelihood_ws(
     x::AbstractMatrix{T},
@@ -110,107 +82,58 @@ function _loglikelihood_ws(
 
     C = lds.obs_model.C
     d = lds.obs_model.d
-    A = lds.state_model.A
-    b = lds.state_model.b
-    x0 = lds.state_model.x0
 
     ll = zero(T)
 
     η = ws.temp_dy                      # length obs_dim
     dx = ws.temp_dx                     # length latent_dim
-    z = ws.temp_solve_Q                # length latent_dim
+    tmp = ws.temp_solve_Q               # length latent_dim
 
-    # Observation term: sum_t [ y_t'η_t - sum(exp(η_t)) ], η_t = Cx_t + d
     @views for t in 1:tsteps
-        mul!(η, C, x[:, t])             # η := C * x_t
-        @. η = η + d                    # η := η + d
+        # Emission (up to the x-constant -log(y!)): y_t'η_t - sum(exp(η_t)),
+        # with η_t = Cx_t + d
+        mul!(η, C, x[:, t])
+        @. η = η + d
         ll += dot(y[:, t], η) - sum(exp, η)
-    end
 
-    # Bind the raw Cholesky factor matrices once and use `LAPACK.trtrs!`
-    # directly. `pdm.chol.L` would allocate a fresh
-    # `LowerTriangular{T,Matrix{T}}` wrapper on every access; PDMats
-    # stores the upper factor in `.chol.factors` (uplo='U'), so trans='T'
-    # turns the call into a solve against L = U'.
-    P0_factors = ws.P0_PD[].chol.factors
-    Q_factors = ws.Q_PD[].chol.factors
-
-    # Prior: -0.5 * || P0^{-1/2} (x1 - x0) ||^2  with P0 = U'U
-    @views begin
-        @. dx = x[:, 1] - x0
-        copyto!(z, dx)
-        LinearAlgebra.LAPACK.trtrs!('U', 'T', 'N', P0_factors, z)   # z := L \ dx
-        ll -= T(0.5) * dot(z, z)
-    end
-
-    # Transitions: -0.5 * sum_{t=2}^T || Q^{-1/2} (x_t - A x_{t-1} - b) ||^2, Q = U'U
-    @views for t in 2:tsteps
-        mul!(dx, A, x[:, t - 1])          # dx := A * x_{t-1}
-        @. dx = x[:, t] - (dx + b)      # dx := x_t - (A x_{t-1} + b)
-        copyto!(z, dx)
-        LinearAlgebra.LAPACK.trtrs!('U', 'T', 'N', Q_factors, z)    # z := L \ dx
-        ll -= T(0.5) * dot(z, z)
+        # Prior (t = 1) / transition (t ≥ 2)
+        ll += stateloglikelihood!(ws, dx, tmp, x, t, lds)
     end
 
     return ll
 end
 
-function joint_loglikelihood!(
-    ll::AbstractVector{T},
-    ws::SLDSSmoothWorkspace{T},
-    cc::LDSConstantCache{T},
-    lds::LinearDynamicalSystem{T,S,O},
+"""
+    observationloglikelihood!(cc, z, λ, x, y, t, lds[, uy])
+
+Poisson emission term: with rate `λ = exp(Cx_t + d)`,
+`log p(y_t|x_t) = y⋅log(λ) - sum(λ) - sum(log(y!))`. Method of the generic
+`observationloglikelihood!` dispatch point (see `continuous_latents.jl`); `z` and `λ`
+are `obs_dim` scratch vectors for the linear predictor and the rate. The cache
+and `uy` arguments are unused (no covariance term; Poisson observation inputs
+are not supported).
+"""
+function observationloglikelihood!(
+    ::LDSLikelihoodCache{T},
+    z::AbstractVector{T},
+    λ::AbstractVector{T},
     x::AbstractMatrix{T},
-    y::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    tsteps = size(y, 2)
-    @assert length(ll) == tsteps
+    y::AbstractMatrix{T0},
+    t::Int,
+    lds::LinearDynamicalSystem{T0,S,O},
+    ::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:PoissonObservationModel{T0}}
+    C = lds.obs_model.C
+    d = lds.obs_model.d
 
-    A = lds.state_model.A
-    b = lds.state_model.b
-    x0 = lds.state_model.x0
+    # z = Cx + d ; λ = exp(z)
+    @views mul!(z, C, x[:, t])
+    z .+= d
+    @. λ = exp(z)
 
-    # Poisson obs: λ = exp(Cx + d); log p(y|x) = sum(y .* logλ - λ - log(y!))
-    z = ws.z
-    λ = ws.λ
-
-    Q_U = cc.Q_PD[].chol.U
-    P0_U = cc.P0_PD[].chol.U
-
-    dxt = ws.dxt
-    tmp = ws.tmp1
-
-    C = cc.C
-    d = cc.d
-
-    for t in 1:tsteps
-        ll_t = zero(T)
-
-        # obs: z = Cx + d ; λ = exp(z)
-        @views mul!(z, C, x[:, t])
-        z .+= d
-        @. λ = exp(z)
-
-        # compute y⋅z - λ - log(y!)  (loggamma(n+1) = log(n!) for real n≥0)
-        @views begin
-            ll_t += sum(y[:, t] .* z) - sum(λ) - sum(yi -> loggamma(yi + one(T)), y[:, t])
-        end
-
-        if t == 1
-            @views dxt .= x[:, 1] .- x0
-            ldiv!(dxt, P0_U, dxt)
-            ll_t += cc.cP0 - T(0.5) * sum(abs2, dxt)
-        else
-            @views mul!(tmp, A, x[:, t - 1])
-            @views tmp .= x[:, t] .- tmp .- b
-            ldiv!(tmp, Q_U, tmp)
-            ll_t += cc.cQ - T(0.5) * sum(abs2, tmp)
-        end
-
-        ll[t] = ll_t
-    end
-
-    return ll
+    # y⋅z - λ - log(y!)  (loggamma(n+1) = log(n!) for real n≥0)
+    yt = view(y, :, t)
+    return dot(yt, z) - sum(λ) - sum(yi -> loggamma(yi + one(T)), yt)
 end
 
 """

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -127,6 +127,11 @@ struct SmoothWorkspace{T<:Real}
     Q_PD::Base.RefValue{PDMat{T,Matrix{T}}}      # (latent_dim × latent_dim)
     P0_PD::Base.RefValue{PDMat{T,Matrix{T}}}     # (latent_dim × latent_dim)
 
+    # Cached log-likelihood normalizers -0.5*(dim*log(2π) + logdet(Σ))
+    cP0::Base.RefValue{T}
+    cQ::Base.RefValue{T}
+    cR::Base.RefValue{T}
+
     # Solve Outputs
     tmp_RC::Matrix{T}    # obs_dim × latent_dim   (R^{-1} C)
     tmp_QA::Matrix{T}    # latent_dim × latent_dim (Q^{-1} A)
@@ -293,6 +298,9 @@ function SmoothWorkspace(
     R_PD = _pd_ref(PDMat(Matrix{T}(I, obs_dim, obs_dim)))
     Q_PD = _pd_ref(PDMat(Matrix{T}(I, latent_dim, latent_dim)))
     P0_PD = _pd_ref(PDMat(Matrix{T}(I, latent_dim, latent_dim)))
+    cP0 = Ref(zero(T))
+    cQ = Ref(zero(T))
+    cR = Ref(zero(T))
 
     tmp_RC = zeros(T, obs_dim, latent_dim)
     tmp_QA = zeros(T, latent_dim, latent_dim)
@@ -409,6 +417,9 @@ function SmoothWorkspace(
         R_PD,
         Q_PD,
         P0_PD,
+        cP0,
+        cQ,
+        cR,
         tmp_RC,
         tmp_QA,
         C_inv_R,
@@ -561,6 +572,13 @@ function compute_smooth_constants!(
     ldiv!(P0chol, ws.x_t)
     ws.x_t .*= -one(T)
 
+    # Log-likelihood normalizers (consumed by the likelihood kernels)
+    latent_dim = lds.latent_dim
+    obs_dim = lds.obs_dim
+    ws.cP0[] = -WT(0.5) * (WT(latent_dim) * log(WT(2π)) + logdet(ws.P0_PD[]))
+    ws.cQ[] = -WT(0.5) * (WT(latent_dim) * log(WT(2π)) + logdet(ws.Q_PD[]))
+    ws.cR[] = -WT(0.5) * (WT(obs_dim) * log(WT(2π)) + logdet(ws.R_PD[]))
+
     return nothing
 end
 
@@ -584,6 +602,9 @@ function _copy_smooth_constants!(
     dst.R_PD[] = src.R_PD[]
     dst.Q_PD[] = src.Q_PD[]
     dst.P0_PD[] = src.P0_PD[]
+    dst.cP0[] = src.cP0[]
+    dst.cQ[] = src.cQ[]
+    dst.cR[] = src.cR[]
     copyto!(dst.tmp_RC, src.tmp_RC)
     copyto!(dst.tmp_QA, src.tmp_QA)
     copyto!(dst.C_inv_R, src.C_inv_R)
@@ -636,6 +657,12 @@ function compute_smooth_constants!(
     copyto!(ws.x_t, ws.I_mat)
     ldiv!(P0_chol, ws.x_t)
     ws.x_t .*= -one(T)
+
+    # Log-likelihood normalizers. No R term for Poisson observations.
+    latent_dim = lds.latent_dim
+    ws.cP0[] = -WT(0.5) * (WT(latent_dim) * log(WT(2π)) + logdet(ws.P0_PD[]))
+    ws.cQ[] = -WT(0.5) * (WT(latent_dim) * log(WT(2π)) + logdet(ws.Q_PD[]))
+    ws.cR[] = zero(WT)
 
     return nothing
 end

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -9,12 +9,17 @@
 # =============================================================================
 
 #=
-Wrap a `PDMat` in a `Ref` whose element type matches the workspace field type
-`PDMat{T,Matrix{T}}`. Pinning the eltype here keeps construction working on both 2- and 3-parameter
-PDMats. Reading (`ref[]`) and rebinding (`ref[] = pd`) are unaffected either way. Not my favorite but it works.
-TODO: Consider lowerbounding PDMats to 0.11.40
+PDMats 0.11.40 added a third (Cholesky) type parameter to `PDMat`, which turns
+the two-parameter `PDMat{T,Matrix{T}}` into a non-concrete UnionAll. 
+TODO: Consider lowerbounding PDMats to 0.11.40 and inlining the 3-param alias.
 =#
-_pd_ref(pd::PDMat{T,Matrix{T}}) where {T} = Base.RefValue{PDMat{T,Matrix{T}}}(pd)
+if length(Base.unwrap_unionall(PDMat).parameters) == 3
+    const DensePDMat{T} = PDMat{T,Matrix{T},Cholesky{T,Matrix{T}}}
+else
+    const DensePDMat{T} = PDMat{T,Matrix{T}}
+end
+
+_pd_ref(pd::PDMat) = Base.RefValue{DensePDMat{eltype(pd)}}(pd)
 
 """
     FilterSmooth{T<:Real}
@@ -90,21 +95,21 @@ mutable struct SufficientStatistics{T<:Real}
     # weighted aggregator can flow non-integer counts through the M-step
     # without truncation.
     init_n::T
-    init_xx::Base.RefValue{PDMat{T,Matrix{T}}}
+    init_xx::Base.RefValue{DensePDMat{T}}
     init_xy::Matrix{T}
-    init_yy::Base.RefValue{PDMat{T,Matrix{T}}}
+    init_yy::Base.RefValue{DensePDMat{T}}
 
     # transitions model
     dyn_n::T
-    dyn_xx::Base.RefValue{PDMat{T,Matrix{T}}}
+    dyn_xx::Base.RefValue{DensePDMat{T}}
     dyn_xy::Matrix{T}
-    dyn_yy::Base.RefValue{PDMat{T,Matrix{T}}}
+    dyn_yy::Base.RefValue{DensePDMat{T}}
 
     # observation model
     obs_n::T
-    obs_xx::Base.RefValue{PDMat{T,Matrix{T}}}
+    obs_xx::Base.RefValue{DensePDMat{T}}
     obs_xy::Matrix{T}
-    obs_yy::Base.RefValue{PDMat{T,Matrix{T}}}
+    obs_yy::Base.RefValue{DensePDMat{T}}
 end
 
 """
@@ -123,9 +128,9 @@ struct SmoothWorkspace{T<:Real}
     # `compute_smooth_constants!`; downstream code consumes via
     # `ws.R_PD[].chol.U` (triangular factor) and `logdet(ws.R_PD[])`.
     # Mirrors `KalmanWorkspace`'s `Q_PD` / `P0_PD` / `R_PD` pattern.
-    R_PD::Base.RefValue{PDMat{T,Matrix{T}}}      # (obs_dim × obs_dim)
-    Q_PD::Base.RefValue{PDMat{T,Matrix{T}}}      # (latent_dim × latent_dim)
-    P0_PD::Base.RefValue{PDMat{T,Matrix{T}}}     # (latent_dim × latent_dim)
+    R_PD::Base.RefValue{DensePDMat{T}}      # (obs_dim × obs_dim)
+    Q_PD::Base.RefValue{DensePDMat{T}}      # (latent_dim × latent_dim)
+    P0_PD::Base.RefValue{DensePDMat{T}}     # (latent_dim × latent_dim)
 
     # Cached log-likelihood normalizers -0.5*(dim*log(2π) + logdet(Σ))
     cP0::Base.RefValue{T}
@@ -678,9 +683,9 @@ mutable struct LDSConstantCache{T<:Real}
     # PDMats for R, Q, P0. Rewrapped once per SLDS smoothing pass by
     # `compute_slds_constants!`; downstream consumers use `.chol.U` and
     # `logdet(...)`. Mirrors `SmoothWorkspace`'s `R_PD` / `Q_PD` / `P0_PD`.
-    R_PD::Base.RefValue{PDMat{T,Matrix{T}}}
-    Q_PD::Base.RefValue{PDMat{T,Matrix{T}}}
-    P0_PD::Base.RefValue{PDMat{T,Matrix{T}}}
+    R_PD::Base.RefValue{DensePDMat{T}}
+    Q_PD::Base.RefValue{DensePDMat{T}}
+    P0_PD::Base.RefValue{DensePDMat{T}}
 
     # LL constant terms
     cP0::T
@@ -971,8 +976,8 @@ struct KalmanWorkspace{T<:Real}
     # Pre-allocated scratch buffers for covariance_forward_backward! (no per-step allocs)
     cov_tmp1::Matrix{T}   # (D, D)
     cov_tmp2::Matrix{T}   # (D, D)
-    pd_tmp::Base.RefValue{PDMat{T,Matrix{T}}} #(D, D)
-    obs_pd_tmp::Base.RefValue{PDMat{T,Matrix{T}}} #(p, p)
+    pd_tmp::Base.RefValue{DensePDMat{T}} #(D, D)
+    obs_pd_tmp::Base.RefValue{DensePDMat{T}} #(p, p)
 
     # Per-trial D-vector scratch for _filter_mean_trial! (column n used by trial n)
     mean_tmp::Matrix{T}   # (D, ntrials)
@@ -982,9 +987,9 @@ struct KalmanWorkspace{T<:Real}
     p_smooth_tt1_shared::Array{T,3}  # (D, D, T)
 
     # Derived constants (refreshed each E-step; M-step mutates Q, R, P0)
-    Q_PD::Base.RefValue{PDMat{T,Matrix{T}}}
-    P0_PD::Base.RefValue{PDMat{T,Matrix{T}}}
-    R_PD::Base.RefValue{PDMat{T,Matrix{T}}}
+    Q_PD::Base.RefValue{DensePDMat{T}}
+    P0_PD::Base.RefValue{DensePDMat{T}}
+    R_PD::Base.RefValue{DensePDMat{T}}
 
     #  Priors — matrix-normal halves stored as `MNPrior`s (M₀ + Λ);
     #  inverse-Wishart halves are split into (μ, df) pairs to keep the
@@ -1002,7 +1007,7 @@ struct KalmanWorkspace{T<:Real}
 
     # Derived terms for Kalman gain and LL computation (refreshed each E-step)
     CiR::Matrix{T}                              # C' * R^{-1}   (D × p)
-    CiRC::Base.RefValue{PDMat{T,Matrix{T}}}     # C' * R^{-1} * C  (D × D), symmetric
+    CiRC::Base.RefValue{DensePDMat{T}}     # C' * R^{-1} * C  (D × D), symmetric
     shared_entropy::Base.RefValue{T}
 
     # Per-trial mean-pass buffers (thread-safe via trial-slice access)

--- a/src/stats/kalman.jl
+++ b/src/stats/kalman.jl
@@ -389,7 +389,7 @@ function backwards_cov!(
     smooth_cov = kws.smooth_cov::Vector{PDMat{T,Matrix{T}}}
     filt_cov = kws.filt_cov::Vector{PDMat{T,Matrix{T}}}
     pred_cov = kws.pred_cov::Vector{PDMat{T,Matrix{T}}}
-    Q_PD = kws.Q_PD::Base.RefValue{PDMat{T,Matrix{T}}}
+    Q_PD = kws.Q_PD::Base.RefValue{DensePDMat{T}}
     G = kws.G::Array{T,3}
     A = lds.state_model.A
 

--- a/test/LinearDynamicalSystems/GaussianLDS.jl
+++ b/test/LinearDynamicalSystems/GaussianLDS.jl
@@ -911,3 +911,48 @@ function test_td_weighted_aggregator_matches_unweighted_with_inputs(;
     end
     return nothing
 end
+
+function test_joint_loglikelihood_matches_mvnormal()
+    #=
+    Regression test for the U- vs U'-solve quadratic-form bug: with a
+    Cholesky Σ = U'U, only the transposed factor whitens (r'Σ⁻¹r = ‖U⁻ᵀr‖²);
+    solving with U itself computes r'(UU')⁻¹r. 
+    =#
+    rng = StableRNG(1234)
+    D_lat, p_obs, T_steps = 2, 3, 25
+
+    A_nd = [0.9 0.1; -0.05 0.85]
+    Q_nd = [0.5 0.2; 0.2 0.4]
+    b_nd = [0.1, -0.1]
+    x0_nd = [0.5, -0.5]
+    P0_nd = [1.0 0.3; 0.3 0.8]
+    C_nd = randn(rng, p_obs, D_lat)
+    R_nd = [0.6 0.1 0.0; 0.1 0.5 0.05; 0.0 0.05 0.7]
+    d_nd = [0.1, 0.2, -0.1]
+
+    sm = GaussianStateModel(; A=A_nd, Q=Q_nd, b=b_nd, x0=x0_nd, P0=P0_nd)
+    om = GaussianObservationModel(; C=C_nd, R=R_nd, d=d_nd)
+    lds = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=D_lat,
+        obs_dim=p_obs,
+        fit_bool=fill(true, 6),
+    )
+
+    x = randn(rng, D_lat, T_steps)
+    y = randn(rng, p_obs, T_steps)
+
+    ll = sum(StateSpaceDynamics.joint_loglikelihood(x, lds, y))
+
+    ref = logpdf(MvNormal(x0_nd, Symmetric(P0_nd)), x[:, 1])
+    for t in 2:T_steps
+        ref += logpdf(MvNormal(A_nd * x[:, t - 1] .+ b_nd, Symmetric(Q_nd)), x[:, t])
+    end
+    for t in 1:T_steps
+        ref += logpdf(MvNormal(C_nd * x[:, t] .+ d_nd, Symmetric(R_nd)), y[:, t])
+    end
+
+    @test ll ≈ ref rtol = 1e-10
+    return nothing
+end

--- a/test/LinearDynamicalSystems/PoissonLDS.jl
+++ b/test/LinearDynamicalSystems/PoissonLDS.jl
@@ -685,3 +685,47 @@ function test_poisson_low_rate_recovery()
     end
     return nothing
 end
+
+function test_joint_loglikelihood_matches_distributions()
+    
+    #=
+    Regression companion to `test_joint_loglikelihood_matches_mvnormal`
+    =#
+    rng = StableRNG(1234)
+    D_lat, p_obs, T_steps = 2, 3, 25
+
+    A_nd = [0.9 0.1; -0.05 0.85]
+    Q_nd = [0.5 0.2; 0.2 0.4]
+    b_nd = [0.1, -0.1]
+    x0_nd = [0.5, -0.5]
+    P0_nd = [1.0 0.3; 0.3 0.8]
+    C_nd = 0.5 .* randn(rng, p_obs, D_lat)
+    d_nd = [0.1, 0.2, -0.1]
+
+    sm = GaussianStateModel(; A=A_nd, Q=Q_nd, b=b_nd, x0=x0_nd, P0=P0_nd)
+    om = PoissonObservationModel(; C=C_nd, d=d_nd)
+    plds = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=D_lat,
+        obs_dim=p_obs,
+        fit_bool=fill(true, 6),
+    )
+
+    x = randn(rng, D_lat, T_steps)
+    λ = exp.(C_nd * x .+ d_nd)
+    y = Float64.(rand.(Ref(rng), Poisson.(λ)))
+
+    ll = sum(StateSpaceDynamics.joint_loglikelihood(x, plds, y))
+
+    ref = logpdf(MvNormal(x0_nd, Symmetric(P0_nd)), x[:, 1])
+    for t in 2:T_steps
+        ref += logpdf(MvNormal(A_nd * x[:, t - 1] .+ b_nd, Symmetric(Q_nd)), x[:, t])
+    end
+    for t in 1:T_steps, i in 1:p_obs
+        ref += logpdf(Poisson(λ[i, t]), y[i, t])
+    end
+
+    @test ll ≈ ref rtol = 1e-10
+    return nothing
+end

--- a/test/LinearDynamicalSystems/PoissonLDS.jl
+++ b/test/LinearDynamicalSystems/PoissonLDS.jl
@@ -729,3 +729,26 @@ function test_joint_loglikelihood_matches_distributions()
     @test ll ≈ ref rtol = 1e-10
     return nothing
 end
+
+function test_newton_objective_is_joint_loglikelihood()
+    #=
+    The Newton line-search objective is `sum(joint_loglikelihood!(ws, x,
+    plds, y, lognorm_t))` with `-Σ log(y!)` normalizer. It must agree per-
+    timestep and in total with the allocating `joint_loglikelihood(x, plds, y)`, 
+    both with the default and the explicitly hoisted normalizer.
+    =#
+    plds, xs, ys = toy_PoissonLDS()
+    x, y = xs[1], ys[1]
+
+    ws = StateSpaceDynamics.SmoothWorkspace(
+        Float64, plds.latent_dim, plds.obs_dim, size(y, 2)
+    )
+    StateSpaceDynamics.compute_smooth_constants!(ws, plds)
+    ref = StateSpaceDynamics.joint_loglikelihood(x, plds, y)
+
+    @test StateSpaceDynamics.joint_loglikelihood!(ws, x, plds, y) ≈ ref rtol = 1e-12
+    lognorm_t = StateSpaceDynamics._poisson_lognorm_t(y)
+    @test StateSpaceDynamics.joint_loglikelihood!(ws, x, plds, y, lognorm_t) ≈ ref rtol =
+        1e-12
+    return nothing
+end

--- a/test/LinearDynamicalSystems/PoissonLDS.jl
+++ b/test/LinearDynamicalSystems/PoissonLDS.jl
@@ -687,7 +687,7 @@ function test_poisson_low_rate_recovery()
 end
 
 function test_joint_loglikelihood_matches_distributions()
-    
+
     #=
     Regression companion to `test_joint_loglikelihood_matches_mvnormal`
     =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,6 +142,10 @@ using SSDTest
                 test_smooth()
             end
 
+            @testset "Log-likelihood" begin
+                test_joint_loglikelihood_matches_mvnormal()
+            end
+
             @testset "EM Algorithm" begin
                 test_estep()
                 test_initial_observation_parameter_updates()
@@ -198,6 +202,10 @@ using SSDTest
                 test_Gradient()
                 test_Hessian()
                 test_smooth()
+            end
+
+            @testset "Log-likelihood" begin
+                test_joint_loglikelihood_matches_distributions()
             end
 
             @testset "Priors - Poisson LDS" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,7 @@ using SSDTest
 
             @testset "Log-likelihood" begin
                 test_joint_loglikelihood_matches_distributions()
+                test_newton_objective_is_joint_loglikelihood()
             end
 
             @testset "Priors - Poisson LDS" begin


### PR DESCRIPTION
PR to partially address #131. 

Split the `joint_loglikelihood` into a `stateloglikelihood!` and an `obsloglikelihood!` (not deadset on names). The rationale for this is 1.) we don't re-implement the same calculation a bunch of places (prior to this we had the same logic in three places and one of them was wrong---SLDS 2.) to avoid differences between models e.g., my previous comment. 3.) to eventually make it s.t. we can offer a fallback `joint_loglikelihood` for generic models, which I'd like to make it easier to do

- Adds tests to check against Distributions
- Fixes the SLDS bug
- Adds stateloglikelihood!` and `obsloglikelihood!` methods