### PR TITLE
Dedupe LDS gradients into shared kernels

### DIFF
--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -5,6 +5,9 @@ Continuous (Linear Gaussian) latents
                             observationloglikelihood!(cc, b1, b2, x, y, t, lds[, uy])
                             joint_loglikelihood!(ll, ws, cc, lds, x, y)
 
+    Gradient kernels:       observationgradient!(out, cc, buf, x, y, t, lds[, uy])
+                            Gradient!(grad, ws, lds, y, x[, ux, uy])
+
     E-Step: Q_state!(sws, lds, suf)
 
     M-Step: update_initial_state_mean!(lds, suf)
@@ -48,6 +51,30 @@ end
 _whiten!(chol::Cholesky, v::AbstractVector) = ldiv!(chol.U', v)
 
 """
+    _transition_residual!(out, x, t, lds[, ux])
+
+Write the dynamics residual `x_t - A x_{t-1} - b - B u_{t-1}` into `out`
+(length `latent_dim`). Shared by the log-likelihood and gradient kernels so
+the affine-dynamics mean is defined in exactly one place. Pass `ux` (state
+inputs, `t`-indexed like `x`) to include the `B u_{t-1}` term; `nothing`
+(default) skips it. Requires `t ≥ 2`.
+"""
+@inline function _transition_residual!(
+    out::AbstractVector{T},
+    x::AbstractMatrix{T},
+    t::Int,
+    lds::LinearDynamicalSystem,
+    ux::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real}
+    @views mul!(out, lds.state_model.A, x[:, t - 1])
+    if ux !== nothing
+        @views mul!(out, lds.state_model.B, ux[:, t - 1], one(T), one(T))
+    end
+    @views out .= x[:, t] .- out .- lds.state_model.b
+    return out
+end
+
+"""
     stateloglikelihood!(cc, dxt, tmp, x, t, lds[, ux])
 
 State-model (prior/transition) contribution to the complete-data log-likelihood
@@ -74,20 +101,12 @@ function stateloglikelihood!(
     lds::LinearDynamicalSystem{T0,S,O},
     ux::Union{Nothing,AbstractMatrix}=nothing,
 ) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:AbstractObservationModel{T0}}
-    A = lds.state_model.A
-    b = lds.state_model.b
-    x0 = lds.state_model.x0
-
     if t == 1
-        @views dxt .= x[:, 1] .- x0
+        @views dxt .= x[:, 1] .- lds.state_model.x0
         _whiten!(cc.P0_PD[].chol, dxt)
         return _cP0(cc) - T(0.5) * sum(abs2, dxt)
     else
-        @views mul!(tmp, A, x[:, t - 1])
-        if ux !== nothing
-            @views mul!(tmp, lds.state_model.B, ux[:, t - 1], one(T), one(T))
-        end
-        @views tmp .= x[:, t] .- tmp .- b
+        _transition_residual!(tmp, x, t, lds, ux)
         _whiten!(cc.Q_PD[].chol, tmp)
         return _cQ(cc) - T(0.5) * sum(abs2, tmp)
     end
@@ -151,6 +170,108 @@ function joint_loglikelihood!(
     end
 
     return ll
+end
+
+"""
+    observationgradient!(out, cc, buf, x, y, t, lds[, uy])
+
+Emission-model contribution `∂ log p(y_t | x_t) / ∂x_t` written into `out`
+(length `latent_dim`). Dispatches on the observation model type `O` (via
+`lds::LinearDynamicalSystem{T,S,O}`) — the gradient companion to
+`observationloglikelihood!`: a custom observation model plugs into `Gradient!`
+(and the SLDS weighted `Gradient!`) by adding a method here, without touching
+the shared state-side gradient math.
+
+Uniform interface:
+- `cc`: an [`LDSLikelihoodCache`](@ref) with Cholesky-derived terms (Gaussian
+  uses the cached `C_inv_R = C'R⁻¹`; models without a covariance ignore it).
+- `buf`: one `obs_dim` scratch vector (overwritten).
+- `uy` (optional): observation inputs, `t`-indexed like `y`; `nothing` or a
+  zero-row matrix skips the `D u_t` term.
+
+See the `GaussianObservationModel` / `PoissonObservationModel` methods in
+`fit_LDS.jl` / `fit_PLDS.jl` for the pattern to follow.
+"""
+function observationgradient! end
+
+"""
+    Gradient!(grad, ws, lds, y, x[, ux, uy])
+    Gradient!(ws, lds, y, x[, ux, uy])
+
+Gradient of the complete-data log-likelihood with respect to the latent path
+`x`, written into `grad` (`latent_dim × tsteps`; the convenience form uses the
+active view of `ws.grad_buf` and returns it). Generic over the observation
+model — the emission term comes from `observationgradient!`, while the state
+side (prior / incoming / outgoing transition factors) is shared:
+
+- `grad[:, t] = obs_grad(t) + A'Q⁻¹ r_{t+1} - Q⁻¹ r_t`   (middle steps)
+- at `t = 1` the `-Q⁻¹ r_t` term is replaced by `-P0⁻¹(x_1 - x_0)`
+- at `t = T` the `A'Q⁻¹ r_{t+1}` term is absent
+
+with `r_t = x_t - A x_{t-1} - b - B u_{t-1}` (see `_transition_residual!`).
+Uses the Cholesky-derived templates cached by `compute_smooth_constants!`;
+requires `tsteps ≥ 2` (matching the Newton smoother's contract).
+"""
+function Gradient!(
+    grad::AbstractMatrix{T},
+    ws::SmoothWorkspace{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    y::AbstractMatrix{T},
+    x::AbstractMatrix{T},
+    ux::Union{Nothing,AbstractMatrix}=nothing,
+    uy::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    tsteps = size(x, 2)
+
+    A_inv_Q = ws.A_inv_Q          # A'Q⁻¹
+    neg_P0_inv = ws.x_t           # -P0⁻¹
+    neg_Q_inv = ws.xt_given_xt_1  # -Q⁻¹
+
+    dxt = ws.dxt
+    dxt_next = ws.dxt_next
+    obs_buf = ws.dyt
+    tmp1 = ws.tmp1
+    tmp2 = ws.tmp2
+    tmp3 = ws.tmp3
+
+    # First time step: emission + prior + outgoing factor at t = 2
+    observationgradient!(tmp1, ws, obs_buf, x, y, 1, lds, uy)
+    @views dxt .= x[:, 1] .- lds.state_model.x0
+    mul!(tmp3, neg_P0_inv, dxt)
+    _transition_residual!(dxt_next, x, 2, lds, ux)
+    mul!(tmp2, A_inv_Q, dxt_next)
+    @views grad[:, 1] .= tmp1 .+ tmp2 .+ tmp3
+
+    # Middle steps: emission + incoming factor at t + outgoing factor at t + 1
+    @views for t in 2:(tsteps - 1)
+        observationgradient!(tmp1, ws, obs_buf, x, y, t, lds, uy)
+        _transition_residual!(dxt, x, t, lds, ux)
+        mul!(tmp3, neg_Q_inv, dxt)
+        _transition_residual!(dxt_next, x, t + 1, lds, ux)
+        mul!(tmp2, A_inv_Q, dxt_next)
+        grad[:, t] .= tmp1 .+ tmp3 .+ tmp2
+    end
+
+    # Last time step: emission + incoming factor at t = T
+    observationgradient!(tmp1, ws, obs_buf, x, y, tsteps, lds, uy)
+    _transition_residual!(dxt, x, tsteps, lds, ux)
+    mul!(tmp3, neg_Q_inv, dxt)
+    @views grad[:, tsteps] .= tmp1 .+ tmp3
+
+    return grad
+end
+
+# Convenience form writing into the workspace's gradient buffer.
+function Gradient!(
+    ws::SmoothWorkspace{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    y::AbstractMatrix{T},
+    x::AbstractMatrix{T},
+    ux::Union{Nothing,AbstractMatrix}=nothing,
+    uy::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    grad = view(ws.grad_buf, :, 1:size(x, 2))
+    return Gradient!(grad, ws, lds, y, x, ux, uy)
 end
 
 """

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -54,10 +54,8 @@ _whiten!(chol::Cholesky, v::AbstractVector) = ldiv!(chol.U', v)
     _transition_residual!(out, x, t, lds[, ux])
 
 Write the dynamics residual `x_t - A x_{t-1} - b - B u_{t-1}` into `out`
-(length `latent_dim`). Shared by the log-likelihood and gradient kernels so
-the affine-dynamics mean is defined in exactly one place. Pass `ux` (state
-inputs, `t`-indexed like `x`) to include the `B u_{t-1}` term; `nothing`
-(default) skips it. Requires `t ≥ 2`.
+(length `latent_dim`). Pass `ux` (state inputs, `t`-indexed like `x`) to
+include the `B u_{t-1}` term; `nothing` (default) skips it. Requires `t ≥ 2`.
 """
 @inline function _transition_residual!(
     out::AbstractVector{T},
@@ -82,10 +80,6 @@ at timestep `t`:
 
 - `t == 1`: `cP0 - 0.5‖P0^{-1/2}(x_1 - x_0)‖²`
 - `t ≥ 2`:  `cQ - 0.5‖Q^{-1/2}(x_t - A x_{t-1} - b - B u_{t-1})‖²`
-
-This term is identical for every observation model (Gaussian, Poisson, ...);
-only the emission term differs, so `joint_loglikelihood!` implementations share
-this helper instead of duplicating the prior/transition math.
 
 `cc` is an [`LDSLikelihoodCache`](@ref) holding the Cholesky factors and
 normalizers; `dxt` and `tmp` are `latent_dim` scratch vectors (overwritten).
@@ -117,20 +111,15 @@ end
 
 Emission-model contribution `log p(y_t | x_t)` to the complete-data
 log-likelihood at timestep `t`. Dispatches on the observation model type `O`
-(via `lds::LinearDynamicalSystem{T,S,O}`) — a custom observation model plugs
-into `joint_loglikelihood!` by adding a method here, without having to
-reimplement (or duplicate) the shared `stateloglikelihood!` term.
+(via `lds::LinearDynamicalSystem{T,S,O}`); a custom observation model plugs
+into `joint_loglikelihood!` by adding a method here.
 
-Uniform interface for all observation models:
 - `cc`: an [`LDSLikelihoodCache`](@ref) with Cholesky factors / normalizers
   (unused by models whose emission term needs no covariance, e.g. Poisson).
 - `buf1`, `buf2`: two `obs_dim` scratch vectors (overwritten); each model uses
   what it needs (Gaussian: residual; Poisson: linear predictor + rate).
 - `uy` (optional): observation inputs, `t`-indexed like `y`; `nothing` or a
   zero-row matrix skips the `D u_t` term.
-
-See the `GaussianObservationModel` / `PoissonObservationModel` methods in
-`fit_LDS.jl` / `fit_PLDS.jl` for the pattern to follow.
 """
 function observationloglikelihood! end
 
@@ -140,9 +129,7 @@ function observationloglikelihood! end
 Per-timestep complete-data log-likelihood for a single SLDS component:
 `ll[t] = log p(y_t | x_t) + log p(x_t | x_{t-1})` (or `+ log p(x_1)` at
 `t == 1`). Generic over the observation model — the emission term comes from
-`observationloglikelihood!`, so supporting a new observation model here only
-requires a new `observationloglikelihood!` method, not a new
-`joint_loglikelihood!` method.
+`observationloglikelihood!`.
 
 Notes:
 - Normalization terms (logdet + log(2π)) are included. These are constant w.r.t.
@@ -177,20 +164,14 @@ end
 
 Emission-model contribution `∂ log p(y_t | x_t) / ∂x_t` written into `out`
 (length `latent_dim`). Dispatches on the observation model type `O` (via
-`lds::LinearDynamicalSystem{T,S,O}`) — the gradient companion to
-`observationloglikelihood!`: a custom observation model plugs into `Gradient!`
-(and the SLDS weighted `Gradient!`) by adding a method here, without touching
-the shared state-side gradient math.
+`lds::LinearDynamicalSystem{T,S,O}`); a custom observation model plugs into
+`Gradient!` (and the SLDS weighted `Gradient!`) by adding a method here.
 
-Uniform interface:
 - `cc`: an [`LDSLikelihoodCache`](@ref) with Cholesky-derived terms (Gaussian
   uses the cached `C_inv_R = C'R⁻¹`; models without a covariance ignore it).
 - `buf`: one `obs_dim` scratch vector (overwritten).
 - `uy` (optional): observation inputs, `t`-indexed like `y`; `nothing` or a
   zero-row matrix skips the `D u_t` term.
-
-See the `GaussianObservationModel` / `PoissonObservationModel` methods in
-`fit_LDS.jl` / `fit_PLDS.jl` for the pattern to follow.
 """
 function observationgradient! end
 
@@ -208,9 +189,8 @@ side (prior / incoming / outgoing transition factors) is shared:
 - at `t = 1` the `-Q⁻¹ r_t` term is replaced by `-P0⁻¹(x_1 - x_0)`
 - at `t = T` the `A'Q⁻¹ r_{t+1}` term is absent
 
-with `r_t = x_t - A x_{t-1} - b - B u_{t-1}` (see `_transition_residual!`).
-Uses the Cholesky-derived templates cached by `compute_smooth_constants!`;
-requires `tsteps ≥ 2` (matching the Newton smoother's contract).
+with `r_t = x_t - A x_{t-1} - b - B u_{t-1}`. Uses the Cholesky-derived
+templates cached by `compute_smooth_constants!`; requires `tsteps ≥ 2`.
 """
 function Gradient!(
     grad::AbstractMatrix{T},
@@ -261,7 +241,6 @@ function Gradient!(
     return grad
 end
 
-# Convenience form writing into the workspace's gradient buffer.
 function Gradient!(
     ws::SmoothWorkspace{T},
     lds::LinearDynamicalSystem{T,S,O},

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -24,8 +24,7 @@ Linear Dynamical System (LDS) implementation with Gaussian state and observation
 This module defines functions specific to the Gaussian observation model: log-likelihoods,
 gradients, Hessians, smoothing, the ELBO/sufficient-statistics machinery, and the EM
 fit driver. Model-agnostic helpers (parameter extraction, `initialize_FilterSmooth`)
-live in `common.jl`; sampling lives in `simulate.jl`. The code is optimized for
-performance, with careful attention to memory allocation and multi-threading.
+live in `common.jl`; sampling lives in `simulate.jl`.
 """
 
 """
@@ -81,9 +80,7 @@ end
     observationloglikelihood!(cc, dyt, _, x, y, t, lds[, uy])
 
 Gaussian emission term: `cR - 0.5*||R^{-1/2}(y_t - Cx_t - d - D uy_t)||^2`.
-Method of the generic `observationloglikelihood!` dispatch point (see
-`continuous_latents.jl`); `dyt` is the `obs_dim` residual scratch, the second
-buffer is unused.
+`dyt` is the `obs_dim` residual scratch; the second buffer is unused.
 """
 function observationloglikelihood!(
     cc::LDSLikelihoodCache{T},
@@ -111,9 +108,7 @@ end
     observationgradient!(out, cc, buf, x, y, t, lds[, uy])
 
 Gaussian emission gradient: `out = C'R⁻¹ (y_t - Cx_t - d - D uy_t)`, using the
-cached `C_inv_R = C'R⁻¹` from `cc`. Method of the generic
-`observationgradient!` dispatch point (see `continuous_latents.jl`); `buf` is
-the `obs_dim` residual scratch.
+cached `C_inv_R = C'R⁻¹` from `cc`.
 """
 function observationgradient!(
     out::AbstractVector{T},

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -108,111 +108,29 @@ function observationloglikelihood!(
 end
 
 """
-    Gradient!(ws, lds, y, x)
+    observationgradient!(out, cc, buf, x, y, t, lds[, uy])
 
-In-place version of `Gradient` that uses pre-computed Cholesky-derived terms from
-`ws::SmoothWorkspace` and writes the result into `ws.grad_buf`.
-Returns `ws.grad_buf`.
+Gaussian emission gradient: `out = C'R⁻¹ (y_t - Cx_t - d - D uy_t)`, using the
+cached `C_inv_R = C'R⁻¹` from `cc`. Method of the generic
+`observationgradient!` dispatch point (see `continuous_latents.jl`); `buf` is
+the `obs_dim` residual scratch.
 """
-function Gradient!(
-    ws::SmoothWorkspace{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    y::AbstractMatrix{T},
+function observationgradient!(
+    out::AbstractVector{T},
+    cc::LDSLikelihoodCache{T},
+    buf::AbstractVector{T},
     x::AbstractMatrix{T},
-    ux::AbstractMatrix{T},
-    uy::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    latent_dim, tsteps = size(x)
-    A = lds.state_model.A
-    b = lds.state_model.b
-    B = lds.state_model.B
-    x0 = lds.state_model.x0
-    C = lds.obs_model.C
-    d_obs = lds.obs_model.d
-    D_obs = lds.obs_model.D
-
-    C_inv_R = ws.C_inv_R
-    A_inv_Q = ws.A_inv_Q
-    # ws.x_t = -P0^{-1}, ws.xt_given_xt_1 = -Q^{-1}
-    neg_P0_inv = ws.x_t         # = -P0^{-1}
-    neg_Q_inv = ws.xt_given_xt_1  # = -Q^{-1}
-
-    grad = ws.grad_buf
-    dxt = ws.dxt
-    dxt_next = ws.dxt_next
-    dyt = ws.dyt
-    tmp1 = ws.tmp1
-    tmp2 = ws.tmp2
-    tmp3 = ws.tmp3
-
-    # Helper macros (inlined): residual `x_t - A x_{t-1} - b - B u_{t-1}` and
-    # `y_t - C x_t - d - D uy_t`. The `B*ux` / `D*uy` updates are no-ops when
-    # `ux` / `uy` have zero rows.
-
-    # First time step
-    @views dxt .= x[:, 1] .- x0
-    @views mul!(dxt_next, A, x[:, 1])
-    @views mul!(dxt_next, B, ux[:, 1], one(T), one(T))
-    @views dxt_next .= x[:, 2] .- dxt_next .- b
-    @views mul!(dyt, C, x[:, 1])
-    @views mul!(dyt, D_obs, uy[:, 1], one(T), one(T))
-    @views dyt .= y[:, 1] .- dyt .- d_obs
-
-    mul!(tmp1, C_inv_R, dyt)
-    mul!(tmp2, A_inv_Q, dxt_next)
-    mul!(tmp3, neg_P0_inv, dxt)
-    grad[:, 1] .= tmp1 .+ tmp2 .+ tmp3
-
-    # Middle steps
-    @views for t in 2:(tsteps - 1)
-        mul!(dxt, A, x[:, t - 1])
-        mul!(dxt, B, ux[:, t - 1], one(T), one(T))
-        dxt .= x[:, t] .- dxt .- b
-
-        mul!(dxt_next, A, x[:, t])
-        mul!(dxt_next, B, ux[:, t], one(T), one(T))
-        dxt_next .= x[:, t + 1] .- dxt_next .- b
-
-        mul!(dyt, C, x[:, t])
-        mul!(dyt, D_obs, uy[:, t], one(T), one(T))
-        dyt .= y[:, t] .- dyt .- d_obs
-
-        mul!(tmp1, C_inv_R, dyt)
-        mul!(tmp2, A_inv_Q, dxt_next)
-        mul!(tmp3, neg_Q_inv, dxt)
-
-        grad[:, t] .= tmp1 .+ tmp3 .+ tmp2
+    y::AbstractMatrix{T0},
+    t::Int,
+    lds::LinearDynamicalSystem{T0,S,O},
+    uy::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:GaussianObservationModel{T0}}
+    @views mul!(buf, lds.obs_model.C, x[:, t])
+    if uy !== nothing
+        @views mul!(buf, lds.obs_model.D, uy[:, t], one(T), one(T))
     end
-
-    # Last time step
-    @views begin
-        mul!(dxt, A, x[:, tsteps - 1])
-        mul!(dxt, B, ux[:, tsteps - 1], one(T), one(T))
-        dxt .= x[:, tsteps] .- dxt .- b
-        mul!(dyt, C, x[:, tsteps])
-        mul!(dyt, D_obs, uy[:, tsteps], one(T), one(T))
-        dyt .= y[:, tsteps] .- dyt .- d_obs
-
-        mul!(tmp1, C_inv_R, dyt)
-        mul!(tmp3, neg_Q_inv, dxt)
-
-        grad[:, tsteps] .= tmp1 .+ tmp3
-    end
-
-    return grad
-end
-
-# Backward-compatible no-input overload.
-function Gradient!(
-    ws::SmoothWorkspace{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    y::AbstractMatrix{T},
-    x::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    tsteps = size(x, 2)
-    ux = zeros(T, 0, tsteps)
-    uy = zeros(T, 0, tsteps)
-    return Gradient!(ws, lds, y, x, ux, uy)
+    @views buf .= y[:, t] .- buf .- lds.obs_model.d
+    return mul!(out, cc.C_inv_R, buf)
 end
 
 """

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -36,9 +36,8 @@ end
 
 Per-timestep complete-data log-likelihood of a Poisson LDS, written into
 `ws.ll_vec` (an active-length view is returned — the workspace may be
-pool-oversized). Mirrors the Gaussian `joint_loglikelihood!`; requires
-`compute_smooth_constants!(ws, plds)` to have been called. The rate follows
-the canonical Poisson GLM `λ_t = exp(C x_t + d)`.
+pool-oversized). Requires `compute_smooth_constants!(ws, plds)` to have been
+called. The rate follows the canonical Poisson GLM `λ_t = exp(C x_t + d)`.
 
 - `ll[1]` includes: log p(x₁) + log p(y₁ | x₁)
 - `ll[t]` for t≥2 includes: log p(x_t | x_{t-1}) + log p(y_t | x_t)
@@ -81,8 +80,7 @@ end
     joint_loglikelihood(x, plds, y)
 
 Per-timestep complete-data log-likelihood of a Poisson LDS for a single trial
-(allocating convenience wrapper around `joint_loglikelihood!`; mirrors the
-Gaussian `joint_loglikelihood`).
+(allocating convenience wrapper around `joint_loglikelihood!`).
 
 # Arguments
 - `x::AbstractMatrix`: latent states, (latent_dim × tsteps)
@@ -106,11 +104,10 @@ end
     observationloglikelihood!(cc, z, λ, x, y, t, lds[, uy])
 
 Poisson emission term: with rate `λ = exp(Cx_t + d)`,
-`log p(y_t|x_t) = y⋅log(λ) - sum(λ) - sum(log(y!))`. Method of the generic
-`observationloglikelihood!` dispatch point (see `continuous_latents.jl`); `z` and `λ`
-are `obs_dim` scratch vectors for the linear predictor and the rate. The cache
-and `uy` arguments are unused (no covariance term; Poisson observation inputs
-are not supported).
+`log p(y_t|x_t) = y⋅log(λ) - sum(λ) - sum(log(y!))`. `z` and `λ` are `obs_dim`
+scratch vectors for the linear predictor and the rate. The cache and `uy`
+arguments are unused (no covariance term; Poisson observation inputs are not
+supported).
 """
 function observationloglikelihood!(
     ::LDSLikelihoodCache{T},
@@ -184,10 +181,8 @@ end
     observationgradient!(out, cc, buf, x, y, t, lds[, uy])
 
 Poisson emission gradient: `out = C'(y_t - λ_t)` with `λ_t = exp(Cx_t + d)`.
-Method of the generic `observationgradient!` dispatch point (see
-`continuous_latents.jl`); `buf` is the `obs_dim` scratch for `y - λ`. The cache
-and `uy` arguments are unused (no covariance term; Poisson observation inputs
-are not supported).
+The cache and `uy` arguments are unused (no covariance term; Poisson
+observation inputs are not supported).
 """
 function observationgradient!(
     out::AbstractVector{T},

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -181,22 +181,29 @@ function loglikelihood(
 end
 
 """
-    Gradient!(ws, lds, y, x)
+    observationgradient!(out, cc, buf, x, y, t, lds[, uy])
 
-In-place gradient of the Poisson LDS complete-data log-likelihood for a single
-trial. Mirrors the Gaussian `Gradient!`: assumes `compute_smooth_constants!(ws, lds)`
-has already populated `ws`, writes into `ws.grad_buf`, and returns the active view.
+Poisson emission gradient: `out = C'(y_t - λ_t)` with `λ_t = exp(Cx_t + d)`.
+Method of the generic `observationgradient!` dispatch point (see
+`continuous_latents.jl`); `buf` is the `obs_dim` scratch for `y - λ`. The cache
+and `uy` arguments are unused (no covariance term; Poisson observation inputs
+are not supported).
 """
-function Gradient!(
-    ws::SmoothWorkspace{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    y::AbstractMatrix{T},
+function observationgradient!(
+    out::AbstractVector{T},
+    ::LDSLikelihoodCache{T},
+    buf::AbstractVector{T},
     x::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    tsteps = size(y, 2)
-    grad = view(ws.grad_buf, :, 1:tsteps)
-    _compute_gradient_poisson!(grad, ws, lds, y, x)
-    return grad
+    y::AbstractMatrix{T0},
+    t::Int,
+    lds::LinearDynamicalSystem{T0,S,O},
+    ::Union{Nothing,AbstractMatrix}=nothing,
+) where {T<:Real,T0<:Real,S<:GaussianStateModel{T0},O<:PoissonObservationModel{T0}}
+    C = lds.obs_model.C
+    d = lds.obs_model.d
+    @views mul!(buf, C, x[:, t])
+    @views buf .= y[:, t] .- exp.(buf .+ d)
+    return mul!(out, C', buf)
 end
 
 """
@@ -606,102 +613,6 @@ function _fill_hessian_blocks_poisson!(
 end
 
 """
-    _compute_gradient_poisson!(grad, ws, lds, y, x)
-
-Compute the gradient of the log-likelihood for Poisson LDS.
-Fills `grad` (latent_dim × tsteps) matrix with gradient values.
-"""
-function _compute_gradient_poisson!(
-    grad::AbstractMatrix{T},
-    ws::SmoothWorkspace{T},
-    lds::LinearDynamicalSystem{T,S,O},
-    y::AbstractMatrix{T},
-    x::AbstractMatrix{T},
-) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    A = lds.state_model.A
-    b = lds.state_model.b
-    C = lds.obs_model.C
-    d = lds.obs_model.d
-    x0 = lds.state_model.x0
-
-    tsteps = size(y, 2)
-    latent_dim, obs_dim = lds.latent_dim, lds.obs_dim
-
-    # Cholesky factors from cached PDMats (upper triangular factor)
-    Q_chol_U = ws.Q_PD[].chol.U
-    P0_chol_U = ws.P0_PD[].chol.U
-
-    # Reuse workspace temp vectors
-    Cx_t = ws.dyt           # obs_dim
-    exp_term = ws.temp_dy   # obs_dim
-    state_diff = ws.dxt     # latent_dim
-    temp_grad = ws.tmp1     # latent_dim
-    common_term = ws.tmp2   # latent_dim
-
-    @views for t in 1:tsteps
-        # Observation term: C' * (y - exp(C*x + d))
-        mul!(Cx_t, C, x[:, t])
-        @. exp_term = exp(Cx_t + d)
-        exp_term .= y[:, t] .- exp_term
-        mul!(common_term, C', exp_term)
-
-        if t == 1
-            # First timestep: common_term + A' * Q⁻¹ * (x₂ - A*x₁ - b) - P0⁻¹ * (x₁ - x0)
-            mul!(state_diff, A, x[:, t])
-            state_diff .= x[:, 2] .- state_diff .- b
-
-            # Q⁻¹ * state_diff via Cholesky: solve Q_chol_U' * Q_chol_U * z = state_diff
-            copyto!(temp_grad, state_diff)
-            ldiv!(Q_chol_U', temp_grad)
-            ldiv!(Q_chol_U, temp_grad)
-
-            mul!(grad[:, t], A', temp_grad)
-            grad[:, t] .+= common_term
-
-            # Subtract P0⁻¹ * (x₁ - x0)
-            state_diff .= x[:, t] .- x0
-            copyto!(temp_grad, state_diff)
-            ldiv!(P0_chol_U', temp_grad)
-            ldiv!(P0_chol_U, temp_grad)
-            grad[:, t] .-= temp_grad
-
-        elseif t == tsteps
-            # Last timestep: common_term - Q⁻¹ * (xₜ - A*xₜ₋₁ - b)
-            mul!(state_diff, A, x[:, t - 1])
-            state_diff .= x[:, t] .- state_diff .- b
-
-            copyto!(temp_grad, state_diff)
-            ldiv!(Q_chol_U', temp_grad)
-            ldiv!(Q_chol_U, temp_grad)
-
-            grad[:, t] .= common_term .- temp_grad
-        else
-            # Middle timesteps
-            # common_term + A' * Q⁻¹ * (xₜ₊₁ - A*xₜ - b) - Q⁻¹ * (xₜ - A*xₜ₋₁ - b)
-
-            # Forward term: A' * Q⁻¹ * (xₜ₊₁ - A*xₜ - b)
-            mul!(state_diff, A, x[:, t])
-            state_diff .= x[:, t + 1] .- state_diff .- b
-            copyto!(temp_grad, state_diff)
-            ldiv!(Q_chol_U', temp_grad)
-            ldiv!(Q_chol_U, temp_grad)
-            mul!(grad[:, t], A', temp_grad)
-            grad[:, t] .+= common_term
-
-            # Backward term: -Q⁻¹ * (xₜ - A*xₜ₋₁ - b)
-            mul!(state_diff, A, x[:, t - 1])
-            state_diff .= x[:, t] .- state_diff .- b
-            copyto!(temp_grad, state_diff)
-            ldiv!(Q_chol_U', temp_grad)
-            ldiv!(Q_chol_U, temp_grad)
-            grad[:, t] .-= temp_grad
-        end
-    end
-
-    return grad
-end
-
-"""
     smooth!(lds, fs, y, sws; max_iter=20, tol=1e-6)
 
 Poisson LDS smoothing using iterative Newton with block tridiagonal solve.
@@ -753,7 +664,7 @@ function smooth!(
     ϕ!() = sum(joint_loglikelihood!(sws, x, lds, y, lognorm_t))
 
     compute_grad! = (gcur, xcur) -> begin
-        _compute_gradient_poisson!(gcur, sws, lds, y, xcur)
+        Gradient!(gcur, sws, lds, y, xcur)
         return nothing
     end
 

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -314,179 +314,55 @@ function Gradient!(
 
     dxt = ws.dxt
     dxt_next = ws.dxt_next
-    dyt = ws.dyt
+    obs_buf = ws.z
     tmp1 = ws.tmp1
     tmp2 = ws.tmp2
     tmp3 = ws.tmp3
-
-    z = ws.z
-    λ = ws.λ
 
     @views for k in 1:K
         lds_k = slds.LDSs[k]
         cc = ws.consts[k]
 
-        A = lds_k.state_model.A
-        b = lds_k.state_model.b
         x0 = lds_k.state_model.x0
 
-        A_inv_Q = cc.A_inv_Q        # A'Q^{-1}
+        A_inv_Q = cc.A_inv_Q          # A'Q^{-1}
         neg_Q_inv = cc.xt_given_xt_1  # -Q^{-1}
-        neg_P0_inv = cc.x_t            # -P0^{-1}
+        neg_P0_inv = cc.x_t           # -P0^{-1}
 
-        if lds_k.obs_model isa GaussianObservationModel{T}
-            C = cc.C
-            d = lds_k.obs_model.d
-            C_inv_R = cc.C_inv_R        # C'R^{-1}
+        # t = 1: emission + prior, both weighted by w[k,1]
+        observationgradient!(tmp1, cc, obs_buf, x, y, 1, lds_k)
+        @. dxt = x[:, 1] - x0
+        mul!(tmp3, neg_P0_inv, dxt)
+        α = w[k, 1]
+        @. grad[:, 1] += α * (tmp1 + tmp3)
 
-            if Tsteps == 1
-                # emission at t=1
-                mul!(dyt, C, x[:, 1])
-                @. dyt = y[:, 1] - dyt - d
-                mul!(tmp1, C_inv_R, dyt)
+        Tsteps == 1 && continue
 
-                # prior at t=1
-                @. dxt = x[:, 1] - x0
-                mul!(tmp3, neg_P0_inv, dxt)
+        # Outgoing dynamics term comes from the factor at time 2, weighted by w[k,2]
+        _transition_residual!(dxt_next, x, 2, lds_k)
+        mul!(tmp2, A_inv_Q, dxt_next)
+        @. grad[:, 1] += w[k, 2] * tmp2
 
-                α = w[k, 1]
-                @. grad[:, 1] += α * (tmp1 + tmp3)
-                continue
-            end
-
-            # t = 1 
-            # emission (weighted by w[k,1])
-            mul!(dyt, C, x[:, 1])
-            @. dyt = y[:, 1] - dyt - d
-            mul!(tmp1, C_inv_R, dyt)
-            α = w[k, 1]
-            @. grad[:, 1] += α * tmp1
-
-            # prior (weighted by w[k,1])
-            @. dxt = x[:, 1] - x0
-            mul!(tmp3, neg_P0_inv, dxt)
-            @. grad[:, 1] += α * tmp3
-
-            # outgoing dynamics term comes from factor at time 2, weighted by w[k,2]
-            mul!(dxt_next, A, x[:, 1])
-            @. dxt_next = x[:, 2] - dxt_next - b
-            mul!(tmp2, A_inv_Q, dxt_next)
-            β = w[k, 2]
-            @. grad[:, 1] += β * tmp2
-
-            # 2 .. T-1
-            for t in 2:(Tsteps - 1)
-                # emission at t, weighted by w[k,t]
-                mul!(dyt, C, x[:, t])
-                @. dyt = y[:, t] - dyt - d
-                mul!(tmp1, C_inv_R, dyt)
-                α = w[k, t]
-                @. grad[:, t] += α * tmp1
-
-                # incoming dynamics factor at time t, weighted by w[k,t]
-                mul!(dxt, A, x[:, t - 1])
-                @. dxt = x[:, t] - dxt - b
-                mul!(tmp3, neg_Q_inv, dxt)
-                @. grad[:, t] += α * tmp3
-
-                # outgoing dynamics factor at time t+1, weighted by w[k,t+1]
-                mul!(dxt_next, A, x[:, t])
-                @. dxt_next = x[:, t + 1] - dxt_next - b
-                mul!(tmp2, A_inv_Q, dxt_next)
-                β = w[k, t + 1]
-                @. grad[:, t] += β * tmp2
-            end
-
-            # t = T
-            # emission at T, weighted by w[k,T]
-            mul!(dyt, C, x[:, Tsteps])
-            @. dyt = y[:, Tsteps] - dyt - d
-            mul!(tmp1, C_inv_R, dyt)
-            α = w[k, Tsteps]
-            @. grad[:, Tsteps] += α * tmp1
-
-            # incoming dynamics factor at time T, weighted by w[k,T]
-            mul!(dxt, A, x[:, Tsteps - 1])
-            @. dxt = x[:, Tsteps] - dxt - b
+        # 2 .. T-1: emission + incoming factor at t (w[k,t]),
+        # outgoing factor at t+1 (w[k,t+1])
+        for t in 2:(Tsteps - 1)
+            observationgradient!(tmp1, cc, obs_buf, x, y, t, lds_k)
+            _transition_residual!(dxt, x, t, lds_k)
             mul!(tmp3, neg_Q_inv, dxt)
-            @. grad[:, Tsteps] += α * tmp3
+            α = w[k, t]
+            @. grad[:, t] += α * (tmp1 + tmp3)
 
-        elseif lds_k.obs_model isa PoissonObservationModel{T}
-            C = cc.C
-            d = cc.d  # cached Poisson log-link intercept
-
-            if Tsteps == 1
-                # emission: C'*(y - λ)
-                mul!(z, C, x[:, 1])
-                @. λ = exp(z + d)
-                @. z = y[:, 1] - λ
-                mul!(tmp1, C', z)
-
-                # prior
-                @. dxt = x[:, 1] - x0
-                mul!(tmp3, neg_P0_inv, dxt)
-
-                α = w[k, 1]
-                @. grad[:, 1] += α * (tmp1 + tmp3)
-                continue
-            end
-
-            # t = 1
-            mul!(z, C, x[:, 1])
-            @. λ = exp(z + d)
-            @. z = y[:, 1] - λ
-            mul!(tmp1, C', z)
-            α = w[k, 1]
-            @. grad[:, 1] += α * tmp1
-
-            @. dxt = x[:, 1] - x0
-            mul!(tmp3, neg_P0_inv, dxt)
-            @. grad[:, 1] += α * tmp3
-
-            # outgoing dynamics factor at time 2 weighted by w[k,2]
-            mul!(dxt_next, A, x[:, 1])
-            @. dxt_next = x[:, 2] - dxt_next - b
+            _transition_residual!(dxt_next, x, t + 1, lds_k)
             mul!(tmp2, A_inv_Q, dxt_next)
-            β = w[k, 2]
-            @. grad[:, 1] += β * tmp2
-
-            # 2 .. T-1
-            for t in 2:(Tsteps - 1)
-                mul!(z, C, x[:, t])
-                @. λ = exp(z + d)
-                @. z = y[:, t] - λ
-                mul!(tmp1, C', z)
-                α = w[k, t]
-                @. grad[:, t] += α * tmp1
-
-                mul!(dxt, A, x[:, t - 1])
-                @. dxt = x[:, t] - dxt - b
-                mul!(tmp3, neg_Q_inv, dxt)
-                @. grad[:, t] += α * tmp3
-
-                mul!(dxt_next, A, x[:, t])
-                @. dxt_next = x[:, t + 1] - dxt_next - b
-                mul!(tmp2, A_inv_Q, dxt_next)
-                β = w[k, t + 1]
-                @. grad[:, t] += β * tmp2
-            end
-
-            # t = T
-            mul!(z, C, x[:, Tsteps])
-            @. λ = exp(z + d)
-            @. z = y[:, Tsteps] - λ
-            mul!(tmp1, C', z)
-            α = w[k, Tsteps]
-            @. grad[:, Tsteps] += α * tmp1
-
-            mul!(dxt, A, x[:, Tsteps - 1])
-            @. dxt = x[:, Tsteps] - dxt - b
-            mul!(tmp3, neg_Q_inv, dxt)
-            @. grad[:, Tsteps] += α * tmp3
-
-        else
-            throw(ArgumentError("Unsupported observation model $(typeof(lds_k.obs_model))"))
+            @. grad[:, t] += w[k, t + 1] * tmp2
         end
+
+        # t = T: emission + incoming factor at T, weighted by w[k,T]
+        observationgradient!(tmp1, cc, obs_buf, x, y, Tsteps, lds_k)
+        _transition_residual!(dxt, x, Tsteps, lds_k)
+        mul!(tmp3, neg_Q_inv, dxt)
+        α = w[k, Tsteps]
+        @. grad[:, Tsteps] += α * (tmp1 + tmp3)
     end
 
     return grad

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -295,9 +295,9 @@ end
 """
     Gradient!(ws, slds, y, x, w)
 
-In-place SLDS gradient with a backend compatible shape to LDS.
-Semantics match current SLDS.jl: compute per-timestep component gradient and scale by w[k,t].
-Writes into `ws.grad_buf` and returns it.
+In-place SLDS gradient: each component's complete-data gradient is scaled
+per-timestep by the responsibility `w[k, t]` and accumulated. Writes into
+`ws.grad_buf` and returns it.
 """
 function Gradient!(
     ws::SLDSSmoothWorkspace{T},

--- a/test/LinearDynamicalSystems/GaussianLDS.jl
+++ b/test/LinearDynamicalSystems/GaussianLDS.jl
@@ -956,3 +956,54 @@ function test_joint_loglikelihood_matches_mvnormal()
     @test ll ≈ ref rtol = 1e-10
     return nothing
 end
+
+function test_gaussian_gradient_nondiag()
+    # Gradient companion to `test_joint_loglikelihood_matches_mvnormal`:
+    # non-diagonal Q/P0/R plus control inputs on both the state (B*ux) and
+    # observation (D*uy) sides, checked against ForwardDiff through the
+    # kernel-based joint_loglikelihood!.
+    rng = StableRNG(4321)
+    D_lat, p_obs, T_steps = 2, 3, 30
+
+    A_nd = [0.9 0.1; -0.05 0.85]
+    Q_nd = [0.5 0.2; 0.2 0.4]
+    b_nd = [0.1, -0.1]
+    x0_nd = [0.5, -0.5]
+    P0_nd = [1.0 0.3; 0.3 0.8]
+    B_nd = randn(rng, D_lat, 2)
+    C_nd = randn(rng, p_obs, D_lat)
+    R_nd = [0.6 0.1 0.0; 0.1 0.5 0.05; 0.0 0.05 0.7]
+    d_nd = [0.1, 0.2, -0.1]
+    D_obs_nd = randn(rng, p_obs, 1)
+
+    sm = GaussianStateModel(; A=A_nd, Q=Q_nd, b=b_nd, x0=x0_nd, P0=P0_nd, B=B_nd)
+    om = GaussianObservationModel(; C=C_nd, R=R_nd, d=d_nd, D=D_obs_nd)
+    lds = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=D_lat,
+        obs_dim=p_obs,
+        fit_bool=fill(true, 6),
+    )
+
+    x = randn(rng, D_lat, T_steps)
+    y = randn(rng, p_obs, T_steps)
+    ux = randn(rng, 2, T_steps)
+    uy = randn(rng, 1, T_steps)
+
+    ws = StateSpaceDynamics.SmoothWorkspace(Float64, D_lat, p_obs, T_steps)
+    StateSpaceDynamics.compute_smooth_constants!(ws, lds)
+    g = copy(StateSpaceDynamics.Gradient!(ws, lds, y, x, ux, uy))
+
+    f =
+        xv -> begin
+            xm = reshape(xv, D_lat, T_steps)
+            wsd = StateSpaceDynamics.SmoothWorkspace(eltype(xv), D_lat, p_obs, T_steps)
+            StateSpaceDynamics.compute_smooth_constants!(wsd, lds)
+            sum(StateSpaceDynamics.joint_loglikelihood!(wsd, xm, lds, y, ux, uy))
+        end
+    g_num = reshape(ForwardDiff.gradient(f, vec(x)), D_lat, T_steps)
+
+    @test norm(g - g_num) < 1e-8
+    return nothing
+end

--- a/test/LinearDynamicalSystems/GaussianLDS.jl
+++ b/test/LinearDynamicalSystems/GaussianLDS.jl
@@ -958,10 +958,10 @@ function test_joint_loglikelihood_matches_mvnormal()
 end
 
 function test_gaussian_gradient_nondiag()
-    # Gradient companion to `test_joint_loglikelihood_matches_mvnormal`:
-    # non-diagonal Q/P0/R plus control inputs on both the state (B*ux) and
-    # observation (D*uy) sides, checked against ForwardDiff through the
-    # kernel-based joint_loglikelihood!.
+    #=
+    Non-diagonal Q/P0/R plus state (B*ux) and observation (D*uy) inputs;
+    gradient checked against ForwardDiff through joint_loglikelihood!.
+    =#
     rng = StableRNG(4321)
     D_lat, p_obs, T_steps = 2, 3, 30
 

--- a/test/LinearDynamicalSystems/PoissonLDS.jl
+++ b/test/LinearDynamicalSystems/PoissonLDS.jl
@@ -754,9 +754,10 @@ function test_newton_objective_is_joint_loglikelihood()
 end
 
 function test_poisson_gradient_nondiag()
-    # Gradient companion to `test_joint_loglikelihood_matches_distributions`:
-    # non-diagonal Q/P0 checked against ForwardDiff through the allocating
-    # joint_loglikelihood.
+    #=
+    Non-diagonal Q/P0; gradient checked against ForwardDiff through the
+    allocating joint_loglikelihood.
+    =#
     rng = StableRNG(4321)
     D_lat, p_obs, T_steps = 2, 3, 30
 

--- a/test/LinearDynamicalSystems/PoissonLDS.jl
+++ b/test/LinearDynamicalSystems/PoissonLDS.jl
@@ -752,3 +752,45 @@ function test_newton_objective_is_joint_loglikelihood()
         1e-12
     return nothing
 end
+
+function test_poisson_gradient_nondiag()
+    # Gradient companion to `test_joint_loglikelihood_matches_distributions`:
+    # non-diagonal Q/P0 checked against ForwardDiff through the allocating
+    # joint_loglikelihood.
+    rng = StableRNG(4321)
+    D_lat, p_obs, T_steps = 2, 3, 30
+
+    A_nd = [0.9 0.1; -0.05 0.85]
+    Q_nd = [0.5 0.2; 0.2 0.4]
+    b_nd = [0.1, -0.1]
+    x0_nd = [0.5, -0.5]
+    P0_nd = [1.0 0.3; 0.3 0.8]
+    C_nd = 0.5 .* randn(rng, p_obs, D_lat)
+    d_nd = [0.1, 0.2, -0.1]
+
+    sm = GaussianStateModel(; A=A_nd, Q=Q_nd, b=b_nd, x0=x0_nd, P0=P0_nd)
+    om = PoissonObservationModel(; C=C_nd, d=d_nd)
+    plds = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=D_lat,
+        obs_dim=p_obs,
+        fit_bool=fill(true, 6),
+    )
+
+    x = randn(rng, D_lat, T_steps)
+    y = Float64.(rand.(Ref(rng), Poisson.(exp.(C_nd * x .+ d_nd))))
+
+    ws = StateSpaceDynamics.SmoothWorkspace(Float64, D_lat, p_obs, T_steps)
+    StateSpaceDynamics.compute_smooth_constants!(ws, plds)
+    g = copy(StateSpaceDynamics.Gradient!(ws, plds, y, x))
+
+    f =
+        xv -> sum(
+            StateSpaceDynamics.joint_loglikelihood(reshape(xv, D_lat, T_steps), plds, y)
+        )
+    g_num = reshape(ForwardDiff.gradient(f, vec(x)), D_lat, T_steps)
+
+    @test norm(g - g_num) < 1e-8
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,7 @@ using SSDTest
 
             @testset "Log-likelihood" begin
                 test_joint_loglikelihood_matches_mvnormal()
+                test_gaussian_gradient_nondiag()
             end
 
             @testset "EM Algorithm" begin
@@ -207,6 +208,7 @@ using SSDTest
             @testset "Log-likelihood" begin
                 test_joint_loglikelihood_matches_distributions()
                 test_newton_objective_is_joint_loglikelihood()
+                test_poisson_gradient_nondiag()
             end
 
             @testset "Priors - Poisson LDS" begin


### PR DESCRIPTION
Stacked on #135 — review only the top commit; the rest is the base branch. Retarget to `main` after #135 merges.

Deduplicates the per-observation-model `Gradient!` implementations (Gaussian / Poisson / SLDS-weighted) into shared kernels in `continuous_latents.jl`, mirroring the likelihood split from #135:

- `observationgradient!(out, cc, buf, x, y, t, lds[, uy])` — per-model emission gradient dispatch point; a new observation model plugs in with one method.
- Shared `Gradient!` assembles emission + prior/transition factors from the cached Cholesky-derived templates.
- `_transition_residual!` defines the affine-dynamics residual `x_t - A x_{t-1} - b - B u_{t-1}` in exactly one place, shared by the likelihood and gradient kernels.