### PR TITLE
refactor / split covariance M-steps and ELBO loops into reusable halves

### DIFF
--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -582,18 +582,24 @@ function update_initial_state_mean!(
     return nothing
 end
 
-function update_initial_state_covariance!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+"""
+    _accumulate_init_scatter!(S0, lds, suf)
+
+Add this model's initial-state scatter `Σγ(x₁-x0)(x₁-x0)' + Σγ P₁` to `S0`.
+
+`S0` is accumulated into rather than overwritten, so a caller fitting one `P0`
+from several models can sum their scatter — each contributing with *its own*
+`x0`. `update_initial_state_covariance!` is the single-model case.
+"""
+function _accumulate_init_scatter!(
+    S0::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    lds.fit_bool[2] || return nothing
     D = lds.latent_dim
     x0 = lds.state_model.x0
     N = suf.init_n
 
-    S0 = sws.reg.S0_sum                              # D × D scratch
-    copyto!(S0, suf.init_yy[])
+    S0 .+= suf.init_yy[]
 
-    # Scatter of the initial state around x0: S0 = Σγ(x₁-x0)(x₁-x0)' + Σγ P₁.
     # Rank-1 updates inline (BLAS.ger! would need a contiguous μ vector and
     # `view(init_xy, 1, :)` allocates a SubArray header — small but nonzero).
     for j in 1:D
@@ -605,35 +611,71 @@ function update_initial_state_covariance!(
             S0[i, j] += T(N) * x0_i * x0_j - x0_i * μ_j - μ_i * x0_j
         end
     end
+    return S0
+end
 
-    #=
-    Matrix-normal prior on x0 (the mean half of the NIW): fold κ₀(x0-μ₀)(x0-μ₀)'
-    into the IW scale, exactly as update_Q!/update_R! fold in their `Wm Λ Wm'`
-    term. Together with `P0_prior` (the IW half) this yields the NIW posterior
-    scale Ψₙ = Ψ + Σγ(x₁x₁'+P₁) + κ₀μ₀μ₀' - κₙ x0 x0'. `x0` must already hold the
-    NIW mean μₙ here (update_initial_state_mean! runs first in the M-step).
-    =#
+"""
+    _accumulate_x0_prior_scatter!(S0, lds)
+
+Add the mean half of the NIW prior, `κ₀(x0-μ₀)(x0-μ₀)'`, to the IW scale —
+exactly as `update_Q!`/`update_R!` fold in their `Wm Λ Wm'` term. Together with
+`P0_prior` (the IW half) this yields the NIW posterior scale
+`Ψₙ = Ψ + Σγ(x₁x₁'+P₁) + κ₀μ₀μ₀' - κₙ x0 x0'`. `x0` must already hold the NIW
+mean μₙ (`update_initial_state_mean!` runs first in the M-step).
+
+One call per distinct `x0`: when several `x0` versions share a `P0`, each
+contributes its own prior term.
+"""
+function _accumulate_x0_prior_scatter!(
+    S0::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     x0_prior = lds.state_model.x0_prior
-    if x0_prior !== nothing
-        κ₀ = x0_prior.Λ[1, 1]
-        μ₀ = x0_prior.M₀
-        for j in 1:D, i in 1:D
-            S0[i, j] += κ₀ * (x0[i] - μ₀[i, 1]) * (x0[j] - μ₀[j, 1])
-        end
+    x0_prior === nothing && return S0
+    D = lds.latent_dim
+    x0 = lds.state_model.x0
+    κ₀ = x0_prior.Λ[1, 1]
+    μ₀ = x0_prior.M₀
+    for j in 1:D, i in 1:D
+        S0[i, j] += κ₀ * (x0[i] - μ₀[i, 1]) * (x0[j] - μ₀[j, 1])
     end
-    Symmetrize!(S0)
+    return S0
+end
 
+"""
+    _finalize_P0!(lds, S0, N)
+
+Turn an accumulated initial-state scatter into `P0`: MLE `S0 / N`, or the IW MAP
+`(Ψ + S0) / (ν + N + D + 1)` when a `P0_prior` is set.
+"""
+function _finalize_P0!(
+    lds::LinearDynamicalSystem{T,S,O}, S0::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
     if lds.state_model.P0_prior === nothing
-        S0 ./= T(N)
+        S0 ./= N
     else
         Ψ, ν = lds.state_model.P0_prior.Ψ, lds.state_model.P0_prior.ν
         # iw_map inlined: (Ψ + S0) / (ν + N + D + 1)
-        denom = ν + T(N) + T(D + 1)
+        denom = ν + N + T(D + 1)
         for i in eachindex(S0)
             S0[i] = (Ψ[i] + S0[i]) / denom
         end
     end
     copyto!(lds.state_model.P0, S0)
+    return nothing
+end
+
+function update_initial_state_covariance!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    lds.fit_bool[2] || return nothing
+
+    S0 = sws.reg.S0_sum                              # D × D scratch
+    fill!(S0, zero(T))
+    _accumulate_init_scatter!(S0, lds, suf)
+    _accumulate_x0_prior_scatter!(S0, lds)
+    Symmetrize!(S0)
+    _finalize_P0!(lds, S0, T(suf.init_n))
     return nothing
 end
 
@@ -669,27 +711,49 @@ function update_A_b!(
     return nothing
 end
 
-function update_Q!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+"""
+    _pack_dyn_W!(W, lds)
+
+Write the stacked dynamics regression `[A b B]` into `W`
+(`latent_dim × (latent_dim + 1 + ux_dim)`).
+"""
+function _pack_dyn_W!(
+    W::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    lds.fit_bool[4] || return nothing
     D = lds.latent_dim
     ux_dim = lds.ux_dim
-
-    # sws.reg.AB is exactly (D × dyn_reg_dim); no view needed.
-    W = sws.reg.AB
     copyto!(view(W, :, 1:D), lds.state_model.A)
     copyto!(view(W, :, D + 1), lds.state_model.b)
     if ux_dim > 0
         copyto!(view(W, :, (D + 2):(D + 1 + ux_dim)), lds.state_model.B)
     end
+    return W
+end
 
-    # Residual scatter S = dyn_yy - W·dyn_xy - dyn_xy'·W' + W·dyn_xx·W'
+"""
+    _accumulate_dyn_scatter!(S_res, lds, suf, sws)
+
+Add this model's dynamics residual scatter
+`dyn_yy - W·dyn_xy - dyn_xy'·W' + W·dyn_xx·W'` (with `W = [A b B]`) to `S_res`.
+
+`S_res` is accumulated into rather than overwritten, so a caller fitting one `Q`
+from several models can sum their scatter — each contributing with its own
+`[A b B]`. Does **not** include the `AB_prior` term: that is one term per
+distinct `[A b B]`, added by `_accumulate_ab_prior_scatter!`.
+"""
+function _accumulate_dyn_scatter!(
+    S_res::AbstractMatrix{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
+    sws::SmoothWorkspace{T},
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    # sws.reg.AB is exactly (D × dyn_reg_dim); no view needed.
+    W = _pack_dyn_W!(sws.reg.AB, lds)
+
     Wxy = sws.elbo.temp                        # D × D scratch (free post-Q_state!)
     mul!(Wxy, W, suf.dyn_xy)
 
-    S_res = sws.reg.Q_sum                      # D × D scratch
-    copyto!(S_res, suf.dyn_yy[].mat)
+    S_res .+= suf.dyn_yy[].mat
     S_res .-= Wxy
     S_res .-= Wxy'
     #=
@@ -714,13 +778,36 @@ function update_Q!(
     copyto!(WL, W)
     BLAS.trmm!('R', 'U', 'T', 'N', one(T), suf.dyn_xx[].chol.factors, WL)
     mul!(S_res, WL, transpose(WL), one(T), one(T))
+    return S_res
+end
 
-    # MN-prior contribution to the IW posterior scale.
+"""
+    _accumulate_ab_prior_scatter!(S_res, lds, sws)
+
+Add the `AB_prior` contribution `Wm Λ Wm'` (`Wm = [A b B] - M₀`) to the IW
+posterior scale of `Q`. One call per distinct `[A b B]`.
+"""
+function _accumulate_ab_prior_scatter!(
+    S_res::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     AB_prior = lds.state_model.AB_prior
-    if AB_prior !== nothing
-        Wm = W .- AB_prior.M₀
-        S_res .+= Wm * AB_prior.Λ * Wm'
-    end
+    AB_prior === nothing && return S_res
+    W = _pack_dyn_W!(sws.reg.AB, lds)
+    Wm = W .- AB_prior.M₀
+    S_res .+= Wm * AB_prior.Λ * Wm'
+    return S_res
+end
+
+"""
+    _finalize_Q!(lds, S_res, N)
+
+Symmetrize an accumulated dynamics residual scatter and turn it into `Q`: MLE
+`S_res / N`, or the IW MAP `(Ψ + S_res) / (ν + N + D + 1)` under a `Q_prior`.
+"""
+function _finalize_Q!(
+    lds::LinearDynamicalSystem{T,S,O}, S_res::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
     #=
     Reflect upper → lower so the matrix is exactly symmetric. (`mul!`
     of `WL · WL'` above can give 1-ULP-asymmetric output; mirroring
@@ -733,7 +820,7 @@ function update_Q!(
 
     Q_prior = lds.state_model.Q_prior
     if Q_prior === nothing
-        S_res ./= T(suf.dyn_n)
+        S_res ./= N
     else
         #=
         iw_map(Ψ, ν, S, N, d) = (Ψ + S) / (ν + N + d + 1), inlined to
@@ -742,12 +829,25 @@ function update_Q!(
         `state_model.Q_prior` field), so we assert the concrete type
         locally to keep the loop type-stable.
         =#
-        denom = Q_prior.ν + T(suf.dyn_n) + T(D + 1)
+        denom = Q_prior.ν + N + T(D + 1)
         Ψ = Q_prior.Ψ::Matrix{T}
         for i in eachindex(S_res)
             S_res[i] = (Ψ[i] + S_res[i]) / denom
         end
     end
     copyto!(lds.state_model.Q, S_res)
+    return nothing
+end
+
+function update_Q!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    lds.fit_bool[4] || return nothing
+
+    S_res = sws.reg.Q_sum                      # D × D scratch
+    fill!(S_res, zero(T))
+    _accumulate_dyn_scatter!(S_res, lds, suf, sws)
+    _accumulate_ab_prior_scatter!(S_res, lds, sws)
+    _finalize_Q!(lds, S_res, T(suf.dyn_n))
     return nothing
 end

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -375,6 +375,41 @@ function mstep!(
 end
 
 """
+    _poisson_q_obs_total(plds, tfs, data, sws_pool)
+
+Observation-side Q-term summed over trials. The Poisson emission is
+irreducibly non-conjugate — there is no sufficient-statistic form — so this
+stays a per-trial loop, chunked across the workspace pool.
+"""
+function _poisson_q_obs_total(
+    plds::LinearDynamicalSystem{T,S,O},
+    tfs::TrialFilterSmooth{T},
+    data::Data{T},
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
+    y = data.y
+    uy = data.uy
+    ntrials = length(y)
+    ntasks = min(ntrials, length(sws_pool))
+    partial = zeros(T, ntasks)
+    chunksize = cld(ntrials, ntasks)
+    tforeach(1:ntasks) do i
+        lo = (i - 1) * chunksize + 1
+        hi = min(i * chunksize, ntrials)
+        lo > hi && return nothing
+        sws = sws_pool[i]
+        acc = zero(T)
+        for trial in lo:hi
+            fs = tfs[trial]
+            acc += Q_obs!(sws, plds, fs.x_smooth, fs.p_smooth, y[trial], uy[trial])
+        end
+        partial[i] = acc
+        return nothing
+    end
+    return sum(partial)
+end
+
+"""
     elbo!(plds, suf, tfs, data, sws_pool)
 
 Suf-based Poisson ELBO. Mirrors the Gaussian TD path's split:
@@ -395,10 +430,6 @@ function elbo!(
     data::Data{T},
     sws_pool::Vector{SmoothWorkspace{T}},
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    y = data.y
-    uy = data.uy
-    ntrials = length(y)
-
     total_entropy = zero(T)
     for fs in tfs.FilterSmooths
         total_entropy += fs.entropy
@@ -406,24 +437,7 @@ function elbo!(
 
     compute_smooth_constants!(sws_pool[1], plds)
     Q_state_total = Q_state!(sws_pool[1], plds, suf)
-
-    ntasks = min(ntrials, length(sws_pool))
-    partial = zeros(T, ntasks)
-    chunksize = cld(ntrials, ntasks)
-    tforeach(1:ntasks) do i
-        lo = (i - 1) * chunksize + 1
-        hi = min(i * chunksize, ntrials)
-        lo > hi && return nothing
-        sws = sws_pool[i]
-        acc = zero(T)
-        for trial in lo:hi
-            fs = tfs[trial]
-            acc += Q_obs!(sws, plds, fs.x_smooth, fs.p_smooth, y[trial], uy[trial])
-        end
-        partial[i] = acc
-        return nothing
-    end
-    Q_obs_total = sum(partial)
+    Q_obs_total = _poisson_q_obs_total(plds, tfs, data, sws_pool)
 
     prior_term = zero(T)
     if plds.state_model.Q_prior !== nothing

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -887,7 +887,7 @@ function _slds_trial_elbo(
     t2::Int,
     ux_trial::Union{Nothing,AbstractMatrix{T}},
     uy_trial::Union{Nothing,AbstractMatrix{T}},
-) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     K = length(slds.LDSs)
     Tsteps = t2 - t1 + 1
     w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps
@@ -897,7 +897,7 @@ function _slds_trial_elbo(
 
     # E_q[log p(y, x | z)], plug-in at the posterior mean, weighted by γ.
     for k in 1:K
-        ll = view(slds_ws.ll_tmp, 1:Tsteps)
+        ll = view(slds_ws.ll_tmp, 1:Tsteps)::AbstractVector{T}
         joint_loglikelihood!(
             ll,
             slds_ws,

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -878,7 +878,7 @@ constants.
 Assumes `slds_ws.consts` already holds the constants of `slds`.
 """
 function _slds_trial_elbo(
-    slds::SLDS{T},
+    slds::SLDS{T,S,O},
     fs::FilterSmooth{T},
     fb_storage::HMMs.ForwardBackwardStorage,
     y_trial::AbstractMatrix{T},
@@ -887,7 +887,7 @@ function _slds_trial_elbo(
     t2::Int,
     ux_trial::Union{Nothing,AbstractMatrix{T}},
     uy_trial::Union{Nothing,AbstractMatrix{T}},
-) where {T<:Real}
+) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     K = length(slds.LDSs)
     Tsteps = t2 - t1 + 1
     w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -868,6 +868,111 @@ function _slds_prior_logdensity(slds::SLDS{T}) where {T<:Real}
 end
 
 """
+    _slds_trial_elbo(slds, fs, fb_storage, y_trial, slds_ws, t1, t2, ux_trial, uy_trial)
+
+One trial's contribution to the SLDS ELBO (everything except the parameter
+log-prior). Split out of `elbo!` so a caller can evaluate a trial against a
+different parameter set than its neighbours, after refreshing the regime
+constants.
+
+Assumes `slds_ws.consts` already holds the constants of `slds`.
+"""
+function _slds_trial_elbo(
+    slds::SLDS{T},
+    fs::FilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    y_trial::AbstractMatrix{T},
+    slds_ws::SLDSSmoothWorkspace{T},
+    t1::Int,
+    t2::Int,
+    ux_trial::Union{Nothing,AbstractMatrix{T}},
+    uy_trial::Union{Nothing,AbstractMatrix{T}},
+) where {T<:Real}
+    K = length(slds.LDSs)
+    Tsteps = t2 - t1 + 1
+    w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps
+
+    trial_elbo = zero(T)
+    x_smooth_trial = fs.x_smooth
+
+    # E_q[log p(y, x | z)], plug-in at the posterior mean, weighted by γ.
+    for k in 1:K
+        ll = view(slds_ws.ll_tmp, 1:Tsteps)
+        joint_loglikelihood!(
+            ll,
+            slds_ws,
+            slds_ws.consts[k],
+            slds.LDSs[k],
+            x_smooth_trial,
+            y_trial,
+            ux_trial,
+            uy_trial,
+        )
+        for t in 1:Tsteps
+            trial_elbo += w[k, t] * ll[t]
+        end
+    end
+
+    #=
+    ½ tr(H Σ) covariance correction. H = weighted Hessian (hessian! writes
+    it un-negated into slds_ws.btd); Σ = p_smooth on the diagonal,
+    p_smooth_tt1[:,:,t] = Cov(x_t, x_{t-1}) off it. Sum both off-diagonal
+    traces rather than doubling one — don't assume exact block symmetry.
+    =#
+    hessian!(slds_ws, slds, x_smooth_trial, y_trial, w, uy_trial)
+    H_diag = slds_ws.btd.H_diag
+    H_sub = slds_ws.btd.H_sub
+    H_super = slds_ws.btd.H_super
+    for t in 1:Tsteps
+        trial_elbo += T(0.5) * _tr_prod(H_diag[t], view(fs.p_smooth, :, :, t))
+    end
+    for t in 2:Tsteps
+        Σ_ttm1 = view(fs.p_smooth_tt1, :, :, t)  # Cov(x_t, x_{t-1})
+        trial_elbo += T(0.5) * _tr_prod(H_super[t - 1], Σ_ttm1)
+        trial_elbo += T(0.5) * _tr_prod(H_sub[t - 1], transpose(Σ_ttm1))
+    end
+
+    # E_q[log p(z_1)].
+    for k in 1:K
+        trial_elbo += w[k, 1] * log(slds.πₖ[k] + T(1e-12))
+    end
+
+    #=
+    E_q[log p(z_t | z_{t-1})] = Σ_t Σ_ij ξ_t[i,j] log A[i,j]. ξ is global-
+    indexed; ξ[t2] is zero by FB convention, so iterate t1..t2-1.
+    =#
+    for t in t1:(t2 - 1)
+        ξt = fb_storage.ξ[t]
+        for i in 1:K, j in 1:K
+            trial_elbo += ξt[i, j] * log(slds.A[i, j] + T(1e-12))
+        end
+    end
+
+    # + H[q(x)] (filled by `smooth!` from the BT log-determinant).
+    trial_elbo += fs.entropy
+
+    #=
+    + H[q(z)], the FB chain entropy
+    −Σ_k γ₁ log γ₁ − Σ_t Σ_ij ξ_t[i,j] (log ξ_t[i,j] − log γ_t[i]).
+    ξ_t[i,j] > 0 ⇒ γ_t[i] > 0, so both logs are safe.
+    =#
+    for k in 1:K
+        wk1 = w[k, 1]
+        wk1 > 0 && (trial_elbo -= wk1 * log(wk1))
+    end
+    for t in t1:(t2 - 1)
+        ξt = fb_storage.ξ[t]
+        tloc = t - t1 + 1
+        for i in 1:K, j in 1:K
+            ξij = ξt[i, j]
+            ξij > 0 && (trial_elbo -= ξij * (log(ξij) - log(w[i, tloc])))
+        end
+    end
+
+    return trial_elbo
+end
+
+"""
     elbo!(slds, tfs, fb_storage, y, slds_ws; seq_ends)
 
 Evidence lower bound for the SLDS at the current variational posteriors —
@@ -908,95 +1013,20 @@ function elbo!(
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
     total_elbo = zero(T)
     ntrials = length(y)
-    K = length(slds.LDSs)
 
     for trial in 1:ntrials
         t1, t2 = HMMs.seq_limits(seq_ends, trial)
-        Tsteps = t2 - t1 + 1
-        y_trial = y[trial]
-        ux_trial = ux === nothing ? nothing : ux[trial]
-        uy_trial = uy === nothing ? nothing : uy[trial]
-        w = view(fb_storage.γ, :, t1:t2)  # K × Tsteps
-
-        trial_elbo = zero(T)
-        fs = tfs[trial]
-        x_smooth_trial = fs.x_smooth
-
-        # E_q[log p(y, x | z)], plug-in at the posterior mean, weighted by γ.
-        for k in 1:K
-            ll = view(slds_ws.ll_tmp, 1:Tsteps)
-            joint_loglikelihood!(
-                ll,
-                slds_ws,
-                slds_ws.consts[k],
-                slds.LDSs[k],
-                x_smooth_trial,
-                y_trial,
-                ux_trial,
-                uy_trial,
-            )
-            for t in 1:Tsteps
-                trial_elbo += w[k, t] * ll[t]
-            end
-        end
-
-        #=
-        ½ tr(H Σ) covariance correction. H = weighted Hessian (hessian! writes
-        it un-negated into slds_ws.btd); Σ = p_smooth on the diagonal,
-        p_smooth_tt1[:,:,t] = Cov(x_t, x_{t-1}) off it. Sum both off-diagonal
-        traces rather than doubling one — don't assume exact block symmetry.
-        =#
-        hessian!(slds_ws, slds, x_smooth_trial, y_trial, w, uy_trial)
-        H_diag = slds_ws.btd.H_diag
-        H_sub = slds_ws.btd.H_sub
-        H_super = slds_ws.btd.H_super
-        for t in 1:Tsteps
-            trial_elbo += T(0.5) * _tr_prod(H_diag[t], view(fs.p_smooth, :, :, t))
-        end
-        for t in 2:Tsteps
-            Σ_ttm1 = view(fs.p_smooth_tt1, :, :, t)  # Cov(x_t, x_{t-1})
-            trial_elbo += T(0.5) * _tr_prod(H_super[t - 1], Σ_ttm1)
-            trial_elbo += T(0.5) * _tr_prod(H_sub[t - 1], transpose(Σ_ttm1))
-        end
-
-        # E_q[log p(z_1)].
-        for k in 1:K
-            trial_elbo += w[k, 1] * log(slds.πₖ[k] + T(1e-12))
-        end
-
-        #=
-        E_q[log p(z_t | z_{t-1})] = Σ_t Σ_ij ξ_t[i,j] log A[i,j]. ξ is global-
-        indexed; ξ[t2] is zero by FB convention, so iterate t1..t2-1.
-        =#
-        for t in t1:(t2 - 1)
-            ξt = fb_storage.ξ[t]
-            for i in 1:K, j in 1:K
-                trial_elbo += ξt[i, j] * log(slds.A[i, j] + T(1e-12))
-            end
-        end
-
-        # + H[q(x)] (filled by `smooth!` from the BT log-determinant).
-        trial_elbo += fs.entropy
-
-        #=
-        + H[q(z)], the FB chain entropy
-        −Σ_k γ₁ log γ₁ − Σ_t Σ_ij ξ_t[i,j] (log ξ_t[i,j] − log γ_t[i]).
-        ξ_t[i,j] > 0 ⇒ γ_t[i] > 0, so both logs are safe.
-        =#
-        for k in 1:K
-            wk1 = w[k, 1]
-            wk1 > 0 && (trial_elbo -= wk1 * log(wk1))
-        end
-        for t in t1:(t2 - 1)
-            ξt = fb_storage.ξ[t]
-            tloc = t - t1 + 1
-            for i in 1:K, j in 1:K
-                ξij = ξt[i, j]
-                ξij > 0 && (trial_elbo -= ξij * (log(ξij) - log(w[i, tloc])))
-            end
-        end
-
-        total_elbo += trial_elbo
+        total_elbo += _slds_trial_elbo(
+            slds,
+            tfs[trial],
+            fb_storage,
+            y[trial],
+            slds_ws,
+            t1,
+            t2,
+            ux === nothing ? nothing : ux[trial],
+            uy === nothing ? nothing : uy[trial],
+        )
     end
 
     return total_elbo + _slds_prior_logdensity(slds)

--- a/src/lds/gaussian_observations.jl
+++ b/src/lds/gaussian_observations.jl
@@ -163,28 +163,49 @@ function update_C_d!(
     return nothing
 end
 
-function update_R!(
-    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
-) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    lds.fit_bool[6] || return nothing
-    p = lds.obs_dim
+"""
+    _pack_obs_V!(V, lds)
+
+Write the stacked emission regression `[C d D]` into `V`
+(`obs_dim × (latent_dim + 1 + uy_dim)`).
+"""
+function _pack_obs_V!(
+    V::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
     D = lds.latent_dim
     uy_dim = lds.uy_dim
-
-    # sws.reg.CD is exactly (p × obs_reg_dim); no view needed.
-    V = sws.reg.CD
     copyto!(view(V, :, 1:D), lds.obs_model.C)
     copyto!(view(V, :, D + 1), lds.obs_model.d)
     if uy_dim > 0
         copyto!(view(V, :, (D + 2):(D + 1 + uy_dim)), lds.obs_model.D)
     end
+    return V
+end
 
-    # Residual scatter S = obs_yy - V·obs_xy - obs_xy'·V' + V·obs_xx·V'
+"""
+    _accumulate_obs_scatter!(S_res, lds, suf, sws)
+
+Add this model's emission residual scatter
+`obs_yy - V·obs_xy - obs_xy'·V' + V·obs_xx·V'` (with `V = [C d D]`) to `S_res`.
+
+`S_res` is accumulated into rather than overwritten, so a caller fitting one `R`
+from several models can sum their scatter — each contributing with its own
+`[C d D]`. Does **not** include the `CD_prior` term: that is one term per
+distinct `[C d D]`, added by `_accumulate_cd_prior_scatter!`.
+"""
+function _accumulate_obs_scatter!(
+    S_res::AbstractMatrix{T},
+    lds::LinearDynamicalSystem{T,S,O},
+    suf::SufficientStatistics{T},
+    sws::SmoothWorkspace{T},
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    # sws.reg.CD is exactly (p × obs_reg_dim); no view needed.
+    V = _pack_obs_V!(sws.reg.CD, lds)
+
     Vxy = sws.elbo.obs_temp                    # p × p scratch (free post-Q_obs!)
     mul!(Vxy, V, suf.obs_xy)
 
-    S_res = sws.elbo.obs_work                  # p × p scratch
-    copyto!(S_res, suf.obs_yy[].mat)
+    S_res .+= suf.obs_yy[].mat
     S_res .-= Vxy
     S_res .-= Vxy'
     #=
@@ -205,24 +226,60 @@ function update_R!(
     copyto!(VL, V)
     BLAS.trmm!('R', 'U', 'T', 'N', one(T), suf.obs_xx[].chol.factors, VL)
     mul!(S_res, VL, transpose(VL), one(T), one(T))
+    return S_res
+end
 
+"""
+    _accumulate_cd_prior_scatter!(S_res, lds, sws)
+
+Add the `CD_prior` contribution `Wm Λ Wm'` (`Wm = [C d D] - M₀`) to the IW
+posterior scale of `R`. One call per distinct `[C d D]`.
+"""
+function _accumulate_cd_prior_scatter!(
+    S_res::AbstractMatrix{T}, lds::LinearDynamicalSystem{T,S,O}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     CD_prior = lds.obs_model.CD_prior
-    if CD_prior !== nothing
-        Wm = V .- CD_prior.M₀
-        S_res .+= Wm * CD_prior.Λ * Wm'
-    end
+    CD_prior === nothing && return S_res
+    V = _pack_obs_V!(sws.reg.CD, lds)
+    Wm = V .- CD_prior.M₀
+    S_res .+= Wm * CD_prior.Λ * Wm'
+    return S_res
+end
 
+"""
+    _finalize_R!(lds, S_res, N)
+
+Symmetrize an accumulated emission residual scatter and turn it into `R`: MLE
+`S_res / N`, or the IW MAP under an `R_prior`.
+"""
+function _finalize_R!(
+    lds::LinearDynamicalSystem{T,S,O}, S_res::AbstractMatrix{T}, N::T
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    p = lds.obs_dim
     for j in 2:p, i in 1:(j - 1)
         S_res[j, i] = S_res[i, j]
     end
 
     if lds.obs_model.R_prior === nothing
-        S_res ./= T(suf.obs_n)
+        S_res ./= N
     else
         Ψ, ν = lds.obs_model.R_prior.Ψ, lds.obs_model.R_prior.ν
-        S_res .= iw_map(Ψ, ν, S_res, T(suf.obs_n), p)
+        S_res .= iw_map(Ψ, ν, S_res, N, p)
     end
     copyto!(lds.obs_model.R, S_res)
+    return nothing
+end
+
+function update_R!(
+    lds::LinearDynamicalSystem{T,S,O}, suf::SufficientStatistics{T}, sws::SmoothWorkspace{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    lds.fit_bool[6] || return nothing
+
+    S_res = sws.elbo.obs_work                  # p × p scratch
+    fill!(S_res, zero(T))
+    _accumulate_obs_scatter!(S_res, lds, suf, sws)
+    _accumulate_cd_prior_scatter!(S_res, lds, sws)
+    _finalize_R!(lds, S_res, T(suf.obs_n))
     return nothing
 end
 


### PR DESCRIPTION
**1 of 5 — splitting #165 into reviewable pieces.** Pure refactor: no behavior change, no new API, no new tests. The existing suite is the proof.

### Why

#165 needs to fit one covariance from several models at once — e.g. a single `R` estimated from the pooled residual scatter of trials whose emission matrices differ. The current updates compute a residual scatter, add a prior term, and finalize in one function body, so there is no seam to pool at. This PR opens the seams and changes nothing else.

### What

Each covariance update becomes an accumulate half and a finalize half, with the existing entry point calling both:

| was | becomes |
|:--|:--|
| `update_initial_state_covariance!` | `_accumulate_init_scatter!` + `_accumulate_x0_prior_scatter!` + `_finalize_P0!` |
| `update_Q!` | `_accumulate_dyn_scatter!` + `_accumulate_ab_prior_scatter!` + `_finalize_Q!` |
| `update_R!` | `_accumulate_obs_scatter!` + `_accumulate_cd_prior_scatter!` + `_finalize_R!` |

The accumulators `+=` into the scatter matrix instead of overwriting it, and the entry points now zero the scratch buffer first, call the halves in the original order, and finalize — so the single-model arithmetic is unchanged operation for operation. The prior scatter is a separate call because a prior term belongs to a *regression*, and #165 can have several regressions sharing one covariance.

Packing the stacked regressions into a workspace buffer is factored out as `_pack_dyn_W!` (`[A b B]`) and `_pack_obs_V!` (`[C d D]`), shared by the residual-scatter, prior-scatter, and log-density paths.

Two per-trial loops move out of their enclosing ELBO functions with their bodies byte-identical:

- `_poisson_q_obs_total` out of the Poisson `elbo!`
- `_slds_trial_elbo` out of the SLDS `elbo!`

so that a trial can later be evaluated against a parameter set that differs from its neighbours'.

### Review notes

- `_finalize_P0!`/`_finalize_Q!`/`_finalize_R!` take the sample count `N` as an argument rather than reading `suf.*_n`, since a pooled fit's `N` is a sum over models.
- The symmetrization stays where it was — after the prior term, before the MAP division — so IW posteriors are unaffected.
- Nothing here is exported, and no call site outside these files changes.

### Follow-ups in this series

2. `depends_on`: declare, validate, and read back per-group parameters
3. Grouped EM for the Gaussian LDS
4. Grouped EM for the Poisson LDS
5. Grouped EM for the SLDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgmEbyHewqUYTJLFegAoK5)_