### PR TITLE
feature / condition-varying parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ancillary parameter dependencies: every `AbstractStateModel` and
+  `AbstractObservationModel` now carries a `depends_on` field (default
+  `nothing`). Setting it to a `NamedTuple` of per-trial label vectors — e.g.
+  `obs_model.depends_on = (C = session, R = session)` — makes those parameters
+  be estimated separately for each group of trials, while everything else stays
+  pooled. This is the "stitching" setup for combining recording sessions that
+  observe different neurons in the same animal: shared latent dynamics,
+  session-specific `C`, `d`/`D` and `R`. Supported for the Gaussian LDS, the
+  Poisson LDS and the SLDS, across `fit!`, `smooth`, `elbo`, `loglikelihood`
+  and `rand`.
+  * Keys are canonicalized to the same groups `fit_bool` uses, since those
+    parameters are fit jointly as one regression — `:A`/`:b`/`:B` name one
+    group and `:C`/`:d`/`:D` another. Labels may be `Symbol`s, integers or
+    strings. Different parameters may use different label vectors; the trial
+    partition is their common refinement.
+  * Fitted values are read back with the new exported `group_labels(model,
+    name)` and `group_parameter(model, name, label)`, and stored on a new
+    `variants` field holding one model object per parameter-group combination.
+    Parameters that do not vary are shared **by reference** across variants.
+  * All versions of a parameter share the model's prior; each version
+    contributes its own log-prior term to the ELBO.
+  * `fit!`, `smooth`, `elbo`, `loglikelihood` and `rand` accept a `depends_on`
+    keyword that overrides the model's stored labels for that call, so a
+    held-out set with a different trial count can be scored without mutating
+    the model.
+  * The efficiency of same-length epochs is preserved *within* each group:
+    trials sharing every parameter form a cell, and the smoothed covariance is
+    computed once per cell and shared across it (parameters differ between
+    cells, so their covariances genuinely differ). The `O(D²·T)` workspace
+    storage is allocated once and reused across cells, so a grouped fit's
+    memory tracks an ungrouped one's instead of scaling with the number of
+    groups
+- For an `SLDS`, every regime must declare the same `depends_on` labels (the
+  grouping of trials is a property of the data, not of a regime); mismatched
+  declarations raise an `ArgumentError`. `x0`/`P0` remain tied across regimes
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/docs/src/LinearDynamicalSystems.md
+++ b/docs/src/LinearDynamicalSystems.md
@@ -375,3 +375,87 @@ fit!(lds, Y; max_iter=20, progress=false)
 ```
 
 Any subset works.
+
+## Parameters that depend on an ancillary variable
+
+Both sub-models carry a `depends_on` field. Leaving it `nothing` (the default)
+gives the usual behaviour: one parameter set shared by every trial. Setting it
+to a `NamedTuple` of per-trial label vectors makes the named parameters be
+**estimated separately for each group of trials**.
+
+The motivating case is stitching several recording sessions from one animal.
+The latent dynamics belong to the animal and should be pooled; the emissions
+belong to the session, because each session records a different set of neurons:
+
+```julia
+using LinearAlgebra, Random, StateSpaceDynamics
+
+session = vcat(fill(:day1, 20), fill(:day2, 15))   # one label per trial
+
+gsm = GaussianStateModel(A = A, Q = Q, b = b, x0 = x0, P0 = P0)
+gom = GaussianObservationModel(C = C, R = R, d = d)
+gom.depends_on = (C = session, R = session)        # C, d, D and R per session
+
+lds = LinearDynamicalSystem(gsm, gom)
+fit!(lds, Y; max_iter = 50)
+
+group_labels(gom, :C)                # [:day1, :day2]
+group_parameter(gom, :C, :day1)      # that session's emission matrix
+group_parameter(gom, :R, :day2)      # that session's observation noise
+```
+
+### Which names are valid
+
+Keys are canonicalized to the same groups `fit_bool` uses, because those
+parameters are fit jointly as one regression:
+
+| Key(s)           | Group                  | `fit_bool` index    |
+|:-----------------|:-----------------------|:--------------------|
+| `:x0`            | initial state mean     | 1                   |
+| `:P0`            | initial state cov      | 2                   |
+| `:A`, `:b`, `:B` | dynamics `[A b B]`     | 3                   |
+| `:Q`             | process noise          | 4                   |
+| `:C`, `:d`, `:D` | emission `[C d D]`     | 5                   |
+| `:R`             | observation noise      | 6 (Gaussian only)   |
+
+`:d` is therefore an alias for `:C`: naming either makes the whole `[C d D]`
+regression group-dependent. Naming two aliases of one group with different
+label vectors is an error.
+
+Labels can be `Symbol`s, integers or strings — anything comparable. Groups are
+ordered by first appearance in the vector set on the model.
+
+Different parameters may use different label vectors: `(Q = condition, C =
+session)` fits one `Q` per condition and one `[C d D]` per session.
+
+### Held-out data
+
+The label vectors live on the model and have one entry per fitted trial, so
+scoring a held-out set with a different trial count needs its own labels.
+`fit!`, `smooth`, `elbo`, `loglikelihood` and `rand` all take a `depends_on`
+keyword that overrides the stored labels for that call:
+
+```julia
+ll = loglikelihood(lds, Y_test; depends_on = (C = session_test, R = session_test))
+```
+
+An override re-assigns trials to groups the model already declares; it cannot
+introduce a new parameter set.
+
+### Priors, SLDS, and cost
+
+All versions of a parameter share the model's prior (`Q_prior`, `R_prior`,
+`CD_prior`, …), and each version contributes its own log-prior term to the
+ELBO.
+
+An `SLDS` supports the same field on each regime's sub-models. The grouping of
+trials is a property of the data, so every regime must declare the same labels;
+only the fitted values differ per regime. `x0` and `P0` stay tied across
+regimes, as they are for an ungrouped SLDS.
+
+Grouping does not give up the efficiency of equal-length epochs. Trials that
+share every parameter form a *cell*, and the smoother computes one covariance
+per cell and shares it across that cell's trials, exactly as it does across all
+trials of an ungrouped model. The expensive `O(D²·T)` workspace storage is
+allocated once and reused across cells, so a grouped fit's memory tracks an
+ungrouped one's rather than growing with the number of sessions.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -39,6 +39,13 @@ MNPrior
 x0_mean_prior
 ```
 
+## Ancillary parameter dependencies
+
+```@docs
+group_labels
+group_parameter
+```
+
 ## Sampling
 
 ```@docs; canonical = false

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -33,6 +33,7 @@ include("stats/priors.jl")
 # Model definitions + inference-state containers.
 include("lds/types.jl")                             # abstract types, model structs, SLDS
 include("lds/workspaces.jl")                        # FilterSmooth / SufficientStatistics / workspaces
+include("lds/parameter_groups.jl")                  # `depends_on` -> per-group parameter variants
 include("utils/show.jl")
 include("utils/validation.jl")
 
@@ -47,6 +48,9 @@ include("lds/continuous_latents.jl")                # state-model Q-term + state
 # Observation models + composite / standalone models.
 include("lds/gaussian_observations.jl")
 include("lds/poisson_observations.jl")
+
+# Grouped (`depends_on`) M-step + ELBO machinery, shared by LDS / PLDS / SLDS.
+include("lds/grouped_em.jl")
 
 # Fitting Functions
 include("lds/fit_LDS.jl")
@@ -64,6 +68,9 @@ export AbstractStateModel, AbstractObservationModel
 export GaussianStateModel, GaussianObservationModel, PoissonObservationModel
 export IWPrior, MNPrior, x0_mean_prior
 export CovUpdateCache
+
+# Ancillary parameter dependencies (`depends_on`)
+export group_labels, group_parameter
 
 # Utilities
 export block_tridgm

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -582,18 +582,27 @@ function update_initial_state_mean!(
     return nothing
 end
 
-function update_initial_state_covariance!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+"""
+    _accumulate_init_scatter!(S0, lds, suf)
+
+Add this model's initial-state scatter `Σγ(x₁-x0)(x₁-x0)' + Σγ P₁` to `S0`.
+
+Split out of `update_initial_state_covariance!` so the grouped M-step can sum
+the scatter across the cells that share a `P0`, each contributing with *its own*
+`x0` — which is what makes an `x0` grouping finer than the `P0` grouping come
+out right.
+"""
+function _accumulate_init_scatter!(
+    S0::AbstractMatrix{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    lds.fit_bool[2] || return nothing
     D = lds.latent_dim
     x0 = lds.state_model.x0
     N = suf.init_n
 
-    S0 = sws.reg.S0_sum                              # D × D scratch
-    copyto!(S0, suf.init_yy[])
+    S0 .+= suf.init_yy[]
 
-    # Scatter of the initial state around x0: S0 = Σγ(x₁-x0)(x₁-x0)' + Σγ P₁.
     # Rank-1 updates inline (BLAS.ger! would need a contiguous μ vector and
     # `view(init_xy, 1, :)` allocates a SubArray header — small but nonzero).
     for j in 1:D
@@ -605,35 +614,71 @@ function update_initial_state_covariance!(
             S0[i, j] += T(N) * x0_i * x0_j - x0_i * μ_j - μ_i * x0_j
         end
     end
+    return S0
+end
 
-    #=
-    Matrix-normal prior on x0 (the mean half of the NIW): fold κ₀(x0-μ₀)(x0-μ₀)'
-    into the IW scale, exactly as update_Q!/update_R! fold in their `Wm Λ Wm'`
-    term. Together with `P0_prior` (the IW half) this yields the NIW posterior
-    scale Ψₙ = Ψ + Σγ(x₁x₁'+P₁) + κ₀μ₀μ₀' - κₙ x0 x0'. `x0` must already hold the
-    NIW mean μₙ here (update_initial_state_mean! runs first in the M-step).
-    =#
+"""
+    _accumulate_x0_prior_scatter!(S0, lds)
+
+Add the mean half of the NIW prior, `κ₀(x0-μ₀)(x0-μ₀)'`, to the IW scale —
+exactly as `update_Q!`/`update_R!` fold in their `Wm Λ Wm'` term. Together with
+`P0_prior` (the IW half) this yields the NIW posterior scale
+`Ψₙ = Ψ + Σγ(x₁x₁'+P₁) + κ₀μ₀μ₀' - κₙ x0 x0'`. `x0` must already hold the NIW
+mean μₙ (`update_initial_state_mean!` runs first in the M-step).
+
+One call per distinct `x0`: when several `x0` versions share a `P0`, each
+contributes its own prior term.
+"""
+function _accumulate_x0_prior_scatter!(
+    S0::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     x0_prior = lds.state_model.x0_prior
-    if x0_prior !== nothing
-        κ₀ = x0_prior.Λ[1, 1]
-        μ₀ = x0_prior.M₀
-        for j in 1:D, i in 1:D
-            S0[i, j] += κ₀ * (x0[i] - μ₀[i, 1]) * (x0[j] - μ₀[j, 1])
-        end
+    x0_prior === nothing && return S0
+    D = lds.latent_dim
+    x0 = lds.state_model.x0
+    κ₀ = x0_prior.Λ[1, 1]
+    μ₀ = x0_prior.M₀
+    for j in 1:D, i in 1:D
+        S0[i, j] += κ₀ * (x0[i] - μ₀[i, 1]) * (x0[j] - μ₀[j, 1])
     end
-    Symmetrize!(S0)
+    return S0
+end
 
+"""
+    _finalize_P0!(lds, S0, N)
+
+Turn an accumulated initial-state scatter into `P0`: MLE `S0 / N`, or the IW MAP
+`(Ψ + S0) / (ν + N + D + 1)` when a `P0_prior` is set.
+"""
+function _finalize_P0!(
+    lds::LinearDynamicalSystem{T,S,O}, S0::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
     if lds.state_model.P0_prior === nothing
-        S0 ./= T(N)
+        S0 ./= N
     else
         Ψ, ν = lds.state_model.P0_prior.Ψ, lds.state_model.P0_prior.ν
         # iw_map inlined: (Ψ + S0) / (ν + N + D + 1)
-        denom = ν + T(N) + T(D + 1)
+        denom = ν + N + T(D + 1)
         for i in eachindex(S0)
             S0[i] = (Ψ[i] + S0[i]) / denom
         end
     end
     copyto!(lds.state_model.P0, S0)
+    return nothing
+end
+
+function update_initial_state_covariance!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    lds.fit_bool[2] || return nothing
+
+    S0 = sws.reg.S0_sum                              # D × D scratch
+    fill!(S0, zero(T))
+    _accumulate_init_scatter!(S0, lds, suf)
+    _accumulate_x0_prior_scatter!(S0, lds)
+    Symmetrize!(S0)
+    _finalize_P0!(lds, S0, T(suf.init_n))
     return nothing
 end
 
@@ -669,27 +714,49 @@ function update_A_b!(
     return nothing
 end
 
-function update_Q!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+"""
+    _pack_dyn_W!(W, lds)
+
+Write the stacked dynamics regression `[A b B]` into `W`
+(`latent_dim × (latent_dim + 1 + ux_dim)`).
+"""
+function _pack_dyn_W!(
+    W::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    lds.fit_bool[4] || return nothing
     D = lds.latent_dim
     ux_dim = lds.ux_dim
-
-    # sws.reg.AB is exactly (D × dyn_reg_dim); no view needed.
-    W = sws.reg.AB
     copyto!(view(W, :, 1:D), lds.state_model.A)
     copyto!(view(W, :, D + 1), lds.state_model.b)
     if ux_dim > 0
         copyto!(view(W, :, (D + 2):(D + 1 + ux_dim)), lds.state_model.B)
     end
+    return W
+end
 
-    # Residual scatter S = dyn_yy - W·dyn_xy - dyn_xy'·W' + W·dyn_xx·W'
+"""
+    _accumulate_dyn_scatter!(S_res, lds, suf, sws)
+
+Add this model's dynamics residual scatter
+`dyn_yy - W·dyn_xy - dyn_xy'·W' + W·dyn_xx·W'` (with `W = [A b B]`) to `S_res`.
+
+Split out of `update_Q!` so the grouped M-step can sum the scatter over the
+cells that share a `Q`, each contributing with its own `[A b B]`. Does **not**
+include the `AB_prior` term — that is one term per distinct `[A b B]`, added by
+`_accumulate_ab_prior_scatter!`.
+"""
+function _accumulate_dyn_scatter!(
+    S_res::AbstractMatrix{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
+    sws::SmoothWorkspace{T},
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    # sws.reg.AB is exactly (D × dyn_reg_dim); no view needed.
+    W = _pack_dyn_W!(sws.reg.AB, lds)
+
     Wxy = sws.elbo.temp                        # D × D scratch (free post-Q_state!)
     mul!(Wxy, W, suf.dyn_xy)
 
-    S_res = sws.reg.Q_sum                      # D × D scratch
-    copyto!(S_res, suf.dyn_yy[].mat)
+    S_res .+= suf.dyn_yy[].mat
     S_res .-= Wxy
     S_res .-= Wxy'
     #=
@@ -714,13 +781,36 @@ function update_Q!(
     copyto!(WL, W)
     BLAS.trmm!('R', 'U', 'T', 'N', one(T), suf.dyn_xx[].chol.factors, WL)
     mul!(S_res, WL, transpose(WL), one(T), one(T))
+    return S_res
+end
 
-    # MN-prior contribution to the IW posterior scale.
+"""
+    _accumulate_ab_prior_scatter!(S_res, lds, sws)
+
+Add the `AB_prior` contribution `Wm Λ Wm'` (`Wm = [A b B] - M₀`) to the IW
+posterior scale of `Q`. One call per distinct `[A b B]`.
+"""
+function _accumulate_ab_prior_scatter!(
+    S_res::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     AB_prior = lds.state_model.AB_prior
-    if AB_prior !== nothing
-        Wm = W .- AB_prior.M₀
-        S_res .+= Wm * AB_prior.Λ * Wm'
-    end
+    AB_prior === nothing && return S_res
+    W = _pack_dyn_W!(sws.reg.AB, lds)
+    Wm = W .- AB_prior.M₀
+    S_res .+= Wm * AB_prior.Λ * Wm'
+    return S_res
+end
+
+"""
+    _finalize_Q!(lds, S_res, N)
+
+Symmetrize an accumulated dynamics residual scatter and turn it into `Q`: MLE
+`S_res / N`, or the IW MAP `(Ψ + S_res) / (ν + N + D + 1)` under a `Q_prior`.
+"""
+function _finalize_Q!(
+    lds::LinearDynamicalSystem{T,S,O}, S_res::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
     #=
     Reflect upper → lower so the matrix is exactly symmetric. (`mul!`
     of `WL · WL'` above can give 1-ULP-asymmetric output; mirroring
@@ -733,7 +823,7 @@ function update_Q!(
 
     Q_prior = lds.state_model.Q_prior
     if Q_prior === nothing
-        S_res ./= T(suf.dyn_n)
+        S_res ./= N
     else
         #=
         iw_map(Ψ, ν, S, N, d) = (Ψ + S) / (ν + N + d + 1), inlined to
@@ -742,12 +832,25 @@ function update_Q!(
         `state_model.Q_prior` field), so we assert the concrete type
         locally to keep the loop type-stable.
         =#
-        denom = Q_prior.ν + T(suf.dyn_n) + T(D + 1)
+        denom = Q_prior.ν + N + T(D + 1)
         Ψ = Q_prior.Ψ::Matrix{T}
         for i in eachindex(S_res)
             S_res[i] = (Ψ[i] + S_res[i]) / denom
         end
     end
     copyto!(lds.state_model.Q, S_res)
+    return nothing
+end
+
+function update_Q!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    lds.fit_bool[4] || return nothing
+
+    S_res = sws.reg.Q_sum                      # D × D scratch
+    fill!(S_res, zero(T))
+    _accumulate_dyn_scatter!(S_res, lds, suf, sws)
+    _accumulate_ab_prior_scatter!(S_res, lds, sws)
+    _finalize_Q!(lds, S_res, T(suf.dyn_n))
     return nothing
 end

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -109,6 +109,10 @@ variant see `smooth!`).
 - `ux` / `uy`: optional dynamics / observation input sequences in the same
   shape family as `y`. Required when `size(state_model.B, 2) > 0` /
   `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 # Returns
 For a single-trial (matrix) `y`:
@@ -122,8 +126,11 @@ function smooth(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _grouped_smooth(lds, data, grp, y)
     tfs = _smooth_data(lds, data)
     return _collect_smooth_output(tfs, y)
 end
@@ -764,6 +771,10 @@ objective the M-step optimizes).
 - `ux` / `uy`: optional dynamics / observation input sequences in the same
   shape family as `y`. Required when `size(state_model.B, 2) > 0` /
   `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -772,8 +783,15 @@ function elbo(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    if grp !== nothing
+        sws_pool = _grouped_sws_pool(lds, data)
+        state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+        return _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+    end
     tfs = initialize_FilterSmooth(lds, data.tsteps)::TrialFilterSmooth{T}
     npool = min(Threads.maxthreadid(), length(data.y))
     sws_pool = [
@@ -837,6 +855,11 @@ Fit a Gaussian Linear Dynamical System via Expectation-Maximization.
   (each trial `(ux_dim, T_i)`); required when `size(state_model.B, 2) > 0`.
 - `uy`: optional observation-input sequence (same shape family) for the
   obs-side input matrix `D`. Required when `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` stored on the state / observation models for this call. Use it
+  to fit or score a dataset whose trial count differs from the one the labels
+  on the model were written for; it may only re-assign trials to groups the
+  model already declares.
 
 Returns a `Vector{T}` of ELBO values, one per iteration.
 """
