### PR TITLE
Add x0_mean_prior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Composable Normal-Inverse-Wishart prior on the initial latent state via a new
+  `GaussianStateModel` field `x0_prior::Union{Nothing,MNPrior}` (the mean half),
+  paired with the existing `P0_prior::IWPrior` (the covariance half). The initial
+  state `x₁ ~ N(x0, P0)` is an intercept-only regression, so its NIW prior is the
+  same `MNPrior` + `IWPrior` composition used for `[A b]`/`Q` and `[C d]`/`R` —
+  no bespoke prior type. Construct the mean half with the exported
+  `x0_mean_prior(μ₀; κ₀)` helper; the M-step then does
+  `x0 = (Σγ·x₁ + κ₀ μ₀) / (Σγ + κ₀)` and folds `κ₀(x0-μ₀)(x0-μ₀)'` into the IW
+  scale. With `κ₀ → 0` (and no `P0_prior`) it reduces exactly to the previous MLE
+  update
+
 ### Changed
 - **Breaking:** renamed the control-input arguments `latent_inputs`/`obs_inputs`
   to `ux`/`uy` across the public API (keywords on `fit!`/`rand`, positional on
@@ -50,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `P0` now fails.
 
 ### Fixed
+- SLDS `forward_backward` could produce `NaN`s when a regime received ~no
+  responsibility at trial starts: its initial-state effective count `init_n`
+  underflowed toward zero, so `x0 = init_xy/init_n` and `P0 = S0/init_n` blew up
+  to `±Inf`/`NaN`, poisoning `dl.logL` and the whole chain posterior. Setting the
+  new initial-state NIW prior (`x0_prior` + `P0_prior`) makes the update degrade
+  to the prior (`x0 → μ₀`, `P0 →` its IW mode) instead of dividing by ~0
 - SLDS ELBO computation (incorrect sign, among other errors); correctness is now
   tested via the K=1 SLDS ≡ LDS equivalence (#145)
 - SLDS posterior sampling drew from the marginals of `q(x)` (a mean-field

--- a/docs/src/LinearDynamicalSystems.md
+++ b/docs/src/LinearDynamicalSystems.md
@@ -290,6 +290,8 @@ You can attach an MN prior to:
 - The stacked dynamics matrix via `AB_prior` on a [`GaussianStateModel`](@ref)
 - The stacked emission matrix via `CD_prior` on a [`GaussianObservationModel`](@ref) or
   [`PoissonObservationModel`](@ref)
+- The initial state mean ``x_0`` via `x0_prior` on a [`GaussianStateModel`](@ref)
+  (see below)
 
 The MN prior is kept separate from the covariance priors on purpose: pairing an
 `AB_prior`/`CD_prior` with the matching `Q_prior`/`R_prior` ([`IWPrior`](@ref)) recovers a
@@ -300,3 +302,76 @@ applies there.
 ```@docs; canonical = false
 MNPrior
 ```
+
+### Example: Adding MN priors to an LDS
+
+All three coefficient matrices can carry an MN prior at once. The stacked matrices are
+``[A\; b]`` (``D \times (D+1)``) and ``[C\; d]`` (``P \times (D+1)``), and ``x_0`` is a
+length-``D`` intercept:
+
+```julia
+using LinearAlgebra, StateSpaceDynamics
+
+D, P = 3, 4
+λ = 1e-2
+
+# Shrink [A b] toward a random walk (A → I, b → 0):
+AB_prior = MNPrior(M₀ = hcat(Matrix(I, D, D), zeros(D)),
+                   Λ  = Matrix(I, D + 1, D + 1) .* λ)
+# Ridge on [C d] (shrink toward 0):
+CD_prior = MNPrior(M₀ = zeros(P, D + 1),
+                   Λ  = Matrix(I, D + 1, D + 1) .* λ)
+# Pull the initial mean x0 toward 0 with κ₀ = 1 pseudo-observation:
+x0_prior = x0_mean_prior(zeros(D); κ₀ = 1.0)
+
+gsm = GaussianStateModel(A=A, Q=Q, b=b, x0=x0, P0=P0,
+                         AB_prior=AB_prior, x0_prior=x0_prior)
+gom = GaussianObservationModel(C=C, R=R, d=d, CD_prior=CD_prior)
+```
+
+## Composing Priors: Full MNIW + NIW
+
+Because the mean and covariance halves attach independently, you can pair every MN prior
+with its matching IW prior to place a full **matrix-normal-inverse-Wishart (MNIW)** prior
+on each regression :``(AB, Q)`` and ``(CD, R)`` or 
+an **NIW** prior on the initial state ``(x_0, P_0)``:
+
+```julia
+using LinearAlgebra, Random, StateSpaceDynamics
+
+rng = MersenneTwister(42)
+D, P = 3, 4
+λ = 1e-2
+
+# Model parameters
+A = 0.9I + 0.05randn(rng, D, D)
+Q = Matrix(I, D, D) .* 0.3
+b = zeros(D); x0 = zeros(D); P0 = Matrix(I, D, D) .* 0.8
+C = randn(rng, P, D)
+R = Matrix(I, P, P) .* 0.25
+d = 0.1 .* randn(rng, P)
+
+# Covariance (IW) halves
+Q_prior  = IWPrior(Ψ = diagm(0 => fill(0.01, D)), ν = D + 3.0)
+R_prior  = IWPrior(Ψ = diagm(0 => fill(0.01, P)), ν = P + 3.0)
+P0_prior = IWPrior(Ψ = diagm(0 => fill(0.01, D)), ν = D + 3.0)
+
+# Mean (MN) halves
+AB_prior = MNPrior(M₀ = hcat(Matrix(I, D, D), zeros(D)), Λ = Matrix(I, D + 1, D + 1) .* λ)
+CD_prior = MNPrior(M₀ = zeros(P, D + 1),                 Λ = Matrix(I, D + 1, D + 1) .* λ)
+x0_prior = x0_mean_prior(zeros(D); κ₀ = 1.0)
+
+# AB_prior + Q_prior → MNIW on (AB, Q); CD_prior + R_prior → MNIW on (CD, R);
+# x0_prior + P0_prior → NIW on (x0, P0).
+gsm = GaussianStateModel(A=A, Q=Q, b=b, x0=x0, P0=P0,
+                         AB_prior=AB_prior, Q_prior=Q_prior,
+                         x0_prior=x0_prior, P0_prior=P0_prior)
+gom = GaussianObservationModel(C=C, R=R, d=d,
+                               CD_prior=CD_prior, R_prior=R_prior)
+lds = LinearDynamicalSystem(gsm, gom)
+
+X, Y = rand(rng, lds, fill(100, 5))   # 5 trials of 100 timesteps each
+fit!(lds, Y; max_iter=20, progress=false)
+```
+
+Any subset works.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,6 +36,10 @@ IWPrior
 MNPrior
 ```
 
+```@docs
+x0_mean_prior
+```
+
 ## Sampling
 
 ```@docs; canonical = false

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -62,7 +62,7 @@ export InvalidProbabilityVectorError, NumericalStabilityError
 export ProbabilisticPCA, SLDS, LinearDynamicalSystem, Data
 export AbstractStateModel, AbstractObservationModel
 export GaussianStateModel, GaussianObservationModel, PoissonObservationModel
-export IWPrior, MNPrior
+export IWPrior, MNPrior, x0_mean_prior
 export CovUpdateCache
 
 # Utilities

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -559,10 +559,21 @@ function update_initial_state_mean!(
     lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     lds.fit_bool[1] || return nothing
-    inv_n = inv(T(suf.init_n))
     x0 = lds.state_model.x0
-    for j in eachindex(x0)
-        x0[j] = suf.init_xy[1, j] * inv_n
+    x0_prior = lds.state_model.x0_prior
+    # NIW mean update: x0 = (Σγ·x₁ + κ₀ μ₀) / (Σγ + κ₀)
+    if x0_prior === nothing
+        inv_n = inv(T(suf.init_n))
+        for j in eachindex(x0)
+            x0[j] = suf.init_xy[1, j] * inv_n
+        end
+    else
+        κ₀ = x0_prior.Λ[1, 1]
+        μ₀ = x0_prior.M₀            # D×1
+        κ_n = T(suf.init_n) + κ₀
+        for j in eachindex(x0)
+            x0[j] = (suf.init_xy[1, j] + κ₀ * μ₀[j, 1]) / κ_n
+        end
     end
     return nothing
 end
@@ -578,6 +589,7 @@ function update_initial_state_covariance!(
     S0 = sws.reg.S0_sum                              # D × D scratch
     copyto!(S0, suf.init_yy[].mat)
 
+    # Scatter of the initial state around x0: S0 = Σγ(x₁-x0)(x₁-x0)' + Σγ P₁.
     # Rank-1 updates inline (BLAS.ger! would need a contiguous μ vector and
     # `view(init_xy, 1, :)` allocates a SubArray header — small but nonzero).
     for j in 1:D
@@ -587,6 +599,22 @@ function update_initial_state_covariance!(
             μ_i = suf.init_xy[1, i]
             x0_i = x0[i]
             S0[i, j] += T(N) * x0_i * x0_j - x0_i * μ_j - μ_i * x0_j
+        end
+    end
+
+    #=
+    Matrix-normal prior on x0 (the mean half of the NIW): fold κ₀(x0-μ₀)(x0-μ₀)'
+    into the IW scale, exactly as update_Q!/update_R! fold in their `Wm Λ Wm'`
+    term. Together with `P0_prior` (the IW half) this yields the NIW posterior
+    scale Ψₙ = Ψ + Σγ(x₁x₁'+P₁) + κ₀μ₀μ₀' - κₙ x0 x0'. `x0` must already hold the
+    NIW mean μₙ here (update_initial_state_mean! runs first in the M-step).
+    =#
+    x0_prior = lds.state_model.x0_prior
+    if x0_prior !== nothing
+        κ₀ = x0_prior.Λ[1, 1]
+        μ₀ = x0_prior.M₀
+        for j in 1:D, i in 1:D
+            S0[i, j] += κ₀ * (x0[i] - μ₀[i, 1]) * (x0[j] - μ₀[j, 1])
         end
     end
     Symmetrize!(S0)

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -662,6 +662,11 @@ function elbo!(
     if lds.state_model.P0_prior !== nothing
         prior_term += iw_logprior_term(lds.state_model.P0, lds.state_model.P0_prior)
     end
+    if lds.state_model.x0_prior !== nothing
+        prior_term += mn_logprior_term(
+            reshape(lds.state_model.x0, :, 1), lds.state_model.P0, lds.state_model.x0_prior
+        )
+    end
     if lds.obs_model.R_prior !== nothing
         prior_term += iw_logprior_term(lds.obs_model.R, lds.obs_model.R_prior)
     end

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -379,6 +379,13 @@ function elbo!(
     if plds.state_model.P0_prior !== nothing
         prior_term += iw_logprior_term(plds.state_model.P0, plds.state_model.P0_prior)
     end
+    if plds.state_model.x0_prior !== nothing
+        prior_term += mn_logprior_term(
+            reshape(plds.state_model.x0, :, 1),
+            plds.state_model.P0,
+            plds.state_model.x0_prior,
+        )
+    end
 
     #=
     MN log-prior trace term on the dynamics [A b B]. The state model is Gaussian

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -692,6 +692,9 @@ function _slds_prior_logdensity(slds::SLDS{T}) where {T<:Real}
         if sm.P0_prior !== nothing
             prior_term += iw_logprior_term(sm.P0, sm.P0_prior)
         end
+        if sm.x0_prior !== nothing
+            prior_term += mn_logprior_term(reshape(sm.x0, :, 1), sm.P0, sm.x0_prior)
+        end
         if sm.AB_prior !== nothing
             ux_dim = lds.ux_dim
             W_ab = Matrix{T}(undef, D, D + 1 + ux_dim)

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -56,6 +56,8 @@ where `B·ux_t` is present only when `B` is supplied (i.e., has nonzero columns)
     the stacked dynamics matrix `[A B]`. Pair with `Q_prior` for a full MNIW prior on `(AB, Q)`.
     Prior matrices are stored as plain `Matrix{T}` (decoupled from `A`'s storage type `M`) so
     they match the internal workspaces regardless of how `A` is stored.
+- `x0_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing`: Optional matrix-normal prior on the
+    initial mean `x0`.
 """
 Base.@kwdef mutable struct GaussianStateModel{
     T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}
@@ -69,6 +71,7 @@ Base.@kwdef mutable struct GaussianStateModel{
     Q_prior::Union{Nothing,IWPrior{T}} = nothing
     P0_prior::Union{Nothing,IWPrior{T}} = nothing
     AB_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
+    x0_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
 end
 
 """

--- a/src/stats/priors.jl
+++ b/src/stats/priors.jl
@@ -131,3 +131,22 @@ ELBO can decrease under strong shrinkage — see git log for the fix context.
 end
 
 @inline mn_logprior_term(W::AbstractMatrix, ::AbstractMatrix, ::Nothing) = zero(eltype(W))
+
+"""
+    x0_mean_prior(μ₀; κ₀=1) -> MNPrior
+
+Convenience constructor for the mean half of a Normal–Inverse–Wishart prior on
+the initial latent state.
+
+- pair this `MNPrior` (on `x0`, via `state_model.x0_prior`) with an `IWPrior` on
+  `P0` (via `state_model.P0_prior`) to obtain the full NIW conjugate prior:
+
+  ```math
+  x0 | P0 ~ N(μ₀, P0 / κ₀),   P0 ~ IW(Ψ, ν)
+  ```
+"""
+function x0_mean_prior(μ₀::AbstractVector{T}; κ₀::Real=one(T)) where {T<:Real}
+    κ₀ > zero(T) || throw(ArgumentError("x0_mean_prior: κ₀ must be positive, got $κ₀"))
+    D = length(μ₀)
+    return MNPrior{T,Matrix{T}}(; M₀=reshape(collect(μ₀), D, 1), Λ=fill(T(κ₀), 1, 1))
+end

--- a/test/LinearDynamicalSystems/GaussianLDS.jl
+++ b/test/LinearDynamicalSystems/GaussianLDS.jl
@@ -485,26 +485,35 @@ function test_x0_niw_prior_map_and_degradation()
     =#
     @testset "Initial-state NIW prior: MAP, MLE reduction, graceful degradation" begin
         D, P = 2, 3
-        mk = (; x0p, P0p) -> begin
-            gsm = GaussianStateModel(;
-                A=0.5 * Matrix(I(D)), Q=Matrix(0.1 * I(D)), b=zeros(D),
-                x0=zeros(D), P0=Matrix(1.0 * I(D)), x0_prior=x0p, P0_prior=P0p,
-            )
-            gom = GaussianObservationModel(; C=0.5 * ones(P, D), R=Matrix(1.0 * I(P)), d=zeros(P))
-            return LinearDynamicalSystem(gsm, gom)
-        end
+        mk =
+            (; x0p, P0p) -> begin
+                gsm = GaussianStateModel(;
+                    A=0.5 * Matrix(I(D)),
+                    Q=Matrix(0.1 * I(D)),
+                    b=zeros(D),
+                    x0=zeros(D),
+                    P0=Matrix(1.0 * I(D)),
+                    x0_prior=x0p,
+                    P0_prior=P0p,
+                )
+                gom = GaussianObservationModel(;
+                    C=0.5 * ones(P, D), R=Matrix(1.0 * I(P)), d=zeros(P)
+                )
+                return LinearDynamicalSystem(gsm, gom)
+            end
         # Hand-set sufficient statistics for one (fake) regime.
         N = 0.7
         msum = [0.4, -0.3]                       # Σγ·x₁
         SS = [0.9 0.1; 0.1 0.7]                  # Σγ(x₁x₁' + P₁), SPD
-        set_suf! = lds -> begin
-            suf = StateSpaceDynamics._initialize_td_sufficient_statistics(Float64, lds, [5])
-            suf.init_n = N
-            suf.init_xy[1, 1] = msum[1]
-            suf.init_xy[1, 2] = msum[2]
-            suf.init_yy[] = PDMat(copy(SS))
-            return suf
-        end
+        set_suf! =
+            lds -> begin
+                suf = StateSpaceDynamics._initialize_td_sufficient_statistics(Float64, lds, [5])
+                suf.init_n = N
+                suf.init_xy[1, 1] = msum[1]
+                suf.init_xy[1, 2] = msum[2]
+                suf.init_yy[] = PDMat(copy(SS))
+                return suf
+            end
         sws = StateSpaceDynamics.SmoothWorkspace(Float64, D, P, 5)
 
         # (1) constructor

--- a/test/LinearDynamicalSystems/GaussianLDS.jl
+++ b/test/LinearDynamicalSystems/GaussianLDS.jl
@@ -474,6 +474,94 @@ function test_gaussian_iw_priors_shape_map_and_R_sanity(; rng=MersenneTwister(20
     return nothing
 end
 
+function test_x0_niw_prior_map_and_degradation()
+    #=
+    Composable NIW prior on the initial state: `x0_prior` and `P0_prior` 
+    Checks (1) the constructor shape, (2) the M-step MAP matches the closed-form
+    NIW posterior mode, (3) with no priors it reduces exactly to the MLE, and
+    (4) it degrades gracefully to the prior when an LDS gets ~zero
+    responsibility at trial starts (the collapse that otherwise makes
+    `x0 = init_xy/init_n` blow up to ±Inf and NaN out forward-backward).
+    =#
+    @testset "Initial-state NIW prior: MAP, MLE reduction, graceful degradation" begin
+        D, P = 2, 3
+        mk = (; x0p, P0p) -> begin
+            gsm = GaussianStateModel(;
+                A=0.5 * Matrix(I(D)), Q=Matrix(0.1 * I(D)), b=zeros(D),
+                x0=zeros(D), P0=Matrix(1.0 * I(D)), x0_prior=x0p, P0_prior=P0p,
+            )
+            gom = GaussianObservationModel(; C=0.5 * ones(P, D), R=Matrix(1.0 * I(P)), d=zeros(P))
+            return LinearDynamicalSystem(gsm, gom)
+        end
+        # Hand-set sufficient statistics for one (fake) regime.
+        N = 0.7
+        msum = [0.4, -0.3]                       # Σγ·x₁
+        SS = [0.9 0.1; 0.1 0.7]                  # Σγ(x₁x₁' + P₁), SPD
+        set_suf! = lds -> begin
+            suf = StateSpaceDynamics._initialize_td_sufficient_statistics(Float64, lds, [5])
+            suf.init_n = N
+            suf.init_xy[1, 1] = msum[1]
+            suf.init_xy[1, 2] = msum[2]
+            suf.init_yy[] = PDMat(copy(SS))
+            return suf
+        end
+        sws = StateSpaceDynamics.SmoothWorkspace(Float64, D, P, 5)
+
+        # (1) constructor
+        μ₀, κ₀ = [1.0, -1.0], 2.0
+        xp = x0_mean_prior(μ₀; κ₀=κ₀)
+        @test xp isa MNPrior
+        @test size(xp.M₀) == (D, 1)
+        @test xp.Λ == fill(κ₀, 1, 1)
+        @test_throws ArgumentError x0_mean_prior(μ₀; κ₀=0.0)
+
+        # (2) MAP == closed-form NIW mode
+        Ψ, ν = Matrix(0.5 * I(D)), 5.0
+        lds = mk(; x0p=xp, P0p=IWPrior(; Ψ=Ψ, ν=ν))
+        suf = set_suf!(lds)
+        StateSpaceDynamics.update_initial_state_mean!(lds, suf)
+        StateSpaceDynamics.update_initial_state_covariance!(lds, suf, sws)
+        κn = N + κ₀
+        x0e = (msum .+ κ₀ .* μ₀) ./ κn
+        Ψn = Ψ .+ SS .+ κ₀ .* (μ₀ * μ₀') .- κn .* (x0e * x0e')
+        @test lds.state_model.x0 ≈ x0e
+        @test lds.state_model.P0 ≈ Ψn ./ (ν + N + D + 1)
+        @test issymmetric(lds.state_model.P0)
+
+        # (3) no priors ⇒ MLE
+        lds0 = mk(; x0p=nothing, P0p=nothing)
+        suf0 = set_suf!(lds0)
+        StateSpaceDynamics.update_initial_state_mean!(lds0, suf0)
+        StateSpaceDynamics.update_initial_state_covariance!(lds0, suf0, sws)
+        x0m = msum ./ N
+        @test lds0.state_model.x0 ≈ x0m
+        @test lds0.state_model.P0 ≈ (SS .- N .* (x0m * x0m')) ./ N
+
+        # (4) collapse
+        ldsd = mk(; x0p=xp, P0p=IWPrior(; Ψ=Ψ, ν=ν))
+        sufd = StateSpaceDynamics._initialize_td_sufficient_statistics(Float64, ldsd, [5])
+        sufd.init_n = 0.0
+        fill!(sufd.init_xy, 0.0)
+        sufd.init_yy[] = PDMat(Matrix(1e-12 * I(D)))
+        StateSpaceDynamics.update_initial_state_mean!(ldsd, sufd)
+        StateSpaceDynamics.update_initial_state_covariance!(ldsd, sufd, sws)
+        @test all(isfinite, ldsd.state_model.x0)
+        @test all(isfinite, ldsd.state_model.P0)
+        @test ldsd.state_model.x0 ≈ μ₀
+        @test ldsd.state_model.P0 ≈ Ψ ./ (ν + D + 1)
+
+        # Contrast: without the prior the same collapse produces non-finite x0.
+        ldsn = mk(; x0p=nothing, P0p=nothing)
+        sufn = StateSpaceDynamics._initialize_td_sufficient_statistics(Float64, ldsn, [5])
+        sufn.init_n = 0.0
+        fill!(sufn.init_xy, 0.0)
+        sufn.init_yy[] = PDMat(Matrix(1e-12 * I(D)))
+        StateSpaceDynamics.update_initial_state_mean!(ldsn, sufn)
+        @test !all(isfinite, ldsn.state_model.x0)
+    end
+    return nothing
+end
+
 function test_gaussian_update_R_matches_residual_cov(; rng=MersenneTwister(7))
     @testset "GaussianLDS: update_R! ≈ residual covariance when latents ~ deterministic" begin
         D, P, Tt, N = 2, 3, 80, 6

--- a/test/LinearDynamicalSystems/SLDS.jl
+++ b/test/LinearDynamicalSystems/SLDS.jl
@@ -1366,6 +1366,33 @@ function test_SLDS_no_priors_zero_prior_logdensity(; rng=MersenneTwister(0xC0FFE
     @test isfinite(StateSpaceDynamics._slds_prior_logdensity(slds))
 end
 
+function test_SLDS_x0_niw_prior(; rng=MersenneTwister(0xB0BA))
+    K, latent_dim, obs_dim = 3, 2, 3
+
+    x0p() = x0_mean_prior(zeros(latent_dim); κ₀=1.0)
+    P0p() = StateSpaceDynamics.IWPrior(; Ψ=Matrix(1.0 * I(latent_dim)), ν=latent_dim + 2.0)
+
+    lds = _make_gaussian_lds(latent_dim, obs_dim)
+    lds.state_model.x0_prior = x0_mean_prior(fill(0.5, latent_dim); κ₀=1.0)
+    slds = SLDS(; A=_rowstochastic(K), πₖ=_probvec(K), LDSs=fill(lds, K))
+    ld = StateSpaceDynamics._slds_prior_logdensity(slds)
+    @test isfinite(ld)
+    @test ld != 0.0
+    @test ld < 0.0   # a shrinkage penalty: -½ κ₀ (x0-μ₀)'P0⁻¹(x0-μ₀) ≤ 0
+
+    lds2 = _make_gaussian_lds(latent_dim, obs_dim)
+    lds2.state_model.x0_prior = x0p()
+    lds2.state_model.P0_prior = P0p()
+    slds2 = SLDS(; A=_rowstochastic(K), πₖ=_probvec(K), LDSs=fill(lds2, K))
+    _, _, y = rand(rng, slds2, fill(20, 3))
+    elbos = fit!(slds2, y; max_iter=8, progress=false)
+    @test all(isfinite, elbos)
+    for lds_k in slds2.LDSs
+        @test all(isfinite, lds_k.state_model.x0)
+        @test all(isfinite, lds_k.state_model.P0)
+    end
+end
+
 #=
 The joint sampler must reproduce the posterior's temporal correlations, not
 just the per-timestep marginals. The old marginal sampler got this wrong; it

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ using SSDTest
                 test_SLDS_estep_elbo_components()
                 test_SLDS_elbo_matches_LDS_marginal_K1()
                 test_SLDS_no_priors_zero_prior_logdensity()
+                test_SLDS_x0_niw_prior()
                 test_SLDS_joint_sample_reproduces_cross_covariance()
             end
 
@@ -162,6 +163,7 @@ using SSDTest
                 test_EM()
                 test_EM(3)
                 test_gaussian_iw_priors_shape_map_and_R_sanity()
+                test_x0_niw_prior_map_and_degradation()
                 test_gaussian_update_R_matches_residual_cov()
                 test_gaussian_weighting_equiv_to_duplication()
                 test_td_mn_priors_shrink()


### PR DESCRIPTION
@harrisonritz this resolves #155.

Adds the needed mean prior on `x0` for a full NIW prior. Fixed 8 problematic runs on a 500 random model init run. The full conjugate prior fixed all the NaN issues during FB. Other issues that popped up were orthogonal (PD error on obs/dynamics model that were fixed with MNIW priors).

Long story short, remember the ABCs of Bayesian Inference: Always Be Checking (your priors)