@@ -848,9 +871,109 @@ function fit!(
     progress::Bool=true,
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _fit_tridiag_grouped!(
+        lds, data, grp; max_iter=max_iter, tol=tol, progress=progress
+    )
     return _fit_tridiag!(lds, data; max_iter=max_iter, tol=tol, progress=progress)
+end
+
+"""
+    _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+
+One grouped E-step: smooth and aggregate each cell with its own parameters, and
+return the total ELBO.
+
+Each cell runs the ordinary `estep!` on its sub-`Data`, so a cell whose trials
+are equal-length still computes its smoothed covariance once and shares it
+across the cell — the efficiency of same-length epochs is preserved *within*
+each group of labels rather than across the whole dataset (parameters differ
+between cells, so their covariances genuinely differ). The Q-terms are summed
+per cell while the workspace still holds that cell's Cholesky constants; the
+prior terms are added once per distinct parameter version.
+"""
+function _grouped_estep_elbo_gaussian!(
+    state::GroupedFitState{T,L},
+    grp::ParameterGrouping,
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {
+    T<:Real,
+    L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:GaussianObservationModel{T}},
+}
+    total = zero(T)
+    for c in 1:grp.ncells
+        lds_c = state.cell_lds[c]
+        suf_c = state.sufs[c]
+        _prepare_cell!(sws_pool[1], state, c)
+        estep!(lds_c, suf_c, state.cell_tfs[c], state.cell_data[c], sws_pool)
+
+        #=
+        `estep!` leaves the cell's constants on `sws_pool[1]` already, but the
+        parallel per-trial fallback reaches that state through a task, so
+        recompute explicitly rather than rely on which chunk ran last.
+        =#
+        compute_smooth_constants!(sws_pool[1], lds_c)
+        total += Q_state!(sws_pool[1], lds_c, suf_c)
+        total += Q_obs!(sws_pool[1], lds_c, suf_c)
+        for fs in state.cell_tfs[c].FilterSmooths
+            total += fs.entropy
+        end
+    end
+    total += _grouped_state_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    total += _grouped_gaussian_obs_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    return total
+end
+
+"""
+    _fit_tridiag_grouped!(lds, data, grp; max_iter, tol, progress)
+
+EM driver for a Gaussian LDS whose parameters depend on an ancillary variable.
+Identical in structure to [`_fit_tridiag!`](@ref): E-step, ELBO, M-step,
+convergence check — but the E-step runs per cell and the M-step pools each
+cell's sufficient statistics per parameter version.
+"""
+function _fit_tridiag_grouped!(
+    lds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping;
+    max_iter::Int=100,
+    tol::Float64=1e-6,
+    progress::Bool=true,
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    sws_pool = _grouped_sws_pool(lds, data)
+    state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+    elbos = Vector{T}(undef, max_iter)
+
+    prog = if progress
+        Progress(max_iter; desc="Fitting grouped LDS via EM...", barlen=50, showspeed=true)
+    else
+        nothing
+    end
+
+    for iter in 1:max_iter
+        elbos[iter] = _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+
+        _grouped_state_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+        _grouped_gaussian_obs_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+
+        prog !== nothing && next!(prog)
+
+        if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
+            prog !== nothing && finish!(prog)
+            resize!(elbos, iter)
+            return elbos
+        end
+    end
+
+    prog !== nothing && finish!(prog)
+    return elbos
 end
 
 function _fit_tridiag!(
@@ -1085,6 +1208,10 @@ see `_filter_cov_pass`. Trial lengths may differ.
 - `ux` / `uy`: optional dynamics / observation input sequences, in the same
   shape family as `y` (matrix, 3-D array, or vector of matrices). Required
   when `size(state_model.B, 2) > 0` / `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 This is the `StatsAPI.loglikelihood` method for the LDS; for the complete-data
 log-likelihood `log p(x, y)` given a trajectory `x`, see `joint_loglikelihood`.
@@ -1097,8 +1224,30 @@ function StatsAPI.loglikelihood(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,SM<:GaussianStateModel{T},OM<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+
+    #=
+    The filter's covariance pass depends only on the parameters and the trial
+    length, so it is shared across the trials of one cell exactly as it is
+    shared across all trials of an ungrouped model.
+    =#
+    if grp !== nothing
+        total_ll = zero(T)
+        for c in 1:grp.ncells
+            trials = grp.cell_trials[c]
+            lds_c = _cell_lds(lds, grp, c)
+            S_chol, K = _filter_cov_pass(lds_c, maximum(data.tsteps[n] for n in trials))
+            for n in trials
+                total_ll += _filter_ll_trial(
+                    lds_c, data.y[n], data.ux[n], data.uy[n], S_chol, K
+                )
+            end
+        end
+        return total_ll
+    end
 
     S_chol, K = _filter_cov_pass(lds, maximum(data.tsteps))
 

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -388,9 +388,15 @@ Suf-based Poisson ELBO. Mirrors the Gaussian TD path's split:
   term on the dynamics `[A b B]` (full `Q⁻¹` form, mirroring the Gaussian path),
   and the MN log-prior trace term on `[C d]` to match the LBFGS objective.
 """
-function elbo!(
+"""
+    _poisson_q_obs_total(plds, tfs, data, sws_pool)
+
+Observation-side Q-term summed over trials. The Poisson emission is
+irreducibly non-conjugate — there is no sufficient-statistic form — so this
+stays a per-trial loop, chunked across the workspace pool.
+"""
+function _poisson_q_obs_total(
     plds::LinearDynamicalSystem{T,S,O},
-    suf::SufficientStatistics{T},
     tfs::TrialFilterSmooth{T},
     data::Data{T},
     sws_pool::Vector{SmoothWorkspace{T}},
@@ -398,15 +404,6 @@ function elbo!(
     y = data.y
     uy = data.uy
     ntrials = length(y)
-
-    total_entropy = zero(T)
-    for fs in tfs.FilterSmooths
-        total_entropy += fs.entropy
-    end
-
-    compute_smooth_constants!(sws_pool[1], plds)
-    Q_state_total = Q_state!(sws_pool[1], plds, suf)
-
     ntasks = min(ntrials, length(sws_pool))
     partial = zeros(T, ntasks)
     chunksize = cld(ntrials, ntasks)
@@ -423,7 +420,24 @@ function elbo!(
         partial[i] = acc
         return nothing
     end
-    Q_obs_total = sum(partial)
+    return sum(partial)
+end
+
+function elbo!(
+    plds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
+    tfs::TrialFilterSmooth{T},
+    data::Data{T},
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
+    total_entropy = zero(T)
+    for fs in tfs.FilterSmooths
+        total_entropy += fs.entropy
+    end
+
+    compute_smooth_constants!(sws_pool[1], plds)
+    Q_state_total = Q_state!(sws_pool[1], plds, suf)
+    Q_obs_total = _poisson_q_obs_total(plds, tfs, data, sws_pool)
 
     prior_term = zero(T)
     if plds.state_model.Q_prior !== nothing
@@ -735,6 +749,10 @@ This is the same quantity `fit!` reports per iteration — a lower bound on the
 # Keywords
 - `newton_max_iter` / `newton_tol`: Newton-smoother iteration cap and
   convergence tolerance (as in `fit!`).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -745,8 +763,17 @@ function elbo(
     uy=nothing,
     newton_max_iter::Int=20,
     newton_tol::Float64=1e-6,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    if grp !== nothing
+        sws_pool = _grouped_sws_pool(plds, data)
+        state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+        return _grouped_estep_elbo_poisson!(
+            state, grp, sws_pool; max_iter=newton_max_iter, tol=T(newton_tol)
+        )
+    end
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
     npool = min(Threads.maxthreadid(), length(data.y))
     sws_pool = [
@@ -778,6 +805,10 @@ iterative-Newton `smooth!`).
 - `y`: observed counts — a `(obs_dim, T)` matrix (single trial), a
   `(obs_dim, T, ntrials)` array, or a `Vector{<:AbstractMatrix}` of per-trial
   `(obs_dim, T_i)` matrices (ragged lengths allowed).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 # Returns
 For a single-trial (matrix) `y`:
@@ -791,8 +822,11 @@ function smooth(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _grouped_smooth(plds, data, grp, y)
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
     # Cap the pool at the trial count — workspaces beyond ntrials are never
     # touched and each carries O(D²·T) of block-tridiagonal storage.
@@ -836,6 +870,10 @@ Fit a Poisson LDS via Laplace-EM.
 - `progress`: show progress bar
 - `newton_max_iter`: Newton iterations per E-step inner solve
 - `newton_tol`: Newton convergence tolerance
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 """
 function fit!(
     plds::LinearDynamicalSystem{T,S,O},
@@ -847,8 +885,20 @@ function fit!(
     progress=true,
     newton_max_iter::Int=20,
     newton_tol::Float64=1e-6,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _fit_plds_grouped!(
+        plds,
+        data,
+        grp;
+        max_iter=max_iter,
+        tol=tol,
+        progress=progress,
+        newton_max_iter=newton_max_iter,
+        newton_tol=newton_tol,
+    )
     T_max = maximum(data.tsteps)
 
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
@@ -891,6 +941,129 @@ function fit!(
         prog !== nothing && next!(prog)
 
         # check convergence
+        if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
+            prog !== nothing && finish!(prog)
+            resize!(elbos, iter)
+            return elbos
+        end
+    end
+
+    prog !== nothing && finish!(prog)
+    return elbos
+end
+
+"""
+    _grouped_estep_elbo_poisson!(state, grp, sws_pool; max_iter, tol)
+
+One grouped Laplace E-step for a Poisson LDS: smooth and aggregate each cell
+with its own parameters, and return the total ELBO. Mirrors
+`_grouped_estep_elbo_gaussian!`, but the observation-side Q-term stays a
+per-trial loop (the Poisson emission has no sufficient-statistic form).
+"""
+function _grouped_estep_elbo_poisson!(
+    state::GroupedFitState{T,L},
+    grp::ParameterGrouping,
+    sws_pool::Vector{SmoothWorkspace{T}};
+    max_iter::Int=20,
+    tol::T=T(1e-6),
+) where {
+    T<:Real,
+    L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:PoissonObservationModel{T}},
+}
+    total = zero(T)
+    for c in 1:grp.ncells
+        lds_c = state.cell_lds[c]
+        suf_c = state.sufs[c]
+        tfs_c = state.cell_tfs[c]
+        _prepare_cell!(sws_pool[1], state, c)
+        estep!(
+            lds_c, suf_c, tfs_c, state.cell_data[c], sws_pool; max_iter=max_iter, tol=tol
+        )
+
+        compute_smooth_constants!(sws_pool[1], lds_c)
+        total += Q_state!(sws_pool[1], lds_c, suf_c)
+        total += _poisson_q_obs_total(lds_c, tfs_c, state.cell_data[c], sws_pool)
+        for fs in tfs_c.FilterSmooths
+            total += fs.entropy
+        end
+    end
+    total += _grouped_state_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    total += _grouped_poisson_obs_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    return total
+end
+
+"""
+    _grouped_update_observation_model!(state, grp, data, sws_pool)
+
+Poisson emission M-step, once per version of `[C d D]`: the LBFGS solve runs on
+the trials of every cell that shares that version, so a `[C d D]` shared across
+cells is still fit from all of their data.
+"""
+function _grouped_update_observation_model!(
+    state::GroupedFitState{T},
+    grp::ParameterGrouping,
+    data::Data{T},
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {T<:Real}
+    for units in _units_by_slot(grp.cell_slot[_G_CD])
+        trials = Int[]
+        for c in units
+            append!(trials, grp.cell_trials[c])
+        end
+        sort!(trials)
+        tfs = TrialFilterSmooth([state.tfs_all[n] for n in trials])
+        update_observation_model!(
+            state.cell_lds[units[1]], tfs, data.y[trials], sws_pool; uy=data.uy[trials]
+        )
+    end
+    return nothing
+end
+
+"""
+    _fit_plds_grouped!(plds, data, grp; ...)
+
+Laplace-EM driver for a Poisson LDS whose parameters depend on an ancillary
+variable. Same structure as the ungrouped `fit!`: the state side flows through
+the pooled sufficient statistics, the emission through one LBFGS solve per
+`[C d D]` version.
+"""
+function _fit_plds_grouped!(
+    plds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping;
+    max_iter::Int=100,
+    tol::Float64=1e-6,
+    progress=true,
+    newton_max_iter::Int=20,
+    newton_tol::Float64=1e-6,
+) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
+    sws_pool = _grouped_sws_pool(plds, data)
+    state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+    elbos = Vector{T}(undef, max_iter)
+
+    prog = if progress
+        Progress(
+            max_iter;
+            desc="Fitting grouped Poisson LDS via LaPlaceEM...",
+            barlen=50,
+            showspeed=true,
+        )
+    else
+        nothing
+    end
+
+    for iter in 1:max_iter
+        elbos[iter] = _grouped_estep_elbo_poisson!(
+            state, grp, sws_pool; max_iter=newton_max_iter, tol=T(newton_tol)
+        )
+
+        _grouped_state_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+        _grouped_update_observation_model!(state, grp, data, sws_pool)
+
+        prog !== nothing && next!(prog)
+
         if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
             prog !== nothing && finish!(prog)
             resize!(elbos, iter)

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -70,6 +70,7 @@ function Random.rand(
     tsteps::Integer;
     ux::Union{Nothing,AbstractMatrix{T}}=nothing,
     uy::Union{Nothing,AbstractMatrix{T}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     lds1 = slds.LDSs[1]
     latent_dim = lds1.latent_dim
@@ -83,8 +84,18 @@ function Random.rand(
     x = Matrix{T}(undef, latent_dim, Ti)
     y = Matrix{T}(undef, obs_dim, Ti)
 
-    state_params = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
-    obs_params = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+    if depends_on === nothing && _has_parameter_dependence(lds1)
+        _single_trial_group_error("slds")
+    end
+    grp = _slds_parameter_grouping(slds, 1; depends_on=depends_on)
+    regimes = if grp === nothing
+        slds.LDSs
+    else
+        _slds_cell_sldss(slds, grp)[grp.trial_cell[1]].LDSs
+    end
+
+    state_params = [_extract_state_params(lds.state_model) for lds in regimes]
+    obs_params = [_extract_obs_params(lds.obs_model) for lds in regimes]
 
     _sample_slds_trial!(
         rng,
@@ -109,6 +120,7 @@ function Random.rand(
     tsteps_per_trial::AbstractVector{<:Integer};
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     lds1 = slds.LDSs[1]
     latent_dim = lds1.latent_dim
@@ -122,8 +134,27 @@ function Random.rand(
     x = Vector{Matrix{T}}(undef, ntrials)
     y = Vector{Matrix{T}}(undef, ntrials)
 
-    state_params = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
-    obs_params = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+    #=
+    Per-trial, per-regime parameter sets: one entry per trial, each a vector
+    over regimes. Ungrouped, every trial shares the same vector.
+    =#
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    if grp === nothing
+        base_state = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
+        base_obs = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+        state_of = fill(base_state, ntrials)
+        obs_of = fill(base_obs, ntrials)
+    else
+        cell_slds = _slds_cell_sldss(slds, grp)
+        cell_state = [
+            [_extract_state_params(lds.state_model) for lds in sc.LDSs] for sc in cell_slds
+        ]
+        cell_obs = [
+            [_extract_obs_params(lds.obs_model) for lds in sc.LDSs] for sc in cell_slds
+        ]
+        state_of = [cell_state[grp.trial_cell[n]] for n in 1:ntrials]
+        obs_of = [cell_obs[grp.trial_cell[n]] for n in 1:ntrials]
+    end
 
     for trial in 1:ntrials
         Ti = Int(tsteps_per_trial[trial])
@@ -137,8 +168,8 @@ function Random.rand(
             y[trial],
             slds.A,
             slds.πₖ,
-            state_params,
-            obs_params,
+            state_of[trial],
+            obs_of[trial],
             lds1.obs_model,
             ux_seq[trial],
             uy_seq[trial],
@@ -896,6 +927,110 @@ Gaussian emissions and no priors this equals the exact marginal log-likelihood.
 
 Returns a scalar. Overwrites `slds_ws.btd`'s Hessian blocks and `ll_tmp`.
 """
+"""
+    _slds_trial_elbo(slds, fs, fb_storage, y_trial, slds_ws, t1, t2, ux_trial, uy_trial)
+
+One trial's contribution to the SLDS ELBO (everything except the parameter
+log-prior). Split out of `elbo!` so the grouped path can evaluate each trial
+against its own cell's parameters after refreshing the regime constants.
+
+Assumes `slds_ws.consts` already holds the constants of `slds`.
+"""
+function _slds_trial_elbo(
+    slds::SLDS{T},
+    fs::FilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    y_trial::AbstractMatrix{T},
+    slds_ws::SLDSSmoothWorkspace{T},
+    t1::Int,
+    t2::Int,
+    ux_trial::Union{Nothing,AbstractMatrix{T}},
+    uy_trial::Union{Nothing,AbstractMatrix{T}},
+) where {T<:Real}
+    K = length(slds.LDSs)
+    Tsteps = t2 - t1 + 1
+    w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps
+
+    trial_elbo = zero(T)
+    x_smooth_trial = fs.x_smooth
+
+    # E_q[log p(y, x | z)], plug-in at the posterior mean, weighted by γ.
+    for k in 1:K
+        ll = view(slds_ws.ll_tmp, 1:Tsteps)
+        joint_loglikelihood!(
+            ll,
+            slds_ws,
+            slds_ws.consts[k],
+            slds.LDSs[k],
+            x_smooth_trial,
+            y_trial,
+            ux_trial,
+            uy_trial,
+        )
+        for t in 1:Tsteps
+            trial_elbo += w[k, t] * ll[t]
+        end
+    end
+
+    #=
+    ½ tr(H Σ) covariance correction. H = weighted Hessian (hessian! writes
+    it un-negated into slds_ws.btd); Σ = p_smooth on the diagonal,
+    p_smooth_tt1[:,:,t] = Cov(x_t, x_{t-1}) off it. Sum both off-diagonal
+    traces rather than doubling one — don't assume exact block symmetry.
+    =#
+    hessian!(slds_ws, slds, x_smooth_trial, y_trial, w, uy_trial)
+    H_diag = slds_ws.btd.H_diag
+    H_sub = slds_ws.btd.H_sub
+    H_super = slds_ws.btd.H_super
+    for t in 1:Tsteps
+        trial_elbo += T(0.5) * _tr_prod(H_diag[t], view(fs.p_smooth, :, :, t))
+    end
+    for t in 2:Tsteps
+        Σ_ttm1 = view(fs.p_smooth_tt1, :, :, t)  # Cov(x_t, x_{t-1})
+        trial_elbo += T(0.5) * _tr_prod(H_super[t - 1], Σ_ttm1)
+        trial_elbo += T(0.5) * _tr_prod(H_sub[t - 1], transpose(Σ_ttm1))
+    end
+
+    # E_q[log p(z_1)].
+    for k in 1:K
+        trial_elbo += w[k, 1] * log(slds.πₖ[k] + T(1e-12))
+    end
+
+    #=
+    E_q[log p(z_t | z_{t-1})] = Σ_t Σ_ij ξ_t[i,j] log A[i,j]. ξ is global-
+    indexed; ξ[t2] is zero by FB convention, so iterate t1..t2-1.
+    =#
+    for t in t1:(t2 - 1)
+        ξt = fb_storage.ξ[t]
+        for i in 1:K, j in 1:K
+            trial_elbo += ξt[i, j] * log(slds.A[i, j] + T(1e-12))
+        end
+    end
+
+    # + H[q(x)] (filled by `smooth!` from the BT log-determinant).
+    trial_elbo += fs.entropy
+
+    #=
+    + H[q(z)], the FB chain entropy
+    −Σ_k γ₁ log γ₁ − Σ_t Σ_ij ξ_t[i,j] (log ξ_t[i,j] − log γ_t[i]).
+    ξ_t[i,j] > 0 ⇒ γ_t[i] > 0, so both logs are safe.
+    =#
+    for k in 1:K
+        wk1 = w[k, 1]
+        wk1 > 0 && (trial_elbo -= wk1 * log(wk1))
+    end
+    for t in t1:(t2 - 1)
+        ξt = fb_storage.ξ[t]
+        tloc = t - t1 + 1
+        for i in 1:K, j in 1:K
+            ξij = ξt[i, j]
+            ξij > 0 && (trial_elbo -= ξij * (log(ξij) - log(w[i, tloc])))
+        end
+    end
+
+    return trial_elbo
+end
+
 function elbo!(
     slds::SLDS{T,S,O},
     tfs::TrialFilterSmooth{T},
@@ -908,95 +1043,20 @@ function elbo!(
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     total_elbo = zero(T)
     ntrials = length(y)
-    K = length(slds.LDSs)
 
     for trial in 1:ntrials
         t1, t2 = HMMs.seq_limits(seq_ends, trial)
-        Tsteps = t2 - t1 + 1
-        y_trial = y[trial]
-        ux_trial = ux === nothing ? nothing : ux[trial]
-        uy_trial = uy === nothing ? nothing : uy[trial]
-        w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps
-
-        trial_elbo = zero(T)
-        fs = tfs[trial]
-        x_smooth_trial = fs.x_smooth
-
-        # E_q[log p(y, x | z)], plug-in at the posterior mean, weighted by γ.
-        for k in 1:K
-            ll = view(slds_ws.ll_tmp, 1:Tsteps)
-            joint_loglikelihood!(
-                ll,
-                slds_ws,
-                slds_ws.consts[k],
-                slds.LDSs[k],
-                x_smooth_trial,
-                y_trial,
-                ux_trial,
-                uy_trial,
-            )
-            for t in 1:Tsteps
-                trial_elbo += w[k, t] * ll[t]
-            end
-        end
-
-        #=
-        ½ tr(H Σ) covariance correction. H = weighted Hessian (hessian! writes
-        it un-negated into slds_ws.btd); Σ = p_smooth on the diagonal,
-        p_smooth_tt1[:,:,t] = Cov(x_t, x_{t-1}) off it. Sum both off-diagonal
-        traces rather than doubling one — don't assume exact block symmetry.
-        =#
-        hessian!(slds_ws, slds, x_smooth_trial, y_trial, w, uy_trial)
-        H_diag = slds_ws.btd.H_diag
-        H_sub = slds_ws.btd.H_sub
-        H_super = slds_ws.btd.H_super
-        for t in 1:Tsteps
-            trial_elbo += T(0.5) * _tr_prod(H_diag[t], view(fs.p_smooth, :, :, t))
-        end
-        for t in 2:Tsteps
-            Σ_ttm1 = view(fs.p_smooth_tt1, :, :, t)  # Cov(x_t, x_{t-1})
-            trial_elbo += T(0.5) * _tr_prod(H_super[t - 1], Σ_ttm1)
-            trial_elbo += T(0.5) * _tr_prod(H_sub[t - 1], transpose(Σ_ttm1))
-        end
-
-        # E_q[log p(z_1)].
-        for k in 1:K
-            trial_elbo += w[k, 1] * log(slds.πₖ[k] + T(1e-12))
-        end
-
-        #=
-        E_q[log p(z_t | z_{t-1})] = Σ_t Σ_ij ξ_t[i,j] log A[i,j]. ξ is global-
-        indexed; ξ[t2] is zero by FB convention, so iterate t1..t2-1.
-        =#
-        for t in t1:(t2 - 1)
-            ξt = fb_storage.ξ[t]
-            for i in 1:K, j in 1:K
-                trial_elbo += ξt[i, j] * log(slds.A[i, j] + T(1e-12))
-            end
-        end
-
-        # + H[q(x)] (filled by `smooth!` from the BT log-determinant).
-        trial_elbo += fs.entropy
-
-        #=
-        + H[q(z)], the FB chain entropy
-        −Σ_k γ₁ log γ₁ − Σ_t Σ_ij ξ_t[i,j] (log ξ_t[i,j] − log γ_t[i]).
-        ξ_t[i,j] > 0 ⇒ γ_t[i] > 0, so both logs are safe.
-        =#
-        for k in 1:K
-            wk1 = w[k, 1]
-            wk1 > 0 && (trial_elbo -= wk1 * log(wk1))
-        end
-        for t in t1:(t2 - 1)
-            ξt = fb_storage.ξ[t]
-            tloc = t - t1 + 1
-            for i in 1:K, j in 1:K
-                ξij = ξt[i, j]
-                ξij > 0 && (trial_elbo -= ξij * (log(ξij) - log(w[i, tloc])))
-            end
-        end
-
-        total_elbo += trial_elbo
+        total_elbo += _slds_trial_elbo(
+            slds,
+            tfs[trial],
+            fb_storage,
+            y[trial],
+            slds_ws,
+            t1,
+            t2,
+            ux === nothing ? nothing : ux[trial],
+            uy === nothing ? nothing : uy[trial],
+        )
     end
 
     return total_elbo + _slds_prior_logdensity(slds)
@@ -1022,6 +1082,10 @@ reproducibility. This matches the first entry of the ELBO trace returned by
   matrices (ragged lengths allowed).
 - `ux` / `uy`: optional control inputs in the same shape family as `y`
   (`nothing` when the regimes carry no `B` / `D`). See [`fit!`](@ref).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -1031,6 +1095,7 @@ function elbo(
     ux=nothing,
     uy=nothing,
     rng::AbstractRNG=Random.default_rng(),
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     # `Data` centralizes shape validation and canonicalizes the three
     # observation/input forms (regime dims are uniform, so validating against
@@ -1046,6 +1111,9 @@ function elbo(
     total_T = last(seq_ends)
     T_max = maximum(data.tsteps)
 
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
+
     tfs = initialize_FilterSmooth(slds.LDSs[1], data.tsteps)::TrialFilterSmooth{T}
     dl = SLDSDiscreteLayer(slds.A, slds.πₖ, zeros(T, K, total_T))
     fb_storage = _make_slds_fb_storage(dl, seq_ends)
@@ -1056,18 +1124,44 @@ function elbo(
 
     # Warm-start q(x) with uniform weights, drawing the sample the E-step's
     # discrete update consumes (mirrors the fit! warm-start).
-    for trial in 1:ntrials
-        w_uniform = fill(one(T) / K, K, data.tsteps[trial])
-        smooth!(
-            slds,
-            tfs[trial],
-            y_seq[trial],
-            w_uniform;
-            ws=slds_ws,
-            x_sample=x_samples[trial],
+    _slds_warmstart!(
+        slds, cell_slds, grp, tfs, y_seq, x_samples, slds_ws, data.tsteps, K; rng=rng,
+        ux=ux_seq, uy=uy_seq,
+    )
+
+    if grp !== nothing
+        #=
+        Narrow the `Union{Nothing,...}` locals so the grouped helpers below are
+        called at their declared argument types.
+        =#
+        grouping = grp::ParameterGrouping
+        cells = cell_slds::Vector
+        _estep_grouped!(
+            cells,
+            grouping,
+            tfs,
+            fb_storage,
+            dl,
+            y_seq,
+            x_samples,
+            slds_ws;
             rng=rng,
-            ux=ux_seq[trial],
-            uy=uy_seq[trial],
+            obs_seq=obs_seq,
+            control_seq=control_seq,
+            seq_ends=seq_ends,
+            ux=ux_seq,
+            uy=uy_seq,
+        )
+        return _elbo_grouped!(
+            cells,
+            grouping,
+            tfs,
+            fb_storage,
+            y_seq,
+            slds_ws;
+            seq_ends=seq_ends,
+            ux=ux_seq,
+            uy=uy_seq,
         )
     end
 
@@ -1244,6 +1338,11 @@ Optional control inputs `ux` / `uy` accept the same shape family as `y`
 — the active regime `zₜ` selects which per-regime `Bₖ` / `Dₖ` multiplies the
 input — and are re-estimated per regime alongside the other parameters. The
 input dimensions must match across regimes (enforced by `validate_SLDS`).
+
+Pass `depends_on` (a `NamedTuple` of per-trial label vectors) to override the
+`depends_on` declared on the regimes' sub-models for this call. Every regime
+must declare the same labels — the grouping of trials is a property of the data
+— and `x0`/`P0` stay tied across regimes as usual.
 """
 function fit!(
     slds::SLDS{T,S,O},
@@ -1253,6 +1352,7 @@ function fit!(
     max_iter::Int=50,
     progress::Bool=true,
     rng::AbstractRNG=Random.default_rng(),
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     #=
     `Data` centralizes shape validation and canonicalizes the three
@@ -1273,6 +1373,13 @@ function fit!(
     seq_ends = cumsum(tsteps_per_trial)
     total_T = last(seq_ends)
     T_max = maximum(tsteps_per_trial)
+
+    #=
+    Ancillary parameter dependencies. `grp === nothing` (no regime declares
+    `depends_on`) keeps every step on its original code path.
+    =#
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
 
     # Continuous-state smoother storage (per-trial sized).
     tfs = initialize_FilterSmooth(slds.LDSs[1], tsteps_per_trial)::TrialFilterSmooth{T}
@@ -1312,21 +1419,10 @@ function fit!(
     Warm-start: smooth each trial once with uniform weights, drawing the first
     sample into x_samples for the first E-step to consume.
     =#
-    for trial in 1:ntrials
-        Ti = tsteps_per_trial[trial]
-        w_uniform = fill(one(T) / K, K, Ti)
-        smooth!(
-            slds,
-            tfs[trial],
-            y_seq[trial],
-            w_uniform;
-            ws=slds_ws,
-            x_sample=x_samples[trial],
-            rng=rng,
-            ux=ux_seq[trial],
-            uy=uy_seq[trial],
-        )
-    end
+    _slds_warmstart!(
+        slds, cell_slds, grp, tfs, y_seq, x_samples, slds_ws, tsteps_per_trial, K; rng=rng,
+        ux=ux_seq, uy=uy_seq,
+    )
 
     for iter in 1:max_iter
 
@@ -1334,41 +1430,93 @@ function fit!(
         E-step: fill q(z) from the current samples, run forward-backward,
         re-smooth q(x), and draw the next samples for the following iteration.
         =#
-        estep!(
-            slds,
-            tfs,
-            fb_storage,
-            dl,
-            y_seq,
-            x_samples,
-            slds_ws;
-            rng=rng,
-            obs_seq=obs_seq,
-            control_seq=control_seq,
-            seq_ends=seq_ends,
-            ux=ux_seq,
-            uy=uy_seq,
-        )
+        if grp === nothing
+            estep!(
+                slds,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                x_samples,
+                slds_ws;
+                rng=rng,
+                obs_seq=obs_seq,
+                control_seq=control_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
 
-        # Compute the ELBO at the current posteriors.
-        elbos[iter] = elbo!(
-            slds, tfs, fb_storage, y_seq, slds_ws; seq_ends=seq_ends, ux=ux_seq, uy=uy_seq
-        )
+            # Compute the ELBO at the current posteriors.
+            elbos[iter] = elbo!(
+                slds,
+                tfs,
+                fb_storage,
+                y_seq,
+                slds_ws;
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
 
-        # M-step: update discrete and continuous parameters.
-        mstep!(
-            slds,
-            tfs,
-            fb_storage,
-            dl,
-            y_seq,
-            sws;
-            obs_seq=obs_seq,
-            seq_ends=seq_ends,
-            ux=ux_seq,
-            uy=uy_seq,
-        )
-        refresh_slds_constants!(slds_ws, slds)
+            # M-step: update discrete and continuous parameters.
+            mstep!(
+                slds,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                sws;
+                obs_seq=obs_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+            refresh_slds_constants!(slds_ws, slds)
+        else
+            grouping = grp::ParameterGrouping
+            cells = cell_slds::Vector
+            _estep_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                x_samples,
+                slds_ws;
+                rng=rng,
+                obs_seq=obs_seq,
+                control_seq=control_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+
+            elbos[iter] = _elbo_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                y_seq,
+                slds_ws;
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+
+            _mstep_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                dl,
+                data,
+                sws;
+                obs_seq=obs_seq,
+                seq_ends=seq_ends,
+            )
+        end
 
         prog !== nothing && next!(prog)
     end
@@ -1377,4 +1525,411 @@ function fit!(
         finish!(prog)
     end
     return elbos
+end
+
+# ============================================================================
+# Ancillary parameter dependencies (`depends_on`) for the SLDS.
+#
+# The trial partition is a property of the *dataset*, so it must be identical
+# across regimes; only the parameter values differ per regime. Given that, each
+# cell is governed by one ordinary `SLDS` whose sub-LDSs hold that cell's
+# parameter arrays, and the existing smoother / weighted aggregator run on it
+# unchanged. Regime constants are refreshed once per cell rather than once per
+# trial, so the per-cell overhead is K Cholesky sets per pass.
+# ============================================================================
+
+"""
+    _slds_warmstart!(slds, cell_slds, grp, tfs, y, x_samples, slds_ws, tsteps, K; ...)
+
+Smooth every trial once with uniform discrete weights, drawing the first
+posterior sample the E-step's discrete update consumes. When `grp === nothing`
+this is the plain per-trial loop; otherwise trials are visited cell by cell so
+the regime constants are refreshed once per cell.
+"""
+function _slds_warmstart!(
+    slds::SLDS{T},
+    cell_slds::Union{Nothing,AbstractVector},
+    grp::Union{Nothing,ParameterGrouping},
+    tfs::TrialFilterSmooth{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T},
+    tsteps::AbstractVector{Int},
+    K::Int;
+    rng::AbstractRNG=Random.default_rng(),
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    function w_of(trial)
+        return fill(one(T) / K, K, tsteps[trial])
+    end
+
+    if grp === nothing || cell_slds === nothing
+        for trial in eachindex(y)
+            smooth!(
+                slds,
+                tfs[trial],
+                y[trial],
+                w_of(trial);
+                ws=slds_ws,
+                x_sample=x_samples[trial],
+                rng=rng,
+                ux=(ux === nothing ? nothing : ux[trial]),
+                uy=(uy === nothing ? nothing : uy[trial]),
+            )
+        end
+        return nothing
+    end
+
+    for c in 1:grp.ncells
+        _slds_smooth_cell!(
+            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+        )
+    end
+    return nothing
+end
+
+"""
+    _slds_parameter_grouping(slds, ntrials; depends_on=nothing)
+
+Trial partition for an `SLDS`, or `nothing` when no regime declares
+`depends_on`. Throws when the regimes disagree about the partition.
+"""
+function _slds_parameter_grouping(
+    slds::SLDS, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing
+)
+    grp = parameter_grouping(slds.LDSs[1], ntrials; depends_on=depends_on)
+    grp === nothing && return nothing
+    for k in 2:length(slds.LDSs)
+        grp_k = parameter_grouping(slds.LDSs[k], ntrials; depends_on=depends_on)
+        ok =
+            grp_k !== nothing &&
+            grp_k.nslots == grp.nslots &&
+            grp_k.cell_state == grp.cell_state &&
+            grp_k.cell_obs == grp.cell_obs &&
+            grp_k.trial_cell == grp.trial_cell
+        ok || throw(
+            ArgumentError(
+                "SLDS: every regime must declare the same `depends_on` labels; regime " *
+                "$k disagrees with regime 1. The grouping of trials is a property of " *
+                "the data and is shared across regimes — only the fitted parameter " *
+                "values differ per regime.",
+            ),
+        )
+    end
+    return grp
+end
+
+"""
+    _slds_cell_sldss(slds, grp) -> Vector{SLDS}
+
+One `SLDS` view per cell, sharing `A` and `πₖ` by reference (so the discrete
+M-step still updates the single shared chain) and holding each regime's
+per-cell parameter arrays.
+"""
+function _slds_cell_sldss(
+    slds::SLDS{T,S,O,TM,ISV}, grp::ParameterGrouping
+) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel,TM,ISV}
+    K = length(slds.LDSs)
+    return [
+        SLDS{T,S,O,TM,ISV}(
+            slds.A, slds.πₖ, [_cell_lds(slds.LDSs[k], grp, c) for k in 1:K]
+        ) for c in 1:grp.ncells
+    ]
+end
+
+"""
+    _slds_smooth_cell!(cell_slds, grp, cell, tfs, y, x_samples, slds_ws, w_of; rng, ux, uy)
+
+Smooth every trial of one cell after refreshing the workspace's regime constants
+for that cell's parameters. `w_of(trial)` supplies the `K × T` responsibilities.
+"""
+function _slds_smooth_cell!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    cell::Int,
+    tfs::TrialFilterSmooth{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T},
+    w_of;
+    rng::AbstractRNG=Random.default_rng(),
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    slds_c = cell_slds[cell]
+    refresh_slds_constants!(slds_ws, slds_c)
+    for trial in grp.cell_trials[cell]
+        smooth!(
+            slds_c,
+            tfs[trial],
+            y[trial],
+            w_of(trial);
+            ws=slds_ws,
+            x_sample=x_samples[trial],
+            rng=rng,
+            ux=(ux === nothing ? nothing : ux[trial]),
+            uy=(uy === nothing ? nothing : uy[trial]),
+        )
+    end
+    return nothing
+end
+
+"""
+    _estep_grouped!(cell_slds, grp, tfs, fb_storage, dl, y, x_samples, slds_ws; ...)
+
+Grouped SLDS E-step. Same three moves as `estep!` — fill `dl.logL` from the
+previous posterior sample, run forward-backward, re-smooth `q(x)` — but each
+pass iterates cells so the regime constants are refreshed once per cell. The
+forward-backward call stays global: the discrete chain is shared by all trials.
+"""
+function _estep_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    dl::SLDSDiscreteLayer{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T};
+    rng::AbstractRNG=Random.default_rng(),
+    obs_seq::AbstractVector,
+    control_seq::AbstractVector,
+    seq_ends::AbstractVector{Int},
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+
+    for c in 1:grp.ncells
+        slds_c = cell_slds[c]
+        refresh_slds_constants!(slds_ws, slds_c)
+        for trial in grp.cell_trials[c]
+            t1, t2 = HMMs.seq_limits(seq_ends, trial)
+            for k in 1:K
+                joint_loglikelihood!(
+                    view(dl.logL, k, t1:t2),
+                    slds_ws,
+                    slds_ws.consts[k],
+                    slds_c.LDSs[k],
+                    x_samples[trial],
+                    y[trial],
+                    (ux === nothing ? nothing : ux[trial]),
+                    (uy === nothing ? nothing : uy[trial]),
+                )
+            end
+        end
+    end
+
+    HMMs.forward_backward!(
+        fb_storage, dl, obs_seq, control_seq; seq_ends=seq_ends, transition_marginals=true
+    )
+
+    function w_of(trial)
+        t1, t2 = HMMs.seq_limits(seq_ends, trial)
+        return view(fb_storage.γ, :, t1:t2)
+    end
+
+    for c in 1:grp.ncells
+        _slds_smooth_cell!(
+            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+        )
+    end
+
+    return nothing
+end
+
+"""
+    _grouped_slds_prior_logdensity(cell_slds, grp, T)
+
+`log p(θ)` for a grouped SLDS: the per-regime terms of
+[`_slds_prior_logdensity`](@ref), counted once per distinct parameter version
+instead of once per regime.
+"""
+function _grouped_slds_prior_logdensity(
+    cell_slds::AbstractVector, grp::ParameterGrouping, ::Type{T}
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+    total = zero(T)
+    for k in 1:K
+        ldss = [cell_slds[c].LDSs[k] for c in 1:grp.ncells]
+        total += _grouped_state_prior_logdensity(ldss, grp.cell_slot, T)
+        if ldss[1].obs_model isa GaussianObservationModel
+            total += _grouped_gaussian_obs_prior_logdensity(ldss, grp.cell_slot, T)
+        else
+            total += _grouped_poisson_obs_prior_logdensity(ldss, grp.cell_slot, T)
+        end
+    end
+    return total
+end
+
+"""
+    _elbo_grouped!(cell_slds, grp, tfs, fb_storage, y, slds_ws; seq_ends, ux, uy)
+
+Grouped SLDS ELBO: each trial's contribution evaluated against its cell's
+parameters, plus one prior term per distinct parameter version.
+"""
+function _elbo_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    y::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T};
+    seq_ends::AbstractVector{Int},
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    total_elbo = zero(T)
+    for c in 1:grp.ncells
+        slds_c = cell_slds[c]
+        refresh_slds_constants!(slds_ws, slds_c)
+        for trial in grp.cell_trials[c]
+            t1, t2 = HMMs.seq_limits(seq_ends, trial)
+            total_elbo += _slds_trial_elbo(
+                slds_c,
+                tfs[trial],
+                fb_storage,
+                y[trial],
+                slds_ws,
+                t1,
+                t2,
+                (ux === nothing ? nothing : ux[trial]),
+                (uy === nothing ? nothing : uy[trial]),
+            )
+        end
+    end
+    return total_elbo + _grouped_slds_prior_logdensity(cell_slds, grp, T)
+end
+
+"""
+    _broadcast_initial_state!(cell_slds, K, do_x0, do_P0)
+
+Copy regime 1's initial-state parameters into every other regime. `x0`/`P0` are
+tied across regimes, and the grouped update writes only into regime 1's
+variants, so this restores the tie — including before the `P0` update, whose
+scatter reads each unit's own `x0`.
+"""
+function _broadcast_initial_state!(
+    cell_slds::AbstractVector, K::Int, do_x0::Bool, do_P0::Bool
+)
+    (do_x0 || do_P0) || return nothing
+    for slds_c in cell_slds
+        src = slds_c.LDSs[1].state_model
+        for k in 2:K
+            dst = slds_c.LDSs[k].state_model
+            do_x0 && copyto!(dst.x0, src.x0)
+            do_P0 && copyto!(dst.P0, src.P0)
+        end
+    end
+    return nothing
+end
+
+"""
+    _mstep_grouped!(cell_slds, grp, tfs, fb_storage, dl, data, sws; obs_seq, seq_ends)
+
+Grouped SLDS M-step.
+
+The discrete layer and the trial partition are shared, so the work is one
+γ-weighted sufficient statistic per (regime, cell). Dynamics and emissions are
+per regime, so they are pooled across the cells that share a version *within* a
+regime; `x0`/`P0` are tied across regimes, so they are pooled across every
+(regime, cell) unit that shares a version.
+
+Units are laid out regime-major, which makes the first unit of any parameter
+version belong to regime 1 — the update writes there and
+`_broadcast_initial_state!` restores the tie.
+"""
+function _mstep_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    dl::SLDSDiscreteLayer{T},
+    data::Data{T},
+    sws::SmoothWorkspace{T};
+    obs_seq::AbstractVector,
+    seq_ends::AbstractVector{Int},
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+    ncells = grp.ncells
+    lds1 = cell_slds[1].LDSs[1]
+
+    # Discrete-layer M-step (slds.A, slds.πₖ are updated in place via dl).
+    StatsAPI.fit!(dl, fb_storage, obs_seq; seq_ends=seq_ends)
+
+    cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
+    cell_tfs = [
+        TrialFilterSmooth([tfs[n] for n in grp.cell_trials[c]]) for c in 1:ncells
+    ]
+    bufs = GroupedSufBuffers(T, lds1, data.tsteps)
+
+    function γ_view(k, trial)
+        t1, t2 = HMMs.seq_limits(seq_ends, trial)
+        return view(fb_storage.γ, k, t1:t2)
+    end
+
+    unit_lds = [cell_slds[c].LDSs[k] for k in 1:K for c in 1:ncells]
+    unit_suf = [
+        _initialize_td_sufficient_statistics(T, lds1, cell_data[c].tsteps) for k in 1:K for
+        c in 1:ncells
+    ]
+
+    for k in 1:K
+        for c in 1:ncells
+            u = (k - 1) * ncells + c
+            weights = [γ_view(k, n) for n in grp.cell_trials[c]]
+            _aggregate_td_suff_stats_weighted!(
+                unit_suf[u], cell_tfs[c], unit_lds[u], cell_data[c], weights, sws
+            )
+        end
+
+        rows = ((k - 1) * ncells + 1):(k * ncells)
+        ldss_k = view(unit_lds, rows)
+        sufs_k = view(unit_suf, rows)
+
+        _grouped_update_A_b!(ldss_k, sufs_k, grp.cell_slot[_G_AB], sws, bufs)
+        _grouped_update_Q!(ldss_k, sufs_k, grp.cell_slot[_G_Q], grp.cell_slot[_G_AB], sws)
+
+        if lds1.obs_model isa GaussianObservationModel{T}
+            _grouped_update_C_d!(ldss_k, sufs_k, grp.cell_slot[_G_CD], sws, bufs)
+            _grouped_update_R!(
+                ldss_k, sufs_k, grp.cell_slot[_G_R], grp.cell_slot[_G_CD], sws
+            )
+        elseif lds1.obs_model isa PoissonObservationModel{T}
+            # Non-conjugate: one LBFGS solve per `[C d D]` version, over the
+            # γ-weighted trials of every cell sharing that version.
+            for units in _units_by_slot(grp.cell_slot[_G_CD])
+                trials = Int[]
+                for c in units
+                    append!(trials, grp.cell_trials[c])
+                end
+                sort!(trials)
+                update_observation_model!(
+                    ldss_k[units[1]],
+                    TrialFilterSmooth([tfs[n] for n in trials]),
+                    data.y[trials],
+                    [sws],
+                    [γ_view(k, n) for n in trials];
+                    uy=data.uy[trials],
+                )
+            end
+        else
+            throw(ArgumentError("Unsupported observation model $(typeof(lds1.obs_model))"))
+        end
+    end
+
+    #=
+    Tied initial state, pooled over every (regime, cell) unit. Since
+    Σₖ γₖ(t=1) = 1, summing the per-regime weighted init stats reproduces the
+    unit-weight pooled statistic the ungrouped path uses.
+    =#
+    slots_x0 = repeat(grp.cell_slot[_G_X0], K)
+    slots_P0 = repeat(grp.cell_slot[_G_P0], K)
+    _grouped_update_x0!(unit_lds, unit_suf, slots_x0, bufs)
+    _broadcast_initial_state!(cell_slds, K, lds1.fit_bool[_G_X0], false)
+    _grouped_update_P0!(unit_lds, unit_suf, slots_P0, slots_x0, sws)
+    _broadcast_initial_state!(cell_slds, K, false, lds1.fit_bool[_G_P0])
+
+    return nothing
 end

--- a/src/lds/gaussian_observations.jl
+++ b/src/lds/gaussian_observations.jl
@@ -163,28 +163,49 @@ function update_C_d!(
     return nothing
 end
 
-function update_R!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
-) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    lds.fit_bool[6] || return nothing
-    p = lds.obs_dim
+"""
+    _pack_obs_V!(V, lds)
+
+Write the stacked emission regression `[C d D]` into `V`
+(`obs_dim × (latent_dim + 1 + uy_dim)`).
+"""
+function _pack_obs_V!(
+    V::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     D = lds.latent_dim
     uy_dim = lds.uy_dim
-
-    # sws.reg.CD is exactly (p × obs_reg_dim); no view needed.
-    V = sws.reg.CD
     copyto!(view(V, :, 1:D), lds.obs_model.C)
     copyto!(view(V, :, D + 1), lds.obs_model.d)
     if uy_dim > 0
         copyto!(view(V, :, (D + 2):(D + 1 + uy_dim)), lds.obs_model.D)
     end
+    return V
+end
 
-    # Residual scatter S = obs_yy - V·obs_xy - obs_xy'·V' + V·obs_xx·V'
+"""
+    _accumulate_obs_scatter!(S_res, lds, suf, sws)
+
+Add this model's emission residual scatter
+`obs_yy - V·obs_xy - obs_xy'·V' + V·obs_xx·V'` (with `V = [C d D]`) to `S_res`.
+
+Split out of `update_R!` so the grouped M-step can sum the scatter over the
+cells that share an `R`, each contributing with its own `[C d D]`. Does **not**
+include the `CD_prior` term — that is one term per distinct `[C d D]`, added by
+`_accumulate_cd_prior_scatter!`.
+"""
+function _accumulate_obs_scatter!(
+    S_res::AbstractMatrix{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
+    sws::SmoothWorkspace{T},
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    # sws.reg.CD is exactly (p × obs_reg_dim); no view needed.
+    V = _pack_obs_V!(sws.reg.CD, lds)
+
     Vxy = sws.elbo.obs_temp                    # p × p scratch (free post-Q_obs!)
     mul!(Vxy, V, suf.obs_xy)
 
-    S_res = sws.elbo.obs_work                  # p × p scratch
-    copyto!(S_res, suf.obs_yy[].mat)
+    S_res .+= suf.obs_yy[].mat
     S_res .-= Vxy
     S_res .-= Vxy'
     #=
@@ -205,24 +226,60 @@ function update_R!(
     copyto!(VL, V)
     BLAS.trmm!('R', 'U', 'T', 'N', one(T), suf.obs_xx[].chol.factors, VL)
     mul!(S_res, VL, transpose(VL), one(T), one(T))
+    return S_res
+end
 
+"""
+    _accumulate_cd_prior_scatter!(S_res, lds, sws)
+
+Add the `CD_prior` contribution `Wm Λ Wm'` (`Wm = [C d D] - M₀`) to the IW
+posterior scale of `R`. One call per distinct `[C d D]`.
+"""
+function _accumulate_cd_prior_scatter!(
+    S_res::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     CD_prior = lds.obs_model.CD_prior
-    if CD_prior !== nothing
-        Wm = V .- CD_prior.M₀
-        S_res .+= Wm * CD_prior.Λ * Wm'
-    end
+    CD_prior === nothing && return S_res
+    V = _pack_obs_V!(sws.reg.CD, lds)
+    Wm = V .- CD_prior.M₀
+    S_res .+= Wm * CD_prior.Λ * Wm'
+    return S_res
+end
 
+"""
+    _finalize_R!(lds, S_res, N)
+
+Symmetrize an accumulated emission residual scatter and turn it into `R`: MLE
+`S_res / N`, or the IW MAP under an `R_prior`.
+"""
+function _finalize_R!(
+    lds::LinearDynamicalSystem{T,S,O}, S_res::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    p = lds.obs_dim
     for j in 2:p, i in 1:(j - 1)
         S_res[j, i] = S_res[i, j]
     end
 
     if lds.obs_model.R_prior === nothing
-        S_res ./= T(suf.obs_n)
+        S_res ./= N
     else
         Ψ, ν = lds.obs_model.R_prior.Ψ, lds.obs_model.R_prior.ν
-        S_res .= iw_map(Ψ, ν, S_res, T(suf.obs_n), p)
+        S_res .= iw_map(Ψ, ν, S_res, N, p)
     end
     copyto!(lds.obs_model.R, S_res)
+    return nothing
+end
+
+function update_R!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    lds.fit_bool[6] || return nothing
+
+    S_res = sws.elbo.obs_work                  # p × p scratch
+    fill!(S_res, zero(T))
+    _accumulate_obs_scatter!(S_res, lds, suf, sws)
+    _accumulate_cd_prior_scatter!(S_res, lds, sws)
+    _finalize_R!(lds, S_res, T(suf.obs_n))
     return nothing
 end
 

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -1,0 +1,650 @@
+#=============================================================================
+Grouped M-step and ELBO for models with `depends_on` set.
+
+The E-step needs no group-specific code: the trials of one cell share every
+parameter, so the ordinary smoother + sufficient-statistics aggregator runs on
+each cell's sub-`Data` unchanged (see `parameter_groups.jl`). What is left is
+
+  * pooling the per-cell sufficient statistics per parameter *version*, and
+  * evaluating the prior terms once per parameter version rather than once per
+    cell.
+
+Both are written against a flat list of "units". A unit is one thing that
+produced a `SufficientStatistics`: a cell for a `LinearDynamicalSystem`, or a
+(regime, cell) pair for an `SLDS`. Each unit carries the `LinearDynamicalSystem`
+holding its parameter arrays and, per parameter group, the slot index it uses.
+Parameters shared by several units are the *same array object*, so writing
+through any one of those units updates all of them.
+=============================================================================#
+
+# Parameter-group ordinals; identical to the `fit_bool` layout.
+const _G_X0 = 1
+const _G_P0 = 2
+const _G_AB = 3
+const _G_Q = 4
+const _G_CD = 5
+const _G_R = 6
+
+"""
+    GroupedSufBuffers{T}
+
+Scratch for pooling per-cell sufficient statistics into one parameter version.
+Only the blocks the regression updates read are pooled (`init_n`/`init_xy`,
+`dyn_xx`/`dyn_xy`, `obs_xx`/`obs_xy`); the covariance updates never need a
+pooled `*_yy` because they accumulate the residual scatter cell by cell, each
+with its own regression matrix. That also avoids taking a Cholesky of a pooled
+`obs_yy`, which can be rank-deficient for a small group.
+"""
+struct GroupedSufBuffers{T<:Real}
+    suf::SufficientStatistics{T}
+    init_yy::Matrix{T}
+    dyn_xx::Matrix{T}
+    obs_xx::Matrix{T}
+end
+
+function GroupedSufBuffers(
+    ::Type{T}, lds::LinearDynamicalSystem{T}, tsteps_per_trial::AbstractVector{Int}
+) where {T<:Real}
+    D = lds.latent_dim
+    dyn_reg_dim = D + 1 + lds.ux_dim
+    obs_reg_dim = D + 1 + lds.uy_dim
+    return GroupedSufBuffers{T}(
+        _initialize_td_sufficient_statistics(T, lds, tsteps_per_trial),
+        zeros(T, D, D),
+        zeros(T, dyn_reg_dim, dyn_reg_dim),
+        zeros(T, obs_reg_dim, obs_reg_dim),
+    )
+end
+
+#=
+Pooling. A version backed by a single unit reuses that unit's statistics
+verbatim, which keeps a fit whose groups happen to be singletons numerically
+identical to the corresponding ungrouped fit.
+=#
+function _pool_init!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.init_xy, zero(T))
+    M = bufs.init_yy
+    fill!(M, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.init_n)
+        suf.init_xy .+= src.init_xy
+        M .+= src.init_yy[]
+    end
+    suf.init_n = n
+    suf.init_yy[] = M
+    return suf
+end
+
+function _pool_dyn!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.dyn_xy, zero(T))
+    XX = bufs.dyn_xx
+    fill!(XX, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.dyn_n)
+        suf.dyn_xy .+= src.dyn_xy
+        XX .+= src.dyn_xx[].mat
+    end
+    suf.dyn_n = n
+    Symmetrize!(XX)
+    suf.dyn_xx[] = PDMat(copy(XX))
+    return suf
+end
+
+function _pool_obs!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.obs_xy, zero(T))
+    XX = bufs.obs_xx
+    fill!(XX, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.obs_n)
+        suf.obs_xy .+= src.obs_xy
+        XX .+= src.obs_xx[].mat
+    end
+    suf.obs_n = n
+    Symmetrize!(XX)
+    suf.obs_xx[] = PDMat(copy(XX))
+    return suf
+end
+
+"""
+    CellConstBlocks{T}
+
+The data-only aggregator constants (`Σ y y'`, the bias/`uy` blocks of `obs_xx`
+and `obs_xy`, the bias/`ux` blocks of `dyn_xx`) for one cell.
+
+A grouped fit shares a single `SmoothWorkspace` pool across cells — the O(D²·T)
+block-tridiagonal and shared-covariance storage is the expensive part and is
+safe to reuse, because a cell's smoothed covariances are consumed by its own
+aggregation before the next cell overwrites them. These blocks, by contrast, are
+per-cell and must survive between iterations, so they are cached here (all of
+them are small: no `tsteps` dimension) and copied back in before each cell's
+aggregation instead of being recomputed every E-step.
+"""
+struct CellConstBlocks{T<:Real}
+    obs_yy::Matrix{T}
+    obs_xy::Matrix{T}
+    obs_xx::Matrix{T}
+    dyn_xx::Matrix{T}
+end
+
+"""
+    _cache_const_blocks!(sws, lds, data) -> CellConstBlocks
+
+Run `_td_init_const_blocks!` for one cell and take a copy of the result.
+"""
+function _cache_const_blocks!(
+    sws::SmoothWorkspace{T}, lds::LinearDynamicalSystem{T}, data::Data{T}
+) where {T<:Real}
+    _td_init_const_blocks!(sws, lds, data)
+    return CellConstBlocks{T}(
+        copy(sws.agg.obs_yy_const),
+        copy(sws.agg.obs_xy_const),
+        copy(sws.agg.obs_xx_const),
+        copy(sws.agg.dyn_xx_const),
+    )
+end
+
+"""
+    _restore_const_blocks!(sws, blocks)
+
+Copy a cell's cached aggregator constants back into the shared workspace.
+"""
+function _restore_const_blocks!(
+    sws::SmoothWorkspace{T}, blocks::CellConstBlocks{T}
+) where {T<:Real}
+    copyto!(sws.agg.obs_yy_const, blocks.obs_yy)
+    copyto!(sws.agg.obs_xy_const, blocks.obs_xy)
+    copyto!(sws.agg.obs_xx_const, blocks.obs_xx)
+    copyto!(sws.agg.dyn_xx_const, blocks.dyn_xx)
+    return sws
+end
+
+"""
+    GroupedFitState{T,L,DT}
+
+Everything a grouped EM fit needs per cell: the cell's `LinearDynamicalSystem`
+view, its sub-`Data`, its slice of the per-trial smoother output, its
+sufficient statistics, its cached aggregator constants, and (Gaussian only) its
+batched mean-pass buffers.
+
+`tfs_all` holds the same `FilterSmooth` objects as `cell_tfs`, in original trial
+order, for the callers that need results per trial rather than per cell.
+"""
+struct GroupedFitState{T<:Real,L,DT}
+    cell_lds::Vector{L}
+    cell_data::Vector{DT}
+    cell_tfs::Vector{TrialFilterSmooth{T}}
+    tfs_all::TrialFilterSmooth{T}
+    sufs::Vector{SufficientStatistics{T}}
+    cell_consts::Vector{CellConstBlocks{T}}
+    cell_batched::Vector{Union{Nothing,BatchedBuffers{T}}}
+    bufs::GroupedSufBuffers{T}
+end
+
+"""
+    _grouped_fit_state(lds, data, grp, sws; batched=false)
+
+Build the per-cell fit state. `batched=true` additionally allocates each cell's
+BLAS-3 mean-pass buffers (Gaussian path only, and only for cells whose trials
+are equal-length and plural); their total footprint is proportional to the
+number of trials, so it matches an ungrouped fit's.
+"""
+function _grouped_fit_state(
+    lds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping,
+    sws::SmoothWorkspace{T};
+    batched::Bool=false,
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    ncells = grp.ncells
+    ntrials = length(data.y)
+    cell_lds = _cell_ldss(lds, grp)
+    cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
+
+    #=
+    Per-trial smoother storage. `cov_alias` is decided per cell: the smoother
+    aliases every equal-length trial's `p_smooth` to the shared cache, so those
+    trials would otherwise each carry a dead (D, D, T) allocation.
+    =#
+    fs_all = Vector{FilterSmooth{T}}(undef, ntrials)
+    cell_batched = Vector{Union{Nothing,BatchedBuffers{T}}}(undef, ncells)
+    for c in 1:ncells
+        trials = grp.cell_trials[c]
+        tsteps = data.tsteps[trials]
+        equal_len = length(trials) > 1 && all(t -> t == tsteps[1], tsteps)
+        alias = batched && equal_len
+        for (i, n) in enumerate(trials)
+            fs_all[n] = initialize_FilterSmooth(lds, tsteps[i]; cov_alias=alias)
+        end
+        cell_batched[c] = if batched && equal_len
+            BatchedBuffers(
+                T,
+                lds.latent_dim,
+                lds.obs_dim,
+                tsteps[1],
+                length(trials);
+                ux_dim=lds.ux_dim,
+                uy_dim=lds.uy_dim,
+            )
+        else
+            nothing
+        end
+    end
+
+    cell_tfs = [
+        TrialFilterSmooth([fs_all[n] for n in grp.cell_trials[c]]) for c in 1:ncells
+    ]
+    sufs = [
+        _initialize_td_sufficient_statistics(T, cell_lds[c], cell_data[c].tsteps) for
+        c in 1:ncells
+    ]
+    cell_consts = [_cache_const_blocks!(sws, cell_lds[c], cell_data[c]) for c in 1:ncells]
+
+    return GroupedFitState(
+        cell_lds,
+        cell_data,
+        cell_tfs,
+        TrialFilterSmooth(fs_all),
+        sufs,
+        cell_consts,
+        cell_batched,
+        GroupedSufBuffers(T, lds, data.tsteps),
+    )
+end
+
+"""
+    _prepare_cell!(sws, state, cell)
+
+Point the shared workspace at one cell: swap in that cell's batched buffers and
+restore its aggregator constants.
+"""
+function _prepare_cell!(sws::SmoothWorkspace, state::GroupedFitState, cell::Int)
+    sws.batched = state.cell_batched[cell]
+    _restore_const_blocks!(sws, state.cell_consts[cell])
+    return sws
+end
+
+"""
+    _grouped_sws_pool(lds, data)
+
+Workspace pool shared by every cell of a grouped fit. Sized at the longest trial
+across all cells; `batched` stays `nothing` here because each cell's BLAS-3
+buffers are swapped in from the `GroupedFitState` by `_prepare_cell!`.
+
+Sharing the pool is what keeps a grouped fit's memory at the ungrouped fit's
+level: the O(D²·T) block-tridiagonal and shared-covariance storage is allocated
+once rather than once per group, which matters when the groups are recording
+sessions and there are dozens of them.
+"""
+function _grouped_sws_pool(lds::LinearDynamicalSystem{T}, data::Data{T}) where {T<:Real}
+    T_max = maximum(data.tsteps)
+    npool = min(Threads.maxthreadid(), length(data.y))
+    return [
+        SmoothWorkspace(
+            T, lds.latent_dim, lds.obs_dim, T_max; ux_dim=lds.ux_dim, uy_dim=lds.uy_dim
+        ) for _ in 1:npool
+    ]
+end
+
+"""
+    _grouped_smooth(lds, data, grp, y)
+
+Smooth each cell with its own parameters and reassemble the results in the
+original trial order. Results are copied out per cell before the next one runs:
+the equal-length fast path aliases every trial's `p_smooth` to the workspace's
+shared covariance cache, which the next cell overwrites.
+"""
+function _grouped_smooth(
+    lds::LinearDynamicalSystem{T}, data::Data{T}, grp::ParameterGrouping, y
+) where {T<:Real}
+    ntrials = length(data.y)
+    xs = Vector{Matrix{T}}(undef, ntrials)
+    Ps = Vector{Array{T,3}}(undef, ntrials)
+    sws_pool = _grouped_sws_pool(lds, data)
+
+    for c in 1:grp.ncells
+        trials = grp.cell_trials[c]
+        cell_data = _subset_data(data, trials)
+        tfs = initialize_FilterSmooth(lds, cell_data.tsteps)::TrialFilterSmooth{T}
+        smooth!(_cell_lds(lds, grp, c), tfs, cell_data, sws_pool)
+        for (i, n) in enumerate(trials)
+            xs[n] = copy(tfs[i].x_smooth)
+            Ps[n] = copy(tfs[i].p_smooth)
+        end
+    end
+
+    return _grouped_smooth_output(xs, Ps, y)
+end
+
+# Public-shape return convention, matching `_collect_smooth_output`.
+_grouped_smooth_output(xs, Ps, ::AbstractMatrix) = (xs[1], Ps[1])
+_grouped_smooth_output(xs, Ps, _) = (xs, Ps)
+
+"""
+    _units_by_slot(slots) -> Vector{Vector{Int}}
+
+Group unit indices by the parameter version they use, one entry per occupied
+version. A `depends_on` label that no unit uses is skipped rather than fitted
+from an empty sufficient statistic.
+"""
+function _units_by_slot(slots::AbstractVector{Int})
+    out = Vector{Int}[]
+    seen = Int[]
+    for (u, s) in enumerate(slots)
+        i = findfirst(isequal(s), seen)
+        if i === nothing
+            push!(seen, s)
+            push!(out, [u])
+        else
+            push!(out[i], u)
+        end
+    end
+    return out
+end
+
+"""
+    _distinct_by_slot(slots, units) -> Vector{Int}
+
+One representative unit per distinct value of `slots` within `units`. Used to
+add a prior term once per distinct parameter version when the prior's group is
+finer than the group being updated (e.g. several `[A b B]` sharing one `Q`).
+"""
+function _distinct_by_slot(slots::AbstractVector{Int}, units::AbstractVector{Int})
+    reps = Int[]
+    seen = Int[]
+    for u in units
+        s = slots[u]
+        if !(s in seen)
+            push!(seen, s)
+            push!(reps, u)
+        end
+    end
+    return reps
+end
+
+# ============================================================================
+# Grouped parameter updates
+# ============================================================================
+
+function _grouped_update_x0!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_initial_state_mean!(ldss[units[1]], _pool_init!(bufs, sufs, units))
+    end
+    return nothing
+end
+
+function _grouped_update_P0!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_x0::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_P0] || return nothing
+    S0 = sws.reg.S0_sum
+    for units in _units_by_slot(slots)
+        fill!(S0, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_init_scatter!(S0, ldss[u], sufs[u])
+            N += T(sufs[u].init_n)
+        end
+        for u in _distinct_by_slot(slots_x0, units)
+            _accumulate_x0_prior_scatter!(S0, ldss[u])
+        end
+        Symmetrize!(S0)
+        _finalize_P0!(ldss[units[1]], S0, N)
+    end
+    return nothing
+end
+
+function _grouped_update_A_b!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_A_b!(ldss[units[1]], _pool_dyn!(bufs, sufs, units), sws)
+    end
+    return nothing
+end
+
+function _grouped_update_Q!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_ab::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_Q] || return nothing
+    S_res = sws.reg.Q_sum
+    for units in _units_by_slot(slots)
+        fill!(S_res, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_dyn_scatter!(S_res, ldss[u], sufs[u], sws)
+            N += T(sufs[u].dyn_n)
+        end
+        for u in _distinct_by_slot(slots_ab, units)
+            _accumulate_ab_prior_scatter!(S_res, ldss[u], sws)
+        end
+        _finalize_Q!(ldss[units[1]], S_res, N)
+    end
+    return nothing
+end
+
+function _grouped_update_C_d!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_C_d!(ldss[units[1]], _pool_obs!(bufs, sufs, units), sws)
+    end
+    return nothing
+end
+
+function _grouped_update_R!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_cd::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_R] || return nothing
+    S_res = sws.elbo.obs_work
+    for units in _units_by_slot(slots)
+        fill!(S_res, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_obs_scatter!(S_res, ldss[u], sufs[u], sws)
+            N += T(sufs[u].obs_n)
+        end
+        for u in _distinct_by_slot(slots_cd, units)
+            _accumulate_cd_prior_scatter!(S_res, ldss[u], sws)
+        end
+        _finalize_R!(ldss[units[1]], S_res, N)
+    end
+    return nothing
+end
+
+"""
+    _grouped_state_mstep!(ldss, sufs, slots, sws, bufs)
+
+The four state-side updates (`x0`, `P0`, `[A b B]`, `Q`) over a flat unit list.
+`slots[g][unit]` is the version of parameter group `g` that a unit uses. Shared
+by the Gaussian LDS, the Poisson LDS, and the SLDS.
+"""
+function _grouped_state_mstep!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Vector{Int}},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    _grouped_update_x0!(ldss, sufs, slots[_G_X0], bufs)
+    _grouped_update_P0!(ldss, sufs, slots[_G_P0], slots[_G_X0], sws)
+    _grouped_update_A_b!(ldss, sufs, slots[_G_AB], sws, bufs)
+    _grouped_update_Q!(ldss, sufs, slots[_G_Q], slots[_G_AB], sws)
+    return nothing
+end
+
+"""
+    _grouped_gaussian_obs_mstep!(ldss, sufs, slots, sws, bufs)
+
+The two Gaussian emission updates (`[C d D]`, `R`) over a flat unit list.
+"""
+function _grouped_gaussian_obs_mstep!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Vector{Int}},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs)
+    _grouped_update_R!(ldss, sufs, slots[_G_R], slots[_G_CD], sws)
+    return nothing
+end
+
+# ============================================================================
+# Grouped prior log-density (the ELBO's `log p(θ)` term)
+# ============================================================================
+
+"""
+    _slot_representatives(slots) -> Vector{Int}
+
+One representative unit per occupied parameter version.
+"""
+_slot_representatives(slots::AbstractVector{Int}) = [u[1] for u in _units_by_slot(slots)]
+
+"""
+    _pair_slot_representatives(slots_a, slots_b) -> Vector{Int}
+
+One representative unit per distinct `(slots_a, slots_b)` pair. The MN priors
+couple a regression with its noise covariance (`x0` with `P0`, `[A b B]` with
+`Q`, `[C d D]` with `R`), so each distinct pair is one instance of that prior —
+which stays consistent with the M-step, where the same pairs decide how often
+the `Wm Λ Wm'` term is folded into the IW scale.
+"""
+function _pair_slot_representatives(
+    slots_a::AbstractVector{Int}, slots_b::AbstractVector{Int}
+)
+    seen = Tuple{Int,Int}[]
+    reps = Int[]
+    for u in eachindex(slots_a)
+        key = (slots_a[u], slots_b[u])
+        if !(key in seen)
+            push!(seen, key)
+            push!(reps, u)
+        end
+    end
+    return reps
+end
+
+"""
+    _grouped_state_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the state-side parameters of a grouped model: the IW terms once
+per covariance version, the MN terms once per distinct regression/covariance
+pair.
+"""
+function _grouped_state_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_P0])
+        sm = ldss[u].state_model
+        sm.P0_prior === nothing || (total += iw_logprior_term(sm.P0, sm.P0_prior))
+    end
+    for u in _slot_representatives(slots[_G_Q])
+        sm = ldss[u].state_model
+        sm.Q_prior === nothing || (total += iw_logprior_term(sm.Q, sm.Q_prior))
+    end
+    for u in _pair_slot_representatives(slots[_G_X0], slots[_G_P0])
+        sm = ldss[u].state_model
+        sm.x0_prior === nothing && continue
+        total += mn_logprior_term(reshape(sm.x0, :, 1), sm.P0, sm.x0_prior)
+    end
+    for u in _pair_slot_representatives(slots[_G_AB], slots[_G_Q])
+        lds = ldss[u]
+        sm = lds.state_model
+        sm.AB_prior === nothing && continue
+        D = lds.latent_dim
+        W_ab = _pack_dyn_W!(Matrix{T}(undef, D, D + 1 + lds.ux_dim), lds)
+        total += mn_logprior_term(W_ab, sm.Q, sm.AB_prior)
+    end
+    return total
+end
+
+"""
+    _grouped_gaussian_obs_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the Gaussian emission parameters of a grouped model.
+"""
+function _grouped_gaussian_obs_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_R])
+        om = ldss[u].obs_model
+        om.R_prior === nothing || (total += iw_logprior_term(om.R, om.R_prior))
+    end
+    for u in _pair_slot_representatives(slots[_G_CD], slots[_G_R])
+        lds = ldss[u]
+        om = lds.obs_model
+        om.CD_prior === nothing && continue
+        D = lds.latent_dim
+        W_cd = _pack_obs_V!(Matrix{T}(undef, lds.obs_dim, D + 1 + lds.uy_dim), lds)
+        total += mn_logprior_term(W_cd, om.R, om.CD_prior)
+    end
+    return total
+end
+
+"""
+    _grouped_poisson_obs_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the Poisson emission parameters of a grouped model. Poisson has
+no observation-noise covariance, so the MN prior on `[C d D]` contributes the
+bare quadratic that the LBFGS emission objective penalizes, once per version.
+"""
+function _grouped_poisson_obs_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_CD])
+        lds = ldss[u]
+        om = lds.obs_model
+        om.CD_prior === nothing && continue
+        D = lds.latent_dim
+        W_cd = _pack_obs_V!(Matrix{T}(undef, lds.obs_dim, D + 1 + lds.uy_dim), lds)
+        Wm = W_cd .- om.CD_prior.M₀
+        total -= T(0.5) * sum(Wm .* (Wm * om.CD_prior.Λ))
+    end
+    return total
+end

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -1,0 +1,699 @@
+#=============================================================================
+Ancillary parameter dependencies (`depends_on`)
+
+`AbstractStateModel` and `AbstractObservationModel` each carry a `depends_on`
+field. When it is `nothing` (the default) the model behaves exactly as before:
+one parameter set shared by every trial, and every entry point takes its
+original ungrouped code path. When it is a `NamedTuple`, the named parameters
+are estimated separately for each group of trials:
+
+    session = [:a, :a, :b, :b, :b]          # one label per trial
+    obs = GaussianObservationModel(C, R, d)
+    obs.depends_on = (C = session, R = session)
+
+Trials labelled `:a` then contribute to one `[C d D]` / `R` estimate and trials
+labelled `:b` to another, while the latent dynamics `A`, `b`, `B`, `Q` and the
+initial state `x0`, `P0` stay shared. That is the "stitching" setup for pooling
+recording sessions that observe different neurons in the same animal: latent
+dynamics common to the animal, emission parameters specific to the session.
+
+Keys are canonicalized to the same groups `fit_bool` uses, because those
+parameters are fit jointly as one regression:
+
+    :x0             -> initial state mean      (fit_bool[1])
+    :P0             -> initial state cov       (fit_bool[2])
+    :A, :b, :B      -> dynamics [A b B]        (fit_bool[3])
+    :Q              -> process noise           (fit_bool[4])
+    :C, :d, :D      -> emission [C d D]        (fit_bool[5])
+    :R              -> observation noise       (fit_bool[6], Gaussian only)
+
+So `:d` is an alias for `:C`; naming either makes the whole `[C d D]`
+regression group-dependent, and naming two aliases of one group with different
+label vectors is an error.
+
+Implementation shape: a *cell* is a maximal set of trials sharing every
+parameter — one element of the common refinement of all the label vectors.
+Trials in a cell are governed by a single `LinearDynamicalSystem`, so the E-step
+runs on them completely unchanged (which is what keeps the equal-length
+shared-covariance fast path alive within each group), and only the M-step and
+the ELBO need to know about groups.
+=============================================================================#
+
+#=
+Any model that carries a `depends_on` field. Spelling it out (rather than
+leaving these helpers untyped) lets inference union-split over the three
+concrete model types instead of dispatching dynamically on `Any`.
+=#
+const DependentModel = Union{AbstractStateModel,AbstractObservationModel}
+
+# Canonical group names, ordered to match `fit_bool`. State-model groups occupy
+# `fit_bool` slots 1:4 and observation-model groups slots 5:6 (5:5 for Poisson).
+_group_names(::GaussianStateModel) = (:x0, :P0, :A, :Q)
+_group_names(::GaussianObservationModel) = (:C, :R)
+_group_names(::PoissonObservationModel) = (:C,)
+
+#=
+Alias resolution: `[A b B]` and `[C d D]` are each fit as a single regression,
+so naming any member of a group makes the whole group group-dependent.
+
+`_try_canonical_param` returns `nothing` for a name the model does not own,
+which is what a *shared* `depends_on` needs: a call-site override is one
+NamedTuple resolved against both sub-models, so each has to be able to ignore
+the other's keys rather than reject them.
+=#
+function _try_canonical_param(::GaussianStateModel, name::Symbol)
+    name in (:A, :b, :B) && return :A
+    name in (:x0, :P0, :Q) && return name
+    return nothing
+end
+
+function _try_canonical_param(::GaussianObservationModel, name::Symbol)
+    name in (:C, :d, :D) && return :C
+    name === :R && return :R
+    return nothing
+end
+
+function _try_canonical_param(::PoissonObservationModel, name::Symbol)
+    name in (:C, :d, :D) && return :C
+    return nothing
+end
+
+_valid_param_names(::GaussianStateModel) = ":x0, :P0, :A, :b, :B, :Q"
+_valid_param_names(::GaussianObservationModel) = ":C, :d, :D, :R"
+function _valid_param_names(::PoissonObservationModel)
+    return ":C, :d, :D (a Poisson emission has no noise covariance)"
+end
+
+function _canonical_param(model::DependentModel, name::Symbol)
+    canonical = _try_canonical_param(model, name)
+    canonical === nothing && throw(
+        ArgumentError(
+            "depends_on: `:$name` is not a parameter of a $(nameof(typeof(model))); " *
+            "valid names are $(_valid_param_names(model))",
+        ),
+    )
+    return canonical
+end
+
+"""
+    ParameterDependence
+
+**Internal.** Resolved, model-intrinsic form of a model's `depends_on`: for each
+of the model's parameter groups, whether it varies, the ordered list of distinct
+labels, and the per-trial labels as supplied.
+
+`nslots[g]` is `length(labels[g])` for a varying group and `1` otherwise, so a
+model's `variants` vector always has `prod(nslots)` entries and a variant's index
+is a fixed function of its per-group slot indices — independent of any dataset,
+which is what lets a `depends_on` override re-assign trials without invalidating
+already-fitted parameters.
+"""
+struct ParameterDependence
+    names::Vector{Symbol}
+    varies::Vector{Bool}
+    labels::Vector{Vector{Any}}
+    trial_labels::Vector{Vector{Any}}
+    nslots::Vector{Int}
+end
+
+_any_varies(dep::ParameterDependence) = any(dep.varies)
+
+function _same_labels(a::Vector{Any}, b::Vector{Any})
+    return length(a) == length(b) && all(isequal(a[i], b[i]) for i in eachindex(a))
+end
+
+"""
+    _resolve_dependence(model) -> ParameterDependence
+
+Validate `model.depends_on` and resolve it against the model's parameter groups.
+Throws `ArgumentError` on unknown parameter names or on aliases of one group
+carrying different label vectors, and `DimensionMismatchError` on label vectors
+of unequal length.
+"""
+function _resolve_dependence(model::DependentModel)
+    names = collect(Symbol, _group_names(model))
+    ngroups = length(names)
+    varies = fill(false, ngroups)
+    labels = [Any[] for _ in 1:ngroups]
+    trial_labels = [Any[] for _ in 1:ngroups]
+    nslots = fill(1, ngroups)
+    dep = ParameterDependence(names, varies, labels, trial_labels, nslots)
+
+    spec = model.depends_on
+    spec === nothing && return dep
+
+    #=
+    Track which user-facing key first claimed each group so a conflicting alias
+    (`(C = s1, d = s2)`) can report both names rather than silently keeping one.
+    =#
+    claimed = Vector{Symbol}(undef, ngroups)
+    for key in keys(spec)
+        canonical = _canonical_param(model, key)
+        g = findfirst(isequal(canonical), names)::Int
+        supplied = getproperty(spec, key)
+        supplied isa AbstractVector || throw(
+            ArgumentError(
+                "depends_on[:$key] must be a vector with one label per trial, " *
+                "got a $(typeof(supplied))",
+            ),
+        )
+        isempty(supplied) && throw(
+            ArgumentError("depends_on[:$key] is empty; expected one label per trial")
+        )
+        current = collect(Any, supplied)
+        if varies[g]
+            _same_labels(current, trial_labels[g]) || throw(
+                ArgumentError(
+                    "depends_on: `:$key` and `:$(claimed[g])` name the same parameter " *
+                    "group (`:$canonical`, fit jointly as one regression) but were " *
+                    "given different label vectors; supply one label vector per group",
+                ),
+            )
+            continue
+        end
+        varies[g] = true
+        claimed[g] = key
+        trial_labels[g] = current
+        labels[g] = collect(Any, unique(current))
+        nslots[g] = length(labels[g])
+    end
+
+    ntrials = 0
+    for g in 1:ngroups
+        varies[g] || continue
+        if ntrials == 0
+            ntrials = length(trial_labels[g])
+        elseif length(trial_labels[g]) != ntrials
+            throw(
+                DimensionMismatchError(
+                    "depends_on[:$(names[g])] length", ntrials, length(trial_labels[g])
+                ),
+            )
+        end
+    end
+
+    return dep
+end
+
+#=
+Mixed-radix (column-major) index of a variant from its per-group slot indices,
+and its inverse. Written out rather than going through `LinearIndices` so the
+`nslots` vector never has to be splatted into a tuple.
+=#
+function _variant_index(nslots::AbstractVector{Int}, slots::AbstractVector{Int})
+    idx = 0
+    for g in length(nslots):-1:1
+        idx = idx * nslots[g] + (slots[g] - 1)
+    end
+    return idx + 1
+end
+
+function _variant_slots(nslots::AbstractVector{Int}, index::Int)
+    slots = Vector{Int}(undef, length(nslots))
+    rest = index - 1
+    for g in eachindex(nslots)
+        slots[g] = rest % nslots[g] + 1
+        rest = rest ÷ nslots[g]
+    end
+    return slots
+end
+
+"""
+    _slot_of(dep, g, label) -> Int
+
+Slot index of `label` within parameter group `g`. Throws when the label was not
+present in the label vector the model was built with — an override may
+re-assign trials to known groups but not introduce new parameter sets.
+"""
+function _slot_of(dep::ParameterDependence, g::Int, label)
+    dep.varies[g] || return 1
+    slot = findfirst(isequal(label), dep.labels[g])
+    slot === nothing && throw(
+        ArgumentError(
+            "depends_on: label $(repr(label)) is not a known group of parameter " *
+            "`:$(dep.names[g])` (known: $(join(map(repr, dep.labels[g]), ", "))). " *
+            "An override may only re-assign trials to existing groups.",
+        ),
+    )
+    return slot::Int
+end
+
+"""
+    _trial_labels_for(dep, g, model, override) -> Vector{Any}
+
+Per-trial labels for group `g`, taken from `override` when it names the group
+(under any alias) and from the model's own `depends_on` otherwise.
+"""
+function _trial_labels_for(
+    dep::ParameterDependence, g::Int, model::DependentModel, override
+)
+    if override !== nothing
+        for key in keys(override)
+            _try_canonical_param(model, key) === dep.names[g] || continue
+            supplied = getproperty(override, key)
+            supplied isa AbstractVector || throw(
+                ArgumentError(
+                    "depends_on override for `:$key` must be a vector with one label " *
+                    "per trial, got a $(typeof(supplied))",
+                ),
+            )
+            return collect(Any, supplied)
+        end
+    end
+    return dep.trial_labels[g]
+end
+
+# ============================================================================
+# Variant construction. Parameters that do not vary are shared *by reference*
+# across every variant, so one M-step write updates all of them; parameters
+# that do vary get one independent copy per slot, with slot 1 aliasing the base
+# model's own array so `model.C` keeps its original meaning.
+# ============================================================================
+
+_slot_arrays(base, nslots::Int) = [i == 1 ? base : copy(base) for i in 1:nslots]
+
+function _build_variants!(
+    sm::GaussianStateModel{T,M,V}, dep::ParameterDependence
+) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
+    ncells = prod(dep.nslots)
+    existing = sm.variants
+    if existing !== nothing && length(existing) == ncells
+        return existing
+    end
+
+    x0s = _slot_arrays(sm.x0, dep.nslots[1])
+    P0s = _slot_arrays(sm.P0, dep.nslots[2])
+    As = _slot_arrays(sm.A, dep.nslots[3])
+    bs = _slot_arrays(sm.b, dep.nslots[3])
+    Bs = _slot_arrays(sm.B, dep.nslots[3])
+    Qs = _slot_arrays(sm.Q, dep.nslots[4])
+
+    variants = Vector{GaussianStateModel{T,M,V}}(undef, ncells)
+    for cell in 1:ncells
+        s = _variant_slots(dep.nslots, cell)
+        variants[cell] = GaussianStateModel{T,M,V}(;
+            A=As[s[3]],
+            Q=Qs[s[4]],
+            b=bs[s[3]],
+            x0=x0s[s[1]],
+            P0=P0s[s[2]],
+            B=Bs[s[3]],
+            Q_prior=sm.Q_prior,
+            P0_prior=sm.P0_prior,
+            AB_prior=sm.AB_prior,
+            x0_prior=sm.x0_prior,
+        )
+    end
+    sm.variants = variants
+    return variants
+end
+
+function _build_variants!(
+    om::GaussianObservationModel{T,M,V}, dep::ParameterDependence
+) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
+    ncells = prod(dep.nslots)
+    existing = om.variants
+    if existing !== nothing && length(existing) == ncells
+        return existing
+    end
+
+    Cs = _slot_arrays(om.C, dep.nslots[1])
+    ds = _slot_arrays(om.d, dep.nslots[1])
+    Ds = _slot_arrays(om.D, dep.nslots[1])
+    Rs = _slot_arrays(om.R, dep.nslots[2])
+
+    variants = Vector{GaussianObservationModel{T,M,V}}(undef, ncells)
+    for cell in 1:ncells
+        s = _variant_slots(dep.nslots, cell)
+        variants[cell] = GaussianObservationModel{T,M,V}(;
+            C=Cs[s[1]],
+            R=Rs[s[2]],
+            d=ds[s[1]],
+            D=Ds[s[1]],
+            R_prior=om.R_prior,
+            CD_prior=om.CD_prior,
+        )
+    end
+    om.variants = variants
+    return variants
+end
+
+function _build_variants!(
+    om::PoissonObservationModel{T,M,V}, dep::ParameterDependence
+) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
+    ncells = prod(dep.nslots)
+    existing = om.variants
+    if existing !== nothing && length(existing) == ncells
+        return existing
+    end
+
+    Cs = _slot_arrays(om.C, dep.nslots[1])
+    ds = _slot_arrays(om.d, dep.nslots[1])
+    Ds = _slot_arrays(om.D, dep.nslots[1])
+
+    variants = Vector{PoissonObservationModel{T,M,V}}(undef, ncells)
+    for cell in 1:ncells
+        s = _variant_slots(dep.nslots, cell)
+        variants[cell] = PoissonObservationModel{T,M,V}(;
+            C=Cs[s[1]], d=ds[s[1]], D=Ds[s[1]], CD_prior=om.CD_prior
+        )
+    end
+    om.variants = variants
+    return variants
+end
+
+# ============================================================================
+# Trial partition
+# ============================================================================
+
+"""
+    ParameterGrouping
+
+**Internal.** The trial partition induced by a model's `depends_on`, together
+with the per-cell parameter lookups the grouped E/M-steps need.
+
+# Fields
+- `names`: canonical parameter-group names, ordered as `fit_bool`
+- `ncells`: number of occupied cells
+- `trial_cell`: cell index of each trial
+- `cell_trials`: trial indices of each cell
+- `cell_state` / `cell_obs`: index into the state / observation model's
+  `variants` vector for each cell
+- `nslots[g]`: number of distinct versions of parameter group `g`
+- `cell_slot[g][cell]`: which version of group `g` a cell uses
+- `slot_labels[g][slot]`: the user's label for that version (`nothing` when the
+  group does not vary)
+"""
+struct ParameterGrouping
+    names::Vector{Symbol}
+    ncells::Int
+    trial_cell::Vector{Int}
+    cell_trials::Vector{Vector{Int}}
+    cell_state::Vector{Int}
+    cell_obs::Vector{Int}
+    nslots::Vector{Int}
+    cell_slot::Vector{Vector{Int}}
+    slot_labels::Vector{Vector{Any}}
+end
+
+"""
+    _validate_override_keys(sm, om, dep_s, dep_o, override)
+
+Reject a call-site `depends_on` that names something neither sub-model owns (a
+typo), or a parameter the model does not declare as varying. An override
+re-assigns trials to existing groups; it cannot introduce a parameter set that
+was never fitted.
+"""
+function _validate_override_keys(
+    sm::DependentModel,
+    om::DependentModel,
+    dep_s::ParameterDependence,
+    dep_o::ParameterDependence,
+    override::Union{Nothing,NamedTuple},
+)
+    override === nothing && return nothing
+    for key in keys(override)
+        cs = _try_canonical_param(sm, key)
+        co = _try_canonical_param(om, key)
+        cs === nothing && co === nothing && throw(
+            ArgumentError(
+                "depends_on override: `:$key` is not a parameter of either sub-model " *
+                "(state: $(_valid_param_names(sm)); " *
+                "observation: $(_valid_param_names(om)))",
+            ),
+        )
+        declared =
+            (cs !== nothing && dep_s.varies[findfirst(isequal(cs), dep_s.names)::Int]) ||
+            (co !== nothing && dep_o.varies[findfirst(isequal(co), dep_o.names)::Int])
+        declared || throw(
+            ArgumentError(
+                "depends_on override: `:$key` is not declared as depending on an " *
+                "ancillary variable by the model; an override may only re-assign " *
+                "trials to groups the model already declares",
+            ),
+        )
+    end
+    return nothing
+end
+
+"""
+    parameter_grouping(lds, ntrials; depends_on=nothing)
+
+Build the trial partition for `lds` over `ntrials` trials, or return `nothing`
+when no parameter of either sub-model depends on an ancillary variable.
+
+`depends_on` optionally overrides the label vectors stored on the models, for
+scoring a dataset whose trial count differs from the fitted one.
+"""
+function parameter_grouping(
+    lds::LinearDynamicalSystem, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing
+)
+    sm = lds.state_model
+    om = lds.obs_model
+    dep_s = _resolve_dependence(sm)
+    dep_o = _resolve_dependence(om)
+
+    #=
+    An override may only re-assign trials to groups the model already knows, so
+    a model with no `depends_on` at all has nothing to override and stays on the
+    ungrouped path.
+    =#
+    if !_any_varies(dep_s) && !_any_varies(dep_o)
+        depends_on === nothing || throw(
+            ArgumentError(
+                "a `depends_on` override was supplied but neither sub-model declares " *
+                "`depends_on`; set it on the model before fitting",
+            ),
+        )
+        return nothing
+    end
+
+    _validate_override_keys(sm, om, dep_s, dep_o, depends_on)
+
+    _build_variants!(sm, dep_s)
+    _build_variants!(om, dep_o)
+
+    ngroups_s = length(dep_s.names)
+    ngroups_o = length(dep_o.names)
+    ngroups = ngroups_s + ngroups_o
+    names = vcat(dep_s.names, dep_o.names)
+    varies = vcat(dep_s.varies, dep_o.varies)
+
+    # Per-trial labels for every group (state groups first, matching fit_bool).
+    trial_labels = Vector{Vector{Any}}(undef, ngroups)
+    for g in 1:ngroups_s
+        trial_labels[g] = _trial_labels_for(dep_s, g, sm, depends_on)
+    end
+    for g in 1:ngroups_o
+        trial_labels[ngroups_s + g] = _trial_labels_for(dep_o, g, om, depends_on)
+    end
+
+    for g in 1:ngroups
+        varies[g] || continue
+        length(trial_labels[g]) == ntrials || throw(
+            DimensionMismatchError(
+                "depends_on labels for :$(names[g])", ntrials, length(trial_labels[g])
+            ),
+        )
+    end
+
+    # Per-trial slot indices, then the per-trial variant index of each sub-model.
+    state_idx = Vector{Int}(undef, ntrials)
+    obs_idx = Vector{Int}(undef, ntrials)
+    s_slots = Vector{Int}(undef, ngroups_s)
+    o_slots = Vector{Int}(undef, ngroups_o)
+    for n in 1:ntrials
+        for g in 1:ngroups_s
+            s_slots[g] = dep_s.varies[g] ? _slot_of(dep_s, g, trial_labels[g][n]) : 1
+        end
+        for g in 1:ngroups_o
+            gg = ngroups_s + g
+            o_slots[g] = dep_o.varies[g] ? _slot_of(dep_o, g, trial_labels[gg][n]) : 1
+        end
+        state_idx[n] = _variant_index(dep_s.nslots, s_slots)
+        obs_idx[n] = _variant_index(dep_o.nslots, o_slots)
+    end
+
+    # Occupied cells, in order of first appearance.
+    trial_cell = Vector{Int}(undef, ntrials)
+    cell_state = Int[]
+    cell_obs = Int[]
+    cell_trials = Vector{Int}[]
+    for n in 1:ntrials
+        cell = 0
+        for c in eachindex(cell_state)
+            if cell_state[c] == state_idx[n] && cell_obs[c] == obs_idx[n]
+                cell = c
+                break
+            end
+        end
+        if cell == 0
+            push!(cell_state, state_idx[n])
+            push!(cell_obs, obs_idx[n])
+            push!(cell_trials, Int[])
+            cell = length(cell_state)
+        end
+        trial_cell[n] = cell
+        push!(cell_trials[cell], n)
+    end
+
+    ncells = length(cell_state)
+    cell_slot = [Vector{Int}(undef, ncells) for _ in 1:ngroups]
+    for c in 1:ncells
+        cs = _variant_slots(dep_s.nslots, cell_state[c])
+        co = _variant_slots(dep_o.nslots, cell_obs[c])
+        for g in 1:ngroups_s
+            cell_slot[g][c] = cs[g]
+        end
+        for g in 1:ngroups_o
+            cell_slot[ngroups_s + g][c] = co[g]
+        end
+    end
+
+    slot_labels = Vector{Vector{Any}}(undef, ngroups)
+    for g in 1:ngroups_s
+        slot_labels[g] = dep_s.varies[g] ? dep_s.labels[g] : Any[nothing]
+    end
+    for g in 1:ngroups_o
+        gg = ngroups_s + g
+        slot_labels[gg] = dep_o.varies[g] ? dep_o.labels[g] : Any[nothing]
+    end
+
+    return ParameterGrouping(
+        names,
+        ncells,
+        trial_cell,
+        cell_trials,
+        cell_state,
+        cell_obs,
+        vcat(dep_s.nslots, dep_o.nslots),
+        cell_slot,
+        slot_labels,
+    )
+end
+
+"""
+    _has_parameter_dependence(model) -> Bool
+
+Whether a model (or either sub-model of a `LinearDynamicalSystem`) declares a
+`depends_on` that actually varies a parameter.
+"""
+function _has_parameter_dependence(model::DependentModel)
+    model.depends_on === nothing && return false
+    return _any_varies(_resolve_dependence(model))
+end
+
+function _has_parameter_dependence(lds::LinearDynamicalSystem)
+    return _has_parameter_dependence(lds.state_model) ||
+           _has_parameter_dependence(lds.obs_model)
+end
+
+"""
+    _single_trial_group_error(what)
+
+`rand` with a scalar `tsteps` draws one trial, which a grouped model cannot
+assign to a parameter version on its own.
+"""
+function _single_trial_group_error(what::AbstractString)
+    return throw(
+        ArgumentError(
+            "rand(rng, $what, tsteps) samples a single trial, but this model's " *
+            "parameters depend on an ancillary variable — say which group the trial " *
+            "belongs to, e.g. `depends_on=(C=[:session_a],)`, or sample several trials " *
+            "at once with `rand(rng, $what, fill(tsteps, ntrials))`.",
+        ),
+    )
+end
+
+"""
+    _cell_lds(lds, grp, cell) -> LinearDynamicalSystem
+
+A view of `lds` restricted to one cell: the state and observation model objects
+holding that cell's parameter arrays. Construction is two immutable struct
+allocations — the parameter arrays are shared, never copied — so the existing
+kernels can be run per cell without any group awareness of their own.
+"""
+function _cell_lds(
+    lds::LinearDynamicalSystem{T,S,O}, grp::ParameterGrouping, cell::Int
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    sm = (lds.state_model.variants::Vector{S})[grp.cell_state[cell]]
+    om = (lds.obs_model.variants::Vector{O})[grp.cell_obs[cell]]
+    return LinearDynamicalSystem{T,S,O}(
+        sm, om, lds.latent_dim, lds.obs_dim, lds.ux_dim, lds.uy_dim, lds.fit_bool
+    )
+end
+
+"""
+    _cell_ldss(lds, grp) -> Vector{LinearDynamicalSystem}
+
+One `_cell_lds` per occupied cell.
+"""
+function _cell_ldss(
+    lds::LinearDynamicalSystem{T,S,O}, grp::ParameterGrouping
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    return [_cell_lds(lds, grp, c) for c in 1:grp.ncells]
+end
+
+"""
+    _subset_data(data, trials) -> Data
+
+The sub-`Data` holding only `trials`, sharing the per-trial matrices by
+reference (nothing is copied).
+"""
+function _subset_data(data::Data, trials::AbstractVector{Int})
+    return Data(data.y[trials], data.ux[trials], data.uy[trials], data.tsteps[trials])
+end
+
+# ============================================================================
+# Public accessors
+# ============================================================================
+
+"""
+    group_labels(model, name) -> Vector
+
+Distinct labels of the parameter group `name` on a state or observation model,
+in the order their parameter versions are stored. Returns an empty vector when
+that parameter does not depend on an ancillary variable.
+
+```julia
+group_labels(obs_model, :C)   # [:session_a, :session_b]
+```
+
+Members of a jointly-fitted group are aliases, so `group_labels(m, :d)` is the
+same as `group_labels(m, :C)`.
+"""
+function group_labels(model::DependentModel, name::Symbol)
+    dep = _resolve_dependence(model)
+    canonical = _canonical_param(model, name)
+    g = findfirst(isequal(canonical), dep.names)::Int
+    return dep.varies[g] ? copy(dep.labels[g]) : Any[]
+end
+
+"""
+    group_parameter(model, name, label)
+
+The version of parameter `name` fitted from the trials labelled `label`.
+
+```julia
+group_parameter(obs_model, :C, :session_a)   # that session's emission matrix
+group_parameter(obs_model, :d, :session_a)   # its emission bias
+```
+
+Throws when the model declares no dependence for that parameter (read the field
+directly in that case) or when `label` is not one of its groups.
+"""
+function group_parameter(model::DependentModel, name::Symbol, label)
+    dep = _resolve_dependence(model)
+    canonical = _canonical_param(model, name)
+    g = findfirst(isequal(canonical), dep.names)::Int
+    dep.varies[g] || throw(
+        ArgumentError(
+            "parameter `:$name` of this $(nameof(typeof(model))) does not depend on an " *
+            "ancillary variable; read `model.$name` directly",
+        ),
+    )
+    slots = fill(1, length(dep.nslots))
+    slots[g] = _slot_of(dep, g, label)
+    variants = _build_variants!(model, dep)
+    return getproperty(variants[_variant_index(dep.nslots, slots)], name)
+end

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -4,6 +4,11 @@
 Abstract supertype for latent-state models of a [`LinearDynamicalSystem`](@ref)
 (e.g. [`GaussianStateModel`](@ref)). A state model defines how the latent state
 evolves from one timestep to the next.
+
+Every concrete subtype carries a `depends_on` field declaring which of its
+parameters are estimated separately per group of trials, and a companion
+`variants` field holding one model object per parameter-group combination.
+See `src/lds/parameter_groups.jl` for the full description.
 """
 abstract type AbstractStateModel{T<:Real} end
 
@@ -14,6 +19,11 @@ Abstract supertype for observation (emission) models of a
 [`LinearDynamicalSystem`](@ref) (e.g. [`GaussianObservationModel`](@ref) or
 [`PoissonObservationModel`](@ref)). An observation model defines how observed
 data are generated from the latent state.
+
+Every concrete subtype carries a `depends_on` field declaring which of its
+parameters are estimated separately per group of trials, and a companion
+`variants` field holding one model object per parameter-group combination.
+See `src/lds/parameter_groups.jl` for the full description.
 """
 abstract type AbstractObservationModel{T<:Real} end
 
@@ -74,6 +84,14 @@ where `B·ux_t` is present only when `B` is supplied (i.e., has nonzero columns)
     they match the internal workspaces regardless of how `A` is stored.
 - `x0_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing`: Optional matrix-normal prior on the
     initial mean `x0`.
+- `depends_on::Union{Nothing,NamedTuple} = nothing`: Optional declaration that some
+    parameters are estimated separately per group of trials. Keys are parameter names
+    (`:x0`, `:P0`, `:A`/`:b`/`:B`, `:Q`), values are per-trial label vectors; `nothing`
+    (the default) means one parameter set shared by every trial.
+- `variants::Union{Nothing,Vector{GaussianStateModel{T,M,V}}} = nothing`: Derived storage
+    for the per-group parameter sets; populated from `depends_on` by the fitting entry
+    points. Parameters that do not vary are shared **by reference** across variants, so
+    an M-step write through any variant is visible from all of them.
 """
 Base.@kwdef mutable struct GaussianStateModel{
     T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}
@@ -88,6 +106,8 @@ Base.@kwdef mutable struct GaussianStateModel{
     P0_prior::Union{Nothing,IWPrior{T}} = nothing
     AB_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
     x0_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
+    depends_on::Union{Nothing,NamedTuple} = nothing
+    variants::Union{Nothing,Vector{GaussianStateModel{T,M,V}}} = nothing
 end
 
 """
@@ -105,6 +125,13 @@ Represents the observation model of a Linear Dynamical System with Gaussian nois
     the stacked emission matrix `[C D]`. Pair with `R_prior` for a full MNIW prior on `(CD, R)`.
     Prior matrices are stored as plain `Matrix{T}` (decoupled from `C`'s storage type `M`) so
     they match the internal workspaces regardless of how `C` is stored.
+- `depends_on::Union{Nothing,NamedTuple} = nothing`: Optional declaration that some
+    parameters are estimated separately per group of trials. Keys are parameter names
+    (`:C`/`:d`/`:D`, `:R`), values are per-trial label vectors; `nothing` (the default)
+    means one parameter set shared by every trial.
+- `variants::Union{Nothing,Vector{GaussianObservationModel{T,M,V}}} = nothing`: Derived
+    storage for the per-group parameter sets; populated from `depends_on` by the fitting
+    entry points. Parameters that do not vary are shared **by reference** across variants.
 """
 Base.@kwdef mutable struct GaussianObservationModel{
     T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}
@@ -115,6 +142,8 @@ Base.@kwdef mutable struct GaussianObservationModel{
     D::M = zeros(eltype(C), size(C, 1), 0)  # eltype-preserving default
     R_prior::Union{Nothing,IWPrior{T}} = nothing
     CD_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
+    depends_on::Union{Nothing,NamedTuple} = nothing
+    variants::Union{Nothing,Vector{GaussianObservationModel{T,M,V}}} = nothing
 end
 
 # Convenience constructors (State)
@@ -197,6 +226,13 @@ model reduces to the canonical `λ_t = exp(C x_t + d)`.
     `(latent_dim+1+uy_dim, latent_dim+1+uy_dim)` respectively. Unlike the Gaussian path there
     is no IW counterpart since Poisson has no observation-noise covariance — this is an
     MN-only prior contributing `½ tr(([C d D] - M₀) Λ ([C d D] - M₀)')` to the LBFGS objective.
+- `depends_on::Union{Nothing,NamedTuple} = nothing`: Optional declaration that `[C d D]`
+    is estimated separately per group of trials. Keys are parameter names (`:C`/`:d`/`:D`),
+    values are per-trial label vectors; `nothing` (the default) means one parameter set
+    shared by every trial.
+- `variants::Union{Nothing,Vector{PoissonObservationModel{T,M,V}}} = nothing`: Derived
+    storage for the per-group parameter sets; populated from `depends_on` by the fitting
+    entry points.
 """
 Base.@kwdef mutable struct PoissonObservationModel{
     T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}
@@ -205,6 +241,8 @@ Base.@kwdef mutable struct PoissonObservationModel{
     d::V
     D::M = zeros(eltype(C), size(C, 1), 0)  # eltype-preserving default (no obs inputs)
     CD_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
+    depends_on::Union{Nothing,NamedTuple} = nothing
+    variants::Union{Nothing,Vector{PoissonObservationModel{T,M,V}}} = nothing
 end
 
 # 2-arg convenience constructor; matches the Gaussian path's positional form

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -468,14 +468,19 @@ concern:
 - `agg`: TD sufficient-stats aggregator + shared-covariance storage
 - `batched`: batched mean-pass buffers, or `nothing` (only `sws_pool[1]` of a
   multi-trial equal-length fit carries one)
+
+Every field except `batched` is `const`. `batched` is reassignable so a grouped
+fit (see `parameter_groups.jl`) can swap in the buffers sized for the group of
+trials it is about to smooth, while sharing the expensive O(D²·T) storage — the
+block-tridiagonal workspace and the shared-covariance cache — across all groups.
 """
-struct SmoothWorkspace{T<:Real}
-    btd::BlockTridiagonalWorkspace{T}
-    consts::SmoothConstants{T}
-    opt::NewtonBuffers{T}
-    reg::RegressionBuffers{T}
-    elbo::ElboBuffers{T}
-    agg::TDAggBuffers{T}
+mutable struct SmoothWorkspace{T<:Real}
+    const btd::BlockTridiagonalWorkspace{T}
+    const consts::SmoothConstants{T}
+    const opt::NewtonBuffers{T}
+    const reg::RegressionBuffers{T}
+    const elbo::ElboBuffers{T}
+    const agg::TDAggBuffers{T}
     batched::Union{Nothing,BatchedBuffers{T}}
 end
 

--- a/src/stats/simulate.jl
+++ b/src/stats/simulate.jl
@@ -116,6 +116,10 @@ Optional input sequences:
 - `uy`: same shape for the observation input `D`. Required when
   `size(obs_model.D, 2) > 0`. Supported for both Gaussian and Poisson
   observation models.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  models' stored `depends_on` for this call. When the model declares ancillary
+  parameter dependencies, each trial is sampled from its own group's parameters
+  — which is how you generate a synthetic multi-session dataset.
 """
 function Random.rand(
     rng::AbstractRNG,
@@ -123,9 +127,15 @@ function Random.rand(
     tsteps::Integer;
     ux::Union{Nothing,AbstractMatrix{T}}=nothing,
     uy::Union{Nothing,AbstractMatrix{T}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    state_params = _extract_state_params(lds.state_model)
-    obs_params = _extract_obs_params(lds.obs_model)
+    if depends_on === nothing && _has_parameter_dependence(lds)
+        _single_trial_group_error("lds")
+    end
+    grp = parameter_grouping(lds, 1; depends_on=depends_on)
+    lds1 = grp === nothing ? lds : _cell_lds(lds, grp, grp.trial_cell[1])
+    state_params = _extract_state_params(lds1.state_model)
+    obs_params = _extract_obs_params(lds1.obs_model)
     Ti = Int(tsteps)
 
     ux_trial = _check_ux(ux, lds.ux_dim, Ti, "ux", T)
@@ -143,11 +153,30 @@ function Random.rand(
     tsteps_per_trial::AbstractVector{<:Integer};
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    state_params = _extract_state_params(lds.state_model)
-    obs_params = _extract_obs_params(lds.obs_model)
-
     ntrials = length(tsteps_per_trial)
+    grp = parameter_grouping(lds, ntrials; depends_on=depends_on)
+
+    #=
+    Per-trial parameter sets. Ungrouped, every trial points at the same two
+    NamedTuples (which themselves reference the model's arrays); grouped, a
+    trial points at its cell's. Either way the sampler below is one code path.
+    =#
+    if grp === nothing
+        state_params = fill(_extract_state_params(lds.state_model), ntrials)
+        obs_params = fill(_extract_obs_params(lds.obs_model), ntrials)
+    else
+        cell_state = [
+            _extract_state_params(_cell_lds(lds, grp, c).state_model) for c in 1:grp.ncells
+        ]
+        cell_obs = [
+            _extract_obs_params(_cell_lds(lds, grp, c).obs_model) for c in 1:grp.ncells
+        ]
+        state_params = [cell_state[grp.trial_cell[n]] for n in 1:ntrials]
+        obs_params = [cell_obs[grp.trial_cell[n]] for n in 1:ntrials]
+    end
+
     x = Vector{Matrix{T}}(undef, ntrials)
     y = Vector{Matrix{T}}(undef, ntrials)
     for i in 1:ntrials
@@ -164,7 +193,14 @@ function Random.rand(
     # gets its own child RNG, indexed by chunk (not `threadid()`).
     if ntrials == 1
         _sample_trial!(
-            rng, x[1], y[1], state_params, obs_params, lds.obs_model, ux_seq[1], uy_seq[1]
+            rng,
+            x[1],
+            y[1],
+            state_params[1],
+            obs_params[1],
+            lds.obs_model,
+            ux_seq[1],
+            uy_seq[1],
         )
         return x, y
     end
@@ -183,8 +219,8 @@ function Random.rand(
                 trng,
                 x[trial],
                 y[trial],
-                state_params,
-                obs_params,
+                state_params[trial],
+                obs_params[trial],
                 lds.obs_model,
                 ux_seq[trial],
                 uy_seq[trial],

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -20,6 +20,36 @@ end
 
 print_full(obj) = print_full(stdout, obj)
 
+#=
+One line per parameter group that depends on an ancillary variable, e.g.
+
+  Depends on:
+   C, d, D  ->  2 groups (:session_a, :session_b)
+
+Prints nothing when `depends_on` is unset, so the display of an ordinary model
+is unchanged.
+=#
+function _show_depends_on(io::IO, model::DependentModel; gap="")
+    model.depends_on === nothing && return nothing
+    dep = _resolve_dependence(model)
+    any(dep.varies) || return nothing
+
+    println(io, gap, " Depends on:")
+    for g in eachindex(dep.names)
+        dep.varies[g] || continue
+        members = if dep.names[g] === :A
+            "A, b, B"
+        elseif dep.names[g] === :C
+            "C, d, D"
+        else
+            String(dep.names[g])
+        end
+        labels = join(map(repr, dep.labels[g]), ", ")
+        println(io, gap, "  $members  ->  $(dep.nslots[g]) groups ($labels)")
+    end
+    return nothing
+end
+
 function Base.show(io::IO, gsm::GaussianStateModel; gap="")
     println(io, gap, "Gaussian State Model:")
     println(io, gap, "---------------------")
@@ -45,6 +75,8 @@ function Base.show(io::IO, gsm::GaussianStateModel; gap="")
     println(io, gap, " Dynamics input:")
     println(io, gap, "  size(B)  = ($(size(gsm.B,1)), $(size(gsm.B,2)))")
 
+    _show_depends_on(io, gsm; gap=gap)
+
     return nothing
 end
 
@@ -63,6 +95,8 @@ function Base.show(io::IO, gom::GaussianObservationModel; gap="")
         println(io, gap, " d = $(round.(gom.d, digits=2))")
         println(io, gap, " D = $(round.(gom.D, digits=2))")
     end
+
+    _show_depends_on(io, gom; gap=gap)
 
     return nothing
 end
@@ -85,6 +119,8 @@ function Base.show(io::IO, pom::PoissonObservationModel; gap="")
             " rate = $(round.(exp.(pom.d), digits = 2))   # exp(d) for inspection only",
         )
     end
+
+    _show_depends_on(io, pom; gap=gap)
 
     return nothing
 end

--- a/src/utils/validation.jl
+++ b/src/utils/validation.jl
@@ -322,6 +322,16 @@ function validate_LDS(lds::LinearDynamicalSystem{T,S,O}) where {T,S,O}
     _validate_obs_model(lds.obs_model, lds.obs_dim, lds.latent_dim)
 
     #=
+    Resolve any ancillary parameter dependencies so a malformed `depends_on`
+    (unknown parameter name, conflicting aliases of one jointly-fitted group,
+    label vectors of unequal length) is reported at construction rather than at
+    the first `fit!`. The resolved value is discarded — the fitting entry points
+    re-resolve it against the actual trial count.
+    =#
+    _resolve_dependence(lds.state_model)
+    _resolve_dependence(lds.obs_model)
+
+    #=
     Check fit_bool length. The Gaussian path uses length 6 — the regression
     M-step fits A&b&B and C&d&D jointly.
     =#

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -1,0 +1,577 @@
+# Ancillary parameter dependencies (`depends_on`): parameters estimated
+# separately per group of trials.
+#
+# The load-bearing correctness check is
+# `test_fully_grouped_matches_independent_fits`: when *every* parameter depends
+# on the session label, a grouped fit over the pooled data must reproduce, to
+# floating point, what independent fits of each session produce. Everything
+# downstream of that (partial grouping, priors, Poisson, SLDS) shares the same
+# machinery.
+
+const PD_LATENT_DIM = 2
+const PD_OBS_DIM = 2
+
+function pd_state_model(::Type{T}=Float64) where {T<:Real}
+    return GaussianStateModel(;
+        A=T[0.92 0.10; -0.10 0.92],
+        Q=Matrix{T}(0.01 * I(PD_LATENT_DIM)),
+        b=zeros(T, PD_LATENT_DIM),
+        x0=zeros(T, PD_LATENT_DIM),
+        P0=Matrix{T}(0.10 * I(PD_LATENT_DIM)),
+    )
+end
+
+function pd_obs_model(::Type{T}=Float64) where {T<:Real}
+    return GaussianObservationModel(;
+        C=T[1.0 0.2; -0.3 1.0],
+        d=zeros(T, PD_OBS_DIM),
+        R=Matrix{T}(0.20 * I(PD_OBS_DIM)),
+    )
+end
+
+function pd_lds(sm, om; fit_bool::Vector{Bool}=fill(true, 6))
+    return LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fit_bool,
+    )
+end
+
+pd_fresh_lds() = pd_lds(pd_state_model(), pd_obs_model())
+
+"""
+EM on the MAP objective is monotone in exact arithmetic; allow a relative slack
+so an accumulated rounding error in the ELBO sum is not read as a real decrease.
+"""
+function pd_is_monotone(elbos::AbstractVector)
+    length(elbos) < 2 && return true
+    slack = 1e-8 * max(1.0, maximum(abs, elbos))
+    return all(>=(-slack), diff(elbos))
+end
+
+"""
+Two-session ground truth: shared latent dynamics, session-specific emissions.
+Mirrors the stitching setup — one animal, two recording sessions.
+"""
+function pd_two_session_truth(; ntrials_per_session::Int=6)
+    labels = vcat(fill(:s1, ntrials_per_session), fill(:s2, ntrials_per_session))
+    sm = pd_state_model()
+    om = pd_obs_model()
+    om.depends_on = (C=labels, R=labels)
+    lds = pd_lds(sm, om)
+
+    # Session 2 sees different "neurons" and is much noisier.
+    C2 = group_parameter(om, :C, :s2)
+    C2 .= [0.4 -0.9; 1.1 0.5]
+    d2 = group_parameter(om, :d, :s2)
+    d2 .= [0.5, -0.5]
+    R2 = group_parameter(om, :R, :s2)
+    R2 .= Matrix(1.5 * I(PD_OBS_DIM))
+
+    return lds, labels
+end
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+function test_depends_on_validation()
+    om = pd_obs_model()
+
+    om.depends_on = (Z=[:a, :b],)
+    @test_throws ArgumentError SSD._resolve_dependence(om)
+
+    # `:d` is an alias of `:C` — they must carry the same labels.
+    om.depends_on = (C=[:a, :b], d=[:a, :a])
+    @test_throws ArgumentError SSD._resolve_dependence(om)
+
+    om.depends_on = (C=[:a, :b], R=[:a, :b, :b])
+    @test_throws SSD.DimensionMismatchError SSD._resolve_dependence(om)
+
+    om.depends_on = (C=Symbol[],)
+    @test_throws ArgumentError SSD._resolve_dependence(om)
+
+    # A Poisson emission has no `R`.
+    pom = PoissonObservationModel(zeros(2, 2), zeros(2))
+    pom.depends_on = (R=[:a, :b],)
+    @test_throws ArgumentError SSD._resolve_dependence(pom)
+
+    # A state model has no `C`.
+    sm = pd_state_model()
+    sm.depends_on = (C=[:a, :b],)
+    @test_throws ArgumentError SSD._resolve_dependence(sm)
+
+    return nothing
+end
+
+function test_depends_on_trial_count_and_override()
+    om = pd_obs_model()
+    om.depends_on = (C=[:a, :a, :b],)
+    lds = pd_lds(pd_state_model(), om)
+
+    rng = StableRNG(101)
+    y3 = [randn(rng, PD_OBS_DIM, 25) for _ in 1:3]
+    y2 = y3[1:2]
+
+    # Labels are written for 3 trials; 2 trials is a mismatch.
+    @test_throws SSD.DimensionMismatchError fit!(
+        lds, y2; max_iter=1, progress=false
+    )
+
+    # ... unless the call supplies its own labels.
+    @test fit!(lds, y2; depends_on=(C=[:a, :b],), max_iter=1, progress=false) isa Vector
+
+    # An override may only re-assign trials to groups the model already knows.
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :unseen],), max_iter=1, progress=false
+    )
+
+    # An override is meaningless without a declared dependence.
+    plain = pd_fresh_lds()
+    @test_throws ArgumentError fit!(
+        plain, y2; depends_on=(C=[:a, :b],), max_iter=1, progress=false
+    )
+
+    # A typo'd override key is rejected rather than silently ignored ...
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :b], nope=[:a, :a, :b]), max_iter=1, progress=false
+    )
+    # ... as is naming a parameter the model never declared as grouped.
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :b], R=[:a, :a, :b]), max_iter=1, progress=false
+    )
+
+    #=
+    An override is one NamedTuple resolved against *both* sub-models, so keys
+    belonging to the emission must not trip up the state model's resolution.
+    =#
+    sm = pd_state_model()
+    sm.depends_on = (Q=[:a, :a, :b],)
+    om2 = pd_obs_model()
+    om2.depends_on = (C=[:a, :a, :b],)
+    both = pd_lds(sm, om2)
+    @test fit!(
+        both, y2; depends_on=(Q=[:a, :b], C=[:a, :b]), max_iter=1, progress=false
+    ) isa Vector
+
+    return nothing
+end
+
+# ============================================================================
+# Accessors and storage layout
+# ============================================================================
+
+function test_group_accessors_and_aliasing()
+    labels = [:s1, :s1, :s2, :s2]
+    om = pd_obs_model()
+    om.depends_on = (C=labels,)
+    lds = pd_lds(pd_state_model(), om)
+
+    @test group_labels(om, :C) == [:s1, :s2]
+    @test group_labels(om, :d) == [:s1, :s2]     # alias of the same group
+    @test group_labels(om, :D) == [:s1, :s2]
+    @test isempty(group_labels(om, :R))          # R does not vary
+
+    @test_throws ArgumentError group_parameter(om, :R, :s1)
+    @test_throws ArgumentError group_parameter(om, :C, :nope)
+
+    grp = SSD.parameter_grouping(lds, length(labels))
+    @test grp !== nothing
+    @test grp.ncells == 2
+    @test grp.trial_cell == [1, 1, 2, 2]
+    @test grp.cell_trials == [[1, 2], [3, 4]]
+
+    variants = om.variants
+    @test variants !== nothing
+    @test length(variants) == 2
+    # Slot 1 aliases the base model, so `om.C` keeps its original meaning.
+    @test variants[1].C === om.C
+    @test group_parameter(om, :C, :s1) === om.C
+    # A varying parameter gets one array per group ...
+    @test variants[1].C !== variants[2].C
+    @test variants[1].d !== variants[2].d
+    # ... a fixed one is shared by reference, so a single M-step write covers all.
+    @test variants[1].R === variants[2].R
+    @test variants[1].R === om.R
+
+    return nothing
+end
+
+function test_grouping_is_the_join_of_label_vectors()
+    session = [:s1, :s1, :s2, :s2]
+    condition = [:c1, :c2, :c1, :c2]
+    sm = pd_state_model()
+    sm.depends_on = (Q=condition,)
+    om = pd_obs_model()
+    om.depends_on = (C=session,)
+    lds = pd_lds(sm, om)
+
+    grp = SSD.parameter_grouping(lds, 4)
+    # Q varies by condition and C by session, so a cell is one (session,
+    # condition) pair: four singleton cells.
+    @test grp.ncells == 4
+    @test sort(grp.trial_cell) == [1, 2, 3, 4]
+    @test grp.nslots[SSD._G_Q] == 2
+    @test grp.nslots[SSD._G_CD] == 2
+    @test grp.nslots[SSD._G_AB] == 1
+
+    return nothing
+end
+
+# ============================================================================
+# Equivalences
+# ============================================================================
+
+"""
+A `depends_on` whose labels are all identical adds no parameters, so it must
+reproduce the ungrouped fit.
+"""
+function test_single_group_matches_ungrouped()
+    rng = StableRNG(202)
+    truth = pd_fresh_lds()
+    _, y = StateSpaceDynamics.rand(rng, truth, fill(40, 5))
+
+    plain = pd_fresh_lds()
+    elbos_plain = fit!(plain, y; max_iter=8, tol=0.0, progress=false)
+
+    om = pd_obs_model()
+    om.depends_on = (C=fill(:only, 5), R=fill(:only, 5))
+    grouped = pd_lds(pd_state_model(), om)
+    elbos_grouped = fit!(grouped, y; max_iter=8, tol=0.0, progress=false)
+
+    @test elbos_grouped ≈ elbos_plain
+    @test grouped.obs_model.C ≈ plain.obs_model.C
+    @test grouped.obs_model.R ≈ plain.obs_model.R
+    @test grouped.state_model.A ≈ plain.state_model.A
+    @test grouped.state_model.Q ≈ plain.state_model.Q
+    @test grouped.state_model.x0 ≈ plain.state_model.x0
+
+    return nothing
+end
+
+"""
+When *every* parameter depends on the session, the sessions share nothing, so a
+grouped fit must equal two independent fits — same ELBO trace (summed) and same
+fitted parameters. This is the sharpest check that the per-cell E-step and the
+slot-wise M-step pooling agree with the ordinary path.
+"""
+function test_fully_grouped_matches_independent_fits()
+    rng = StableRNG(303)
+
+    truth1 = pd_fresh_lds()
+    _, y1 = StateSpaceDynamics.rand(rng, truth1, fill(35, 4))
+
+    truth2 = pd_fresh_lds()
+    truth2.obs_model.C .= [0.3 -1.0; 1.2 0.4]
+    truth2.obs_model.R .= Matrix(0.9 * I(PD_OBS_DIM))
+    truth2.state_model.A .= [0.7 0.3; -0.3 0.7]
+    _, y2 = StateSpaceDynamics.rand(rng, truth2, fill(35, 4))
+
+    y = vcat(y1, y2)
+    labels = vcat(fill(:s1, 4), fill(:s2, 4))
+
+    fit_kwargs = (; max_iter=6, tol=0.0, progress=false)
+
+    lds1 = pd_fresh_lds()
+    elbos1 = fit!(lds1, y1; fit_kwargs...)
+    lds2 = pd_fresh_lds()
+    elbos2 = fit!(lds2, y2; fit_kwargs...)
+
+    sm = pd_state_model()
+    sm.depends_on = (x0=labels, P0=labels, A=labels, Q=labels)
+    om = pd_obs_model()
+    om.depends_on = (C=labels, R=labels)
+    grouped = pd_lds(sm, om)
+    elbos_g = fit!(grouped, y; fit_kwargs...)
+
+    @test elbos_g ≈ elbos1 .+ elbos2
+
+    for (label, ref) in ((:s1, lds1), (:s2, lds2))
+        @test group_parameter(grouped.obs_model, :C, label) ≈ ref.obs_model.C
+        @test group_parameter(grouped.obs_model, :d, label) ≈ ref.obs_model.d
+        @test group_parameter(grouped.obs_model, :R, label) ≈ ref.obs_model.R
+        @test group_parameter(grouped.state_model, :A, label) ≈ ref.state_model.A
+        @test group_parameter(grouped.state_model, :b, label) ≈ ref.state_model.b
+        @test group_parameter(grouped.state_model, :Q, label) ≈ ref.state_model.Q
+        @test group_parameter(grouped.state_model, :x0, label) ≈ ref.state_model.x0
+        @test group_parameter(grouped.state_model, :P0, label) ≈ ref.state_model.P0
+    end
+
+    return nothing
+end
+
+"""
+Ragged trial lengths inside a group take the per-trial smoother fallback rather
+than the shared-covariance fast path; the answer must not depend on which.
+"""
+function test_grouped_handles_ragged_trial_lengths()
+    rng = StableRNG(404)
+    lds, labels = pd_two_session_truth(; ntrials_per_session=3)
+    _, y = StateSpaceDynamics.rand(rng, lds, [30, 41, 27, 33, 30, 38])
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    elbos = fit!(fitted, y; max_iter=10, tol=0.0, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    return nothing
+end
+
+# ============================================================================
+# Fitting behaviour
+# ============================================================================
+
+function test_grouped_elbo_increases_and_recovers_noise()
+    rng = StableRNG(505)
+    truth, labels = pd_two_session_truth(; ntrials_per_session=8)
+    _, y = StateSpaceDynamics.rand(rng, truth, fill(80, length(labels)))
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    elbos = fit!(fitted, y; max_iter=60, tol=1e-8, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    #=
+    `C` is identifiable only up to a shared linear transform of the latent
+    space, so compare what is identifiable: session 2 was simulated 7.5x
+    noisier, and each session's noise covariance must come back that way rather
+    than being averaged into one.
+    =#
+    R1 = group_parameter(fitted.obs_model, :R, :s1)
+    R2 = group_parameter(fitted.obs_model, :R, :s2)
+    @test isposdef(R1)
+    @test isposdef(R2)
+    @test tr(R2) > 3 * tr(R1)
+
+    # Letting the emissions differ by session must fit at least as well as
+    # forcing them to be shared.
+    shared = pd_fresh_lds()
+    fit!(shared, y; max_iter=60, tol=1e-8, progress=false)
+    @test loglikelihood(fitted, y) > loglikelihood(shared, y)
+
+    return nothing
+end
+
+function test_grouped_smooth_loglikelihood_and_heldout()
+    rng = StableRNG(606)
+    truth, labels = pd_two_session_truth(; ntrials_per_session=4)
+    _, y = StateSpaceDynamics.rand(rng, truth, fill(45, length(labels)))
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    fit!(fitted, y; max_iter=15, tol=1e-8, progress=false)
+
+    xs, Ps = smooth(fitted, y)
+    @test length(xs) == length(y)
+    @test size(xs[1]) == (PD_LATENT_DIM, 45)
+    @test size(Ps[1]) == (PD_LATENT_DIM, PD_LATENT_DIM, 45)
+    @test all(x -> all(isfinite, x), xs)
+
+    #=
+    Each cell's smoothed covariance is computed once and shared within the
+    cell, but the two sessions have different emissions, so their covariances
+    must differ — i.e. sharing is per group, not global.
+    =#
+    @test Ps[1] ≈ Ps[2]
+    @test !(Ps[1] ≈ Ps[end])
+
+    @test isfinite(loglikelihood(fitted, y))
+    @test isfinite(elbo(fitted, y))
+
+    # Held-out scoring: a different trial count needs a `depends_on` override.
+    y_new = y[[1, 5, 6]]
+    lab_new = labels[[1, 5, 6]]
+    @test_throws SSD.DimensionMismatchError loglikelihood(fitted, y_new)
+    @test isfinite(loglikelihood(fitted, y_new; depends_on=(C=lab_new, R=lab_new)))
+    xs_new, _ = smooth(fitted, y_new; depends_on=(C=lab_new, R=lab_new))
+    @test length(xs_new) == 3
+
+    return nothing
+end
+
+function test_grouped_integer_labels_and_priors()
+    rng = StableRNG(707)
+    labels = [1, 1, 2, 2, 2]          # integers, not Symbols
+    truth = pd_fresh_lds()
+    _, y = StateSpaceDynamics.rand(rng, truth, fill(40, 5))
+
+    sm = pd_state_model()
+    sm.Q_prior = IWPrior(; Ψ=Matrix(0.01 * I(PD_LATENT_DIM)), ν=6.0)
+    om = pd_obs_model()
+    om.R_prior = IWPrior(; Ψ=Matrix(0.05 * I(PD_OBS_DIM)), ν=6.0)
+    om.depends_on = (C=labels, R=labels)
+    fitted = pd_lds(sm, om)
+
+    elbos = fit!(fitted, y; max_iter=25, tol=1e-9, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    @test group_labels(om, :C) == [1, 2]
+    # Each version of `R` gets its own prior term and its own MAP update.
+    @test isposdef(group_parameter(om, :R, 1))
+    @test isposdef(group_parameter(om, :R, 2))
+
+    return nothing
+end
+
+function test_grouped_rand_needs_a_label_for_one_trial()
+    truth, labels = pd_two_session_truth(; ntrials_per_session=2)
+    rng = StableRNG(808)
+
+    # A single trial cannot be assigned to a group on its own.
+    @test_throws ArgumentError StateSpaceDynamics.rand(rng, truth, 20)
+    x, y = StateSpaceDynamics.rand(rng, truth, 20; depends_on=(C=[:s2], R=[:s2]))
+    @test size(y) == (PD_OBS_DIM, 20)
+
+    # Multi-trial sampling uses the model's own labels.
+    _, ys = StateSpaceDynamics.rand(rng, truth, fill(20, length(labels)))
+    @test length(ys) == length(labels)
+
+    return nothing
+end
+
+# ============================================================================
+# Poisson
+# ============================================================================
+
+function test_grouped_poisson_fit()
+    rng = StableRNG(909)
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+
+    sm = pd_state_model()
+    om = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
+    om.depends_on = (C=labels,)
+    truth = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+    C2 = group_parameter(om, :C, :s2)
+    C2 .= [-0.4 0.7; 0.5 -0.3]
+    d2 = group_parameter(om, :d, :s2)
+    d2 .= [0.2, 1.4]
+
+    _, y = StateSpaceDynamics.rand(rng, truth, fill(40, length(labels)))
+
+    om_fit = PoissonObservationModel([0.5 0.0; 0.0 0.5], [1.0, 1.0])
+    om_fit.depends_on = (C=labels,)
+    fitted = LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om_fit,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+
+    elbos = fit!(fitted, y; max_iter=8, tol=0.0, progress=false)
+    @test all(isfinite, elbos)
+    @test elbos[end] > elbos[1]
+
+    # The two sessions really did get separate emission parameters.
+    @test !(group_parameter(om_fit, :C, :s1) ≈ group_parameter(om_fit, :C, :s2))
+    @test isfinite(elbo(fitted, y))
+
+    xs, _ = smooth(fitted, y)
+    @test length(xs) == length(y)
+
+    return nothing
+end
+
+# ============================================================================
+# SLDS
+# ============================================================================
+
+function pd_slds(labels; K::Int=2)
+    ldss = map(1:K) do k
+        sm = pd_state_model()
+        sm.A .= k == 1 ? [0.95 0.05; -0.05 0.95] : [0.60 0.30; -0.30 0.60]
+        om = pd_obs_model()
+        if labels !== nothing
+            om.depends_on = (C=labels, R=labels)
+        end
+        return pd_lds(sm, om)
+    end
+    A = [0.9 0.1; 0.1 0.9]
+    πₖ = [0.5, 0.5]
+    return SLDS(; A=A, πₖ=πₖ, LDSs=ldss)
+end
+
+function test_grouped_slds_fit()
+    rng = StableRNG(1010)
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+
+    truth = pd_slds(labels)
+    for k in 1:2
+        C2 = group_parameter(truth.LDSs[k].obs_model, :C, :s2)
+        C2 .= [0.2 -0.9; 1.0 0.3]
+        R2 = group_parameter(truth.LDSs[k].obs_model, :R, :s2)
+        R2 .= Matrix(1.0 * I(PD_OBS_DIM))
+    end
+    _, _, y = StateSpaceDynamics.rand(rng, truth, fill(35, length(labels)))
+
+    fitted = pd_slds(labels)
+    elbos = fit!(fitted, y; max_iter=6, progress=false, rng=StableRNG(11))
+    @test length(elbos) == 6
+    @test all(isfinite, elbos)
+
+    # Each regime keeps a separate emission per session.
+    for k in 1:2
+        om = fitted.LDSs[k].obs_model
+        @test !(group_parameter(om, :C, :s1) ≈ group_parameter(om, :C, :s2))
+        @test isposdef(group_parameter(om, :R, :s1))
+        @test isposdef(group_parameter(om, :R, :s2))
+    end
+
+    # x0/P0 stay tied across regimes even when grouped.
+    @test fitted.LDSs[2].state_model.x0 ≈ fitted.LDSs[1].state_model.x0
+    @test fitted.LDSs[2].state_model.P0 ≈ fitted.LDSs[1].state_model.P0
+
+    @test isfinite(elbo(fitted, y; rng=StableRNG(12)))
+
+    return nothing
+end
+
+function test_grouped_slds_requires_matching_labels()
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+    slds = pd_slds(labels)
+    # Regime 2 disagrees about how trials are grouped.
+    slds.LDSs[2].obs_model.depends_on = (C=vcat(fill(:s1, 4), fill(:s2, 2)),)
+    @test_throws ArgumentError SSD._slds_parameter_grouping(slds, 6)
+
+    # A regime that declares nothing at all is also a disagreement.
+    slds2 = pd_slds(labels)
+    slds2.LDSs[2].obs_model.depends_on = nothing
+    @test_throws ArgumentError SSD._slds_parameter_grouping(slds2, 6)
+
+    # No regime declaring anything is simply the ungrouped path.
+    @test SSD._slds_parameter_grouping(pd_slds(nothing), 6) === nothing
+
+    return nothing
+end
+
+# ============================================================================
+# Display
+# ============================================================================
+
+function test_grouped_show()
+    labels = [:s1, :s1, :s2]
+    om = pd_obs_model()
+    om.depends_on = (C=labels, R=labels)
+    out = sprint(show, om)
+    @test occursin("Depends on:", out)
+    @test occursin("C, d, D", out)
+    @test occursin(":s2", out)
+
+    plain = sprint(show, pd_obs_model())
+    @test !occursin("Depends on:", plain)
+
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,39 @@ using SSDTest
                 test_poisson_gradient_shape_and_finiteness()
             end
         end
+
+        include("LinearDynamicalSystems/ParameterDependencies.jl")
+        @testset "Ancillary parameter dependencies" begin
+            @testset "Validation and accessors" begin
+                test_depends_on_validation()
+                test_depends_on_trial_count_and_override()
+                test_group_accessors_and_aliasing()
+                test_grouping_is_the_join_of_label_vectors()
+                test_grouped_show()
+            end
+
+            @testset "Equivalences" begin
+                test_single_group_matches_ungrouped()
+                test_fully_grouped_matches_independent_fits()
+                test_grouped_handles_ragged_trial_lengths()
+            end
+
+            @testset "Gaussian fitting" begin
+                test_grouped_elbo_increases_and_recovers_noise()
+                test_grouped_smooth_loglikelihood_and_heldout()
+                test_grouped_integer_labels_and_priors()
+                test_grouped_rand_needs_a_label_for_one_trial()
+            end
+
+            @testset "Poisson fitting" begin
+                test_grouped_poisson_fit()
+            end
+
+            @testset "SLDS fitting" begin
+                test_grouped_slds_fit()
+                test_grouped_slds_requires_matching_labels()
+            end
+        end
     end
 
     # Optimization primitives (line search + Newton)


### PR DESCRIPTION
Every AbstractStateModel and AbstractObservationModel gains a `depends_on` field (default `nothing`). Setting it to a NamedTuple of per-trial label vectors makes the named parameters be estimated separately for each group of trials, while everything else stays pooled:

    obs.depends_on = (C = session, R = session)

That is the stitching setup for combining recording sessions that observe different neurons in the same animal: latent dynamics shared by the animal, emission parameters specific to the session.

Design. A *cell* is a maximal set of trials sharing every parameter — the common refinement of all the label vectors. Trials in a cell are governed by a single LinearDynamicalSystem, so the E-step runs on each cell's sub-`Data` completely unchanged; only the M-step and the ELBO become group-aware. This keeps the equal-length shared-covariance fast path alive *within* each group (parameters differ between cells, so their covariances genuinely differ), and the O(D^2*T) workspace storage is allocated once and reused across cells, so a grouped fit's memory tracks an ungrouped one's rather than scaling with the number of sessions.

Keys canonicalize to the same groups fit_bool uses, since those parameters are fit jointly as one regression: :A/:b/:B name one group, :C/:d/:D another. Labels may be Symbols, integers or strings. Different parameters may use different label vectors.

Per-group values live in a new `variants` field holding one model object per parameter-group combination, with non-varying parameters shared by reference so a single M-step write covers all of them. They are read back with the new exported `group_labels` and `group_parameter`.

The covariance updates accumulate their residual scatter cell by cell, each with its own regression matrix, so a grouping of (say) C finer than that of R comes out right; the MN/IW prior terms are counted once per distinct parameter version. `update_Q!`, `update_R!` and `update_initial_state_covariance!` were refactored into accumulate/finalize halves so the grouped and ungrouped paths share one implementation.

Supported for the Gaussian LDS, the Poisson LDS and the SLDS across `fit!`, `smooth`, `elbo`, `loglikelihood` and `rand`, each of which also accepts a `depends_on` keyword overriding the model's stored labels so a held-out set with a different trial count can be scored without mutating the model. For an SLDS every regime must declare the same labels (the trial partition is a property of the data); x0/P0 stay tied across regimes.

With `depends_on` unset, every entry point takes its original code path.