### PR TITLE
feature / grouped EM for the Gaussian LDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     throw an `ArgumentError` on a model that declares `depends_on` rather than
     silently fitting one pooled parameter set
   * With `depends_on` unset, every entry point takes its original code path
+  * A regression pooled over groups whose noise covariance differs — `(R =
+    session,)` with one emission over every session, or `(Q = session,)` with
+    one set of dynamics — is fitted by generalized least squares. Held fixed,
+    the covariance divides out of the score only when the units share it; when
+    they do not the output rows couple, and solving the pooled normal equations
+    walks the ELBO downhill. The GLS solve reduces to exactly the pooled answer
+    when the covariances agree, so the cheap path stays a special case rather
+    than a second estimator, and is only reached when they genuinely differ
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     with the new exported `group_labels(model, name)` and
     `group_parameter(model, name, label)`
   * `show` reports the declared groups for a model that has any
-  * **Not yet honoured by fitting.** The grouped E/M-step lands in a follow-up;
-    until it does, `fit!`, `smooth`, `elbo`, `loglikelihood` and `rand` throw
-    an `ArgumentError` on a model that declares `depends_on` rather than
+  * Honoured by the **Gaussian LDS** across `fit!`, `smooth`, `elbo`,
+    `loglikelihood` and `rand`, each of which also accepts a `depends_on`
+    keyword overriding the model's stored labels so a held-out set with a
+    different trial count can be scored without mutating the model. All
+    versions of a parameter share the model's prior; each version contributes
+    its own log-prior term to the ELBO
+  * The efficiency of same-length epochs is preserved *within* each group:
+    trials sharing every parameter form a cell, and the smoothed covariance is
+    computed once per cell and shared across it (parameters differ between
+    cells, so their covariances genuinely differ). The `O(D²·T)` workspace
+    storage is allocated once and reused across cells, so a grouped fit's
+    memory tracks an ungrouped one's instead of scaling with the number of
+    groups
+  * **The Poisson LDS and the SLDS are not wired up yet.** Their grouped
+    E/M-steps land in follow-ups; until then their `fit!`, `smooth` and `elbo`
+    throw an `ArgumentError` on a model that declares `depends_on` rather than
     silently fitting one pooled parameter set
+  * With `depends_on` unset, every entry point takes its original code path
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/docs/src/LinearDynamicalSystems.md
+++ b/docs/src/LinearDynamicalSystems.md
@@ -375,3 +375,82 @@ fit!(lds, Y; max_iter=20, progress=false)
 ```
 
 Any subset works.
+
+## Parameters that depend on an ancillary variable
+
+Both sub-models carry a `depends_on` field. Leaving it `nothing` (the default)
+gives the usual behaviour: one parameter set shared by every trial. Setting it
+to a `NamedTuple` of per-trial label vectors makes the named parameters be
+**estimated separately for each group of trials**.
+
+The motivating case is stitching several recording sessions from one animal.
+The latent dynamics belong to the animal and should be pooled; the emissions
+belong to the session, because each session records a different set of neurons:
+
+```julia
+using LinearAlgebra, Random, StateSpaceDynamics
+
+session = vcat(fill(:day1, 20), fill(:day2, 15))   # one label per trial
+
+gsm = GaussianStateModel(A = A, Q = Q, b = b, x0 = x0, P0 = P0)
+gom = GaussianObservationModel(C = C, R = R, d = d)
+gom.depends_on = (C = session, R = session)        # C, d, D and R per session
+
+lds = LinearDynamicalSystem(gsm, gom)
+fit!(lds, Y; max_iter = 50)
+
+group_labels(gom, :C)                # [:day1, :day2]
+group_parameter(gom, :C, :day1)      # that session's emission matrix
+group_parameter(gom, :R, :day2)      # that session's observation noise
+```
+
+### Which names are valid
+
+Keys are canonicalized to the same groups `fit_bool` uses, because those
+parameters are fit jointly as one regression:
+
+| Key(s)           | Group                  | `fit_bool` index    |
+|:-----------------|:-----------------------|:--------------------|
+| `:x0`            | initial state mean     | 1                   |
+| `:P0`            | initial state cov      | 2                   |
+| `:A`, `:b`, `:B` | dynamics `[A b B]`     | 3                   |
+| `:Q`             | process noise          | 4                   |
+| `:C`, `:d`, `:D` | emission `[C d D]`     | 5                   |
+| `:R`             | observation noise      | 6 (Gaussian only)   |
+
+`:d` is therefore an alias for `:C`: naming either makes the whole `[C d D]`
+regression group-dependent. Naming two aliases of one group with different
+label vectors is an error.
+
+Labels can be `Symbol`s, integers or strings — anything comparable. Groups are
+ordered by first appearance in the vector set on the model.
+
+Different parameters may use different label vectors: `(Q = condition, C =
+session)` fits one `Q` per condition and one `[C d D]` per session.
+
+### Held-out data
+
+The label vectors live on the model and have one entry per fitted trial, so
+scoring a held-out set with a different trial count needs its own labels.
+`fit!`, `smooth`, `elbo`, `loglikelihood` and `rand` all take a `depends_on`
+keyword that overrides the stored labels for that call:
+
+```julia
+ll = loglikelihood(lds, Y_test; depends_on = (C = session_test, R = session_test))
+```
+
+An override re-assigns trials to groups the model already declares; it cannot
+introduce a new parameter set.
+
+### Priors and cost
+
+All versions of a parameter share the model's prior (`Q_prior`, `R_prior`,
+`CD_prior`, …), and each version contributes its own log-prior term to the
+ELBO.
+
+Grouping does not give up the efficiency of equal-length epochs. Trials that
+share every parameter form a *cell*, and the smoother computes one covariance
+per cell and shares it across that cell's trials, exactly as it does across all
+trials of an ungrouped model. The expensive `O(D²·T)` workspace storage is
+allocated once and reused across cells, so a grouped fit's memory tracks an
+ungrouped one's rather than growing with the number of sessions.

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -49,6 +49,9 @@ include("lds/continuous_latents.jl")                # state-model Q-term + state
 include("lds/gaussian_observations.jl")
 include("lds/poisson_observations.jl")
 
+# Grouped (`depends_on`) M-step + ELBO machinery, shared by LDS / PLDS / SLDS.
+include("lds/grouped_em.jl")
+
 # Fitting Functions
 include("lds/fit_LDS.jl")
 include("lds/fit_PLDS.jl")

--- a/src/lds/continuous_latents.jl
+++ b/src/lds/continuous_latents.jl
@@ -703,6 +703,22 @@ function update_A_b!(
         W = mn_map(suf.dyn_xx[], suf.dyn_xy, AB_prior)
     end
 
+    _unpack_dyn_W!(lds, W)
+    return nothing
+end
+
+"""
+    _unpack_dyn_W!(lds, W)
+
+Write a stacked dynamics regression `W = [A b B]` back into `lds`. The inverse
+of [`_pack_dyn_W!`](@ref); shared by the ordinary M-step and by callers that
+solve for `W` themselves (see `_tied_gls_regression`).
+"""
+function _unpack_dyn_W!(
+    lds::LinearDynamicalSystem{T,S,O}, W::AbstractMatrix{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
+    ux_dim = lds.ux_dim
     copyto!(lds.state_model.A, view(W, :, 1:D))
     copyto!(lds.state_model.b, view(W, :, D + 1))
     if ux_dim > 0

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -109,6 +109,10 @@ variant see `smooth!`).
 - `ux` / `uy`: optional dynamics / observation input sequences in the same
   shape family as `y`. Required when `size(state_model.B, 2) > 0` /
   `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 # Returns
 For a single-trial (matrix) `y`:
@@ -122,9 +126,11 @@ function smooth(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    _reject_unsupported_dependence(lds)
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _grouped_smooth(lds, data, grp, y)
     tfs = _smooth_data(lds, data)
     return _collect_smooth_output(tfs, y)
 end
@@ -765,6 +771,10 @@ objective the M-step optimizes).
 - `ux` / `uy`: optional dynamics / observation input sequences in the same
   shape family as `y`. Required when `size(state_model.B, 2) > 0` /
   `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -773,9 +783,15 @@ function elbo(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    _reject_unsupported_dependence(lds)
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    if grp !== nothing
+        sws_pool = _grouped_sws_pool(lds, data)
+        state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+        return _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+    end
     tfs = initialize_FilterSmooth(lds, data.tsteps)::TrialFilterSmooth{T}
     npool = min(Threads.maxthreadid(), length(data.y))
     sws_pool = [
@@ -839,6 +855,11 @@ Fit a Gaussian Linear Dynamical System via Expectation-Maximization.
   (each trial `(ux_dim, T_i)`); required when `size(state_model.B, 2) > 0`.
 - `uy`: optional observation-input sequence (same shape family) for the
   obs-side input matrix `D`. Required when `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` stored on the state / observation models for this call. Use it
+  to fit or score a dataset whose trial count differs from the one the labels
+  on the model were written for; it may only re-assign trials to groups the
+  model already declares.
 
 Returns a `Vector{T}` of ELBO values, one per iteration.
 """
@@ -850,10 +871,109 @@ function fit!(
     progress::Bool=true,
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
-    _reject_unsupported_dependence(lds)
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _fit_tridiag_grouped!(
+        lds, data, grp; max_iter=max_iter, tol=tol, progress=progress
+    )
     return _fit_tridiag!(lds, data; max_iter=max_iter, tol=tol, progress=progress)
+end
+
+"""
+    _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+
+One grouped E-step: smooth and aggregate each cell with its own parameters, and
+return the total ELBO.
+
+Each cell runs the ordinary `estep!` on its sub-`Data`, so a cell whose trials
+are equal-length still computes its smoothed covariance once and shares it
+across the cell — the efficiency of same-length epochs is preserved *within*
+each group of labels rather than across the whole dataset (parameters differ
+between cells, so their covariances genuinely differ). The Q-terms are summed
+per cell while the workspace still holds that cell's Cholesky constants; the
+prior terms are added once per distinct parameter version.
+"""
+function _grouped_estep_elbo_gaussian!(
+    state::GroupedFitState{T,L},
+    grp::ParameterGrouping,
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {
+    T<:Real,
+    L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:GaussianObservationModel{T}},
+}
+    total = zero(T)
+    for c in 1:grp.ncells
+        lds_c = state.cell_lds[c]
+        suf_c = state.sufs[c]
+        _prepare_cell!(sws_pool[1], state, c)
+        estep!(lds_c, suf_c, state.cell_tfs[c], state.cell_data[c], sws_pool)
+
+        #=
+        `estep!` leaves the cell's constants on `sws_pool[1]` already, but the
+        parallel per-trial fallback reaches that state through a task, so
+        recompute explicitly rather than rely on which chunk ran last.
+        =#
+        compute_smooth_constants!(sws_pool[1], lds_c)
+        total += Q_state!(sws_pool[1], lds_c, suf_c)
+        total += Q_obs!(sws_pool[1], lds_c, suf_c)
+        for fs in state.cell_tfs[c].FilterSmooths
+            total += fs.entropy
+        end
+    end
+    total += _grouped_state_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    total += _grouped_gaussian_obs_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    return total
+end
+
+"""
+    _fit_tridiag_grouped!(lds, data, grp; max_iter, tol, progress)
+
+EM driver for a Gaussian LDS whose parameters depend on an ancillary variable.
+Identical in structure to [`_fit_tridiag!`](@ref): E-step, ELBO, M-step,
+convergence check — but the E-step runs per cell and the M-step pools each
+cell's sufficient statistics per parameter version.
+"""
+function _fit_tridiag_grouped!(
+    lds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping;
+    max_iter::Int=100,
+    tol::Float64=1e-6,
+    progress::Bool=true,
+) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
+    sws_pool = _grouped_sws_pool(lds, data)
+    state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+    elbos = Vector{T}(undef, max_iter)
+
+    prog = if progress
+        Progress(max_iter; desc="Fitting grouped LDS via EM...", barlen=50, showspeed=true)
+    else
+        nothing
+    end
+
+    for iter in 1:max_iter
+        elbos[iter] = _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
+
+        _grouped_state_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+        _grouped_gaussian_obs_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+
+        prog !== nothing && next!(prog)
+
+        if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
+            prog !== nothing && finish!(prog)
+            resize!(elbos, iter)
+            return elbos
+        end
+    end
+
+    prog !== nothing && finish!(prog)
+    return elbos
 end
 
 function _fit_tridiag!(
@@ -1088,6 +1208,10 @@ see `_filter_cov_pass`. Trial lengths may differ.
 - `ux` / `uy`: optional dynamics / observation input sequences, in the same
   shape family as `y` (matrix, 3-D array, or vector of matrices). Required
   when `size(state_model.B, 2) > 0` / `size(obs_model.D, 2) > 0`.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 This is the `StatsAPI.loglikelihood` method for the LDS; for the complete-data
 log-likelihood `log p(x, y)` given a trajectory `x`, see `joint_loglikelihood`.
@@ -1100,9 +1224,30 @@ function StatsAPI.loglikelihood(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,SM<:GaussianStateModel{T},OM<:GaussianObservationModel{T}}
-    _reject_unsupported_dependence(lds)
     data = Data(lds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+
+    #=
+    The filter's covariance pass depends only on the parameters and the trial
+    length, so it is shared across the trials of one cell exactly as it is
+    shared across all trials of an ungrouped model.
+    =#
+    if grp !== nothing
+        total_ll = zero(T)
+        for c in 1:grp.ncells
+            trials = grp.cell_trials[c]
+            lds_c = _cell_lds(lds, grp, c)
+            S_chol, K = _filter_cov_pass(lds_c, maximum(data.tsteps[n] for n in trials))
+            for n in trials
+                total_ll += _filter_ll_trial(
+                    lds_c, data.y[n], data.ux[n], data.uy[n], S_chol, K
+                )
+            end
+        end
+        return total_ll
+    end
 
     S_chol, K = _filter_cov_pass(lds, maximum(data.tsteps))
 

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -904,7 +904,7 @@ function _grouped_estep_elbo_gaussian!(
     L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:GaussianObservationModel{T}},
 }
     total = zero(T)
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         lds_c = state.cell_lds[c]
         suf_c = state.sufs[c]
         _prepare_cell!(sws_pool[1], state, c)
@@ -1236,7 +1236,7 @@ function StatsAPI.loglikelihood(
     =#
     if grp !== nothing
         total_ll = zero(T)
-        for c in 1:grp.ncells
+        for c in 1:(grp.ncells)
             trials = grp.cell_trials[c]
             lds_c = _cell_lds(lds, grp, c)
             S_chol, K = _filter_cov_pass(lds_c, maximum(data.tsteps[n] for n in trials))

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -910,11 +910,8 @@ function _grouped_estep_elbo_gaussian!(
         _prepare_cell!(sws_pool[1], state, c)
         estep!(lds_c, suf_c, state.cell_tfs[c], state.cell_data[c], sws_pool)
 
-        #=
-        `estep!` leaves the cell's constants on `sws_pool[1]` already, but the
-        parallel per-trial fallback reaches that state through a task, so
-        recompute explicitly rather than rely on which chunk ran last.
-        =#
+        # The parallel fallback reaches this state through a task, so recompute
+        # rather than rely on which chunk ran last.
         compute_smooth_constants!(sws_pool[1], lds_c)
         total += Q_state!(sws_pool[1], lds_c, suf_c)
         total += Q_obs!(sws_pool[1], lds_c, suf_c)
@@ -1229,11 +1226,8 @@ function StatsAPI.loglikelihood(
     data = Data(lds, y; ux=ux, uy=uy)
     grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
 
-    #=
-    The filter's covariance pass depends only on the parameters and the trial
-    length, so it is shared across the trials of one cell exactly as it is
-    shared across all trials of an ungrouped model.
-    =#
+    # The covariance pass depends only on parameters and trial length, so it is
+    # shared within a cell as it is across an ungrouped model.
     if grp !== nothing
         total_ll = zero(T)
         for c in 1:(grp.ncells)

--- a/src/lds/gaussian_observations.jl
+++ b/src/lds/gaussian_observations.jl
@@ -155,6 +155,22 @@ function update_C_d!(
         V = mn_map(suf.obs_xx[], suf.obs_xy, CD_prior)
     end
 
+    _unpack_obs_V!(lds, V)
+    return nothing
+end
+
+"""
+    _unpack_obs_V!(lds, V)
+
+Write a stacked emission regression `V = [C d D]` back into `lds`. The inverse
+of [`_pack_obs_V!`](@ref); shared by the ordinary M-step and by callers that
+solve for `V` themselves (see `_tied_gls_regression`).
+"""
+function _unpack_obs_V!(
+    lds::LinearDynamicalSystem{T,S,O}, V::AbstractMatrix{T}
+) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
+    D = lds.latent_dim
+    uy_dim = lds.uy_dim
     copyto!(lds.obs_model.C, view(V, :, 1:D))
     copyto!(lds.obs_model.d, view(V, :, D + 1))
     if uy_dim > 0

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -371,6 +371,80 @@ function _distinct_by_slot(slots::AbstractVector{Int}, units::AbstractVector{Int
     return reps
 end
 
+"""
+    _shared_noise(noise_slots, units) -> Bool
+
+Whether every unit of a regression slot draws on the same noise version. When
+it does, that covariance is a common factor of the score and divides out, so
+pooling the units' statistics and solving the ordinary normal equations is
+exact. When it does not, the rows couple and the estimate has to come from
+[`_tied_gls_regression`](@ref).
+"""
+function _shared_noise(noise_slots::AbstractVector{Int}, units::AbstractVector{Int})
+    length(units) == 1 && return true
+    s = noise_slots[units[1]]
+    return all(u -> noise_slots[u] == s, units)
+end
+
+"""
+    _tied_gls_regression(Szz, Szy, Sigma, prior, Sigma_prior) -> W
+
+Fit one regression matrix `W` (`p x m`) shared by several units whose residual
+covariances `Sigma[u]` (`p x p`) differ. `Szz[u]` is the unit's `m x m`
+regressor Gram matrix and `Szy[u]` its `m x p` cross-product — the `*_xx` /
+`*_xy` blocks of a `SufficientStatistics`.
+
+Pooling the units' statistics and solving the ordinary normal equations
+maximizes the objective only when the units also share `Sigma`: held fixed, it
+divides out of the score. When it does not, the output rows couple,
+
+    sum_u Sigma_u^-1 (Szy_u' - W Szz_u) = 0
+
+which vectorizes to the `(p*m)`-square system
+
+    [sum_u (Szz_u kron Sigma_u^-1)] vec(W) = vec(sum_u Sigma_u^-1 Szy_u')
+
+A matrix-normal `prior` on `W` contributes `Lambda kron Sigma_prior^-1` on the
+left and `Sigma_prior^-1 M0 Lambda` on the right. Its row scale is a residual
+covariance and there is no single one here, so the caller passes the
+representative it stores the fitted `W` on.
+
+With every `Sigma[u]` equal this returns exactly [`mn_map`](@ref)'s answer — the
+common factor cancels from both sides — so the cheap pooled path is a special
+case of this one rather than a second estimator.
+
+Costs `O((p*m)^3)` time and `O((p*m)^2)` memory. For a wide emission that
+dominates the whole M-step, so callers reach for it only when the residual
+covariance genuinely is not shared.
+"""
+function _tied_gls_regression(
+    Szz::AbstractVector{<:AbstractMatrix{T}},
+    Szy::AbstractVector{<:AbstractMatrix{T}},
+    Sigma::AbstractVector{<:AbstractMatrix{T}},
+    prior::Union{Nothing,MNPrior},
+    Sigma_prior::AbstractMatrix{T},
+) where {T<:Real}
+    m = size(Szz[1], 1)
+    p = size(Szy[1], 2)
+
+    lhs = zeros(T, m * p, m * p)
+    rhs = zeros(T, p, m)
+    for u in eachindex(Szz)
+        Sinv = inv(cholesky(Symmetric(Sigma[u])))
+        # vec(Sigma^-1 W Szz) = (Szz kron Sigma^-1) vec(W), Szz symmetric.
+        lhs .+= kron(Szz[u], Sinv)
+        mul!(rhs, Sinv, transpose(Szy[u]), one(T), one(T))
+    end
+
+    if prior !== nothing
+        Sinv0 = inv(cholesky(Symmetric(Sigma_prior)))
+        lhs .+= kron(prior.Λ, Sinv0)
+        mul!(rhs, Sinv0, prior.M₀ * prior.Λ, one(T), one(T))
+    end
+
+    return reshape(Symmetric(lhs) \ vec(rhs), p, m)
+end
+
 # ============================================================================
 # Grouped parameter updates
 # ============================================================================
@@ -416,11 +490,26 @@ function _grouped_update_A_b!(
     ldss::AbstractVector,
     sufs::AbstractVector,
     slots::AbstractVector{Int},
+    slots_q::AbstractVector{Int},
     sws::SmoothWorkspace,
     bufs::GroupedSufBuffers,
 )
     for units in _units_by_slot(slots)
-        update_A_b!(ldss[units[1]], _pool_dyn!(bufs, sufs, units), sws)
+        lds = ldss[units[1]]
+        if _shared_noise(slots_q, units)
+            # One `Q` over these units, so it divides out and pooled OLS is exact.
+            update_A_b!(lds, _pool_dyn!(bufs, sufs, units), sws)
+        else
+            lds.fit_bool[_G_AB] || continue
+            W = _tied_gls_regression(
+                [sufs[u].dyn_xx[].mat for u in units],
+                [sufs[u].dyn_xy for u in units],
+                [ldss[u].state_model.Q for u in units],
+                lds.state_model.AB_prior,
+                lds.state_model.Q,
+            )
+            _unpack_dyn_W!(lds, W)
+        end
     end
     return nothing
 end
@@ -453,11 +542,26 @@ function _grouped_update_C_d!(
     ldss::AbstractVector,
     sufs::AbstractVector,
     slots::AbstractVector{Int},
+    slots_r::AbstractVector{Int},
     sws::SmoothWorkspace,
     bufs::GroupedSufBuffers,
 )
     for units in _units_by_slot(slots)
-        update_C_d!(ldss[units[1]], _pool_obs!(bufs, sufs, units), sws)
+        lds = ldss[units[1]]
+        if _shared_noise(slots_r, units)
+            # One `R` over these units, so it divides out and pooled OLS is exact.
+            update_C_d!(lds, _pool_obs!(bufs, sufs, units), sws)
+        else
+            lds.fit_bool[_G_CD] || continue
+            V = _tied_gls_regression(
+                [sufs[u].obs_xx[].mat for u in units],
+                [sufs[u].obs_xy for u in units],
+                [ldss[u].obs_model.R for u in units],
+                lds.obs_model.CD_prior,
+                lds.obs_model.R,
+            )
+            _unpack_obs_V!(lds, V)
+        end
     end
     return nothing
 end
@@ -502,7 +606,7 @@ function _grouped_state_mstep!(
 )
     _grouped_update_x0!(ldss, sufs, slots[_G_X0], bufs)
     _grouped_update_P0!(ldss, sufs, slots[_G_P0], slots[_G_X0], sws)
-    _grouped_update_A_b!(ldss, sufs, slots[_G_AB], sws, bufs)
+    _grouped_update_A_b!(ldss, sufs, slots[_G_AB], slots[_G_Q], sws, bufs)
     _grouped_update_Q!(ldss, sufs, slots[_G_Q], slots[_G_AB], sws)
     return nothing
 end
@@ -519,7 +623,7 @@ function _grouped_gaussian_obs_mstep!(
     sws::SmoothWorkspace,
     bufs::GroupedSufBuffers,
 )
-    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs)
+    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], slots[_G_R], sws, bufs)
     _grouped_update_R!(ldss, sufs, slots[_G_R], slots[_G_CD], sws)
     return nothing
 end

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -1,0 +1,619 @@
+#=============================================================================
+Grouped M-step and ELBO for models with `depends_on` set.
+
+The E-step needs no group-specific code: the trials of one cell share every
+parameter, so the ordinary smoother + sufficient-statistics aggregator runs on
+each cell's sub-`Data` unchanged (see `parameter_groups.jl`). What is left is
+
+  * pooling the per-cell sufficient statistics per parameter *version*, and
+  * evaluating the prior terms once per parameter version rather than once per
+    cell.
+
+Both are written against a flat list of "units". A unit is one thing that
+produced a `SufficientStatistics`: a cell for a `LinearDynamicalSystem`, or a
+(regime, cell) pair for an `SLDS`. Each unit carries the `LinearDynamicalSystem`
+holding its parameter arrays and, per parameter group, the slot index it uses.
+Parameters shared by several units are the *same array object*, so writing
+through any one of those units updates all of them.
+=============================================================================#
+
+"""
+    GroupedSufBuffers{T}
+
+Scratch for pooling per-cell sufficient statistics into one parameter version.
+Only the blocks the regression updates read are pooled (`init_n`/`init_xy`,
+`dyn_xx`/`dyn_xy`, `obs_xx`/`obs_xy`); the covariance updates never need a
+pooled `*_yy` because they accumulate the residual scatter cell by cell, each
+with its own regression matrix. That also avoids taking a Cholesky of a pooled
+`obs_yy`, which can be rank-deficient for a small group.
+"""
+struct GroupedSufBuffers{T<:Real}
+    suf::SufficientStatistics{T}
+    init_yy::Matrix{T}
+    dyn_xx::Matrix{T}
+    obs_xx::Matrix{T}
+end
+
+function GroupedSufBuffers(
+    ::Type{T}, lds::LinearDynamicalSystem{T}, tsteps_per_trial::AbstractVector{Int}
+) where {T<:Real}
+    D = lds.latent_dim
+    dyn_reg_dim = D + 1 + lds.ux_dim
+    obs_reg_dim = D + 1 + lds.uy_dim
+    return GroupedSufBuffers{T}(
+        _initialize_td_sufficient_statistics(T, lds, tsteps_per_trial),
+        zeros(T, D, D),
+        zeros(T, dyn_reg_dim, dyn_reg_dim),
+        zeros(T, obs_reg_dim, obs_reg_dim),
+    )
+end
+
+#=
+Pooling. A version backed by a single unit reuses that unit's statistics
+verbatim, which keeps a fit whose groups happen to be singletons numerically
+identical to the corresponding ungrouped fit.
+=#
+function _pool_init!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.init_xy, zero(T))
+    M = bufs.init_yy
+    fill!(M, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.init_n)
+        suf.init_xy .+= src.init_xy
+        M .+= src.init_yy[]
+    end
+    suf.init_n = n
+    suf.init_yy[] = M
+    return suf
+end
+
+function _pool_dyn!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.dyn_xy, zero(T))
+    XX = bufs.dyn_xx
+    fill!(XX, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.dyn_n)
+        suf.dyn_xy .+= src.dyn_xy
+        XX .+= src.dyn_xx[].mat
+    end
+    suf.dyn_n = n
+    Symmetrize!(XX)
+    suf.dyn_xx[] = PDMat(copy(XX))
+    return suf
+end
+
+function _pool_obs!(
+    bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
+) where {T<:Real}
+    length(units) == 1 && return sufs[units[1]]
+    suf = bufs.suf
+    n = zero(T)
+    fill!(suf.obs_xy, zero(T))
+    XX = bufs.obs_xx
+    fill!(XX, zero(T))
+    for u in units
+        src = sufs[u]
+        n += T(src.obs_n)
+        suf.obs_xy .+= src.obs_xy
+        XX .+= src.obs_xx[].mat
+    end
+    suf.obs_n = n
+    Symmetrize!(XX)
+    suf.obs_xx[] = PDMat(copy(XX))
+    return suf
+end
+
+"""
+    CellConstBlocks{T}
+
+The data-only aggregator constants (`Σ y y'`, the bias/`uy` blocks of `obs_xx`
+and `obs_xy`, the bias/`ux` blocks of `dyn_xx`) for one cell.
+
+A grouped fit shares a single `SmoothWorkspace` pool across cells — the O(D²·T)
+block-tridiagonal and shared-covariance storage is the expensive part and is
+safe to reuse, because a cell's smoothed covariances are consumed by its own
+aggregation before the next cell overwrites them. These blocks, by contrast, are
+per-cell and must survive between iterations, so they are cached here (all of
+them are small: no `tsteps` dimension) and copied back in before each cell's
+aggregation instead of being recomputed every E-step.
+"""
+struct CellConstBlocks{T<:Real}
+    obs_yy::Matrix{T}
+    obs_xy::Matrix{T}
+    obs_xx::Matrix{T}
+    dyn_xx::Matrix{T}
+end
+
+"""
+    _cache_const_blocks!(sws, lds, data) -> CellConstBlocks
+
+Run `_td_init_const_blocks!` for one cell and take a copy of the result.
+"""
+function _cache_const_blocks!(
+    sws::SmoothWorkspace{T}, lds::LinearDynamicalSystem{T}, data::Data{T}
+) where {T<:Real}
+    _td_init_const_blocks!(sws, lds, data)
+    return CellConstBlocks{T}(
+        copy(sws.agg.obs_yy_const),
+        copy(sws.agg.obs_xy_const),
+        copy(sws.agg.obs_xx_const),
+        copy(sws.agg.dyn_xx_const),
+    )
+end
+
+"""
+    _restore_const_blocks!(sws, blocks)
+
+Copy a cell's cached aggregator constants back into the shared workspace.
+"""
+function _restore_const_blocks!(
+    sws::SmoothWorkspace{T}, blocks::CellConstBlocks{T}
+) where {T<:Real}
+    copyto!(sws.agg.obs_yy_const, blocks.obs_yy)
+    copyto!(sws.agg.obs_xy_const, blocks.obs_xy)
+    copyto!(sws.agg.obs_xx_const, blocks.obs_xx)
+    copyto!(sws.agg.dyn_xx_const, blocks.dyn_xx)
+    return sws
+end
+
+"""
+    GroupedFitState{T,L,DT}
+
+Everything a grouped EM fit needs per cell: the cell's `LinearDynamicalSystem`
+view, its sub-`Data`, its slice of the per-trial smoother output, its
+sufficient statistics, its cached aggregator constants, and (Gaussian only) its
+batched mean-pass buffers.
+
+`tfs_all` holds the same `FilterSmooth` objects as `cell_tfs`, in original trial
+order, for the callers that need results per trial rather than per cell.
+"""
+struct GroupedFitState{T<:Real,L,DT}
+    cell_lds::Vector{L}
+    cell_data::Vector{DT}
+    cell_tfs::Vector{TrialFilterSmooth{T}}
+    tfs_all::TrialFilterSmooth{T}
+    sufs::Vector{SufficientStatistics{T}}
+    cell_consts::Vector{CellConstBlocks{T}}
+    cell_batched::Vector{Union{Nothing,BatchedBuffers{T}}}
+    bufs::GroupedSufBuffers{T}
+end
+
+"""
+    _grouped_fit_state(lds, data, grp, sws; batched=false)
+
+Build the per-cell fit state. `batched=true` additionally allocates each cell's
+BLAS-3 mean-pass buffers (Gaussian path only, and only for cells whose trials
+are equal-length and plural); their total footprint is proportional to the
+number of trials, so it matches an ungrouped fit's.
+"""
+function _grouped_fit_state(
+    lds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping,
+    sws::SmoothWorkspace{T};
+    batched::Bool=false,
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    ncells = grp.ncells
+    ntrials = length(data.y)
+    cell_lds = _cell_ldss(lds, grp)
+    cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
+
+    #=
+    Per-trial smoother storage. `cov_alias` is decided per cell: the smoother
+    aliases every equal-length trial's `p_smooth` to the shared cache, so those
+    trials would otherwise each carry a dead (D, D, T) allocation.
+    =#
+    fs_all = Vector{FilterSmooth{T}}(undef, ntrials)
+    cell_batched = Vector{Union{Nothing,BatchedBuffers{T}}}(undef, ncells)
+    for c in 1:ncells
+        trials = grp.cell_trials[c]
+        tsteps = data.tsteps[trials]
+        equal_len = length(trials) > 1 && all(t -> t == tsteps[1], tsteps)
+        alias = batched && equal_len
+        for (i, n) in enumerate(trials)
+            fs_all[n] = initialize_FilterSmooth(lds, tsteps[i]; cov_alias=alias)
+        end
+        cell_batched[c] = if batched && equal_len
+            BatchedBuffers(
+                T,
+                lds.latent_dim,
+                lds.obs_dim,
+                tsteps[1],
+                length(trials);
+                ux_dim=lds.ux_dim,
+                uy_dim=lds.uy_dim,
+            )
+        else
+            nothing
+        end
+    end
+
+    cell_tfs = [
+        TrialFilterSmooth([fs_all[n] for n in grp.cell_trials[c]]) for c in 1:ncells
+    ]
+    sufs = [
+        _initialize_td_sufficient_statistics(T, cell_lds[c], cell_data[c].tsteps) for
+        c in 1:ncells
+    ]
+    cell_consts = [_cache_const_blocks!(sws, cell_lds[c], cell_data[c]) for c in 1:ncells]
+
+    return GroupedFitState(
+        cell_lds,
+        cell_data,
+        cell_tfs,
+        TrialFilterSmooth(fs_all),
+        sufs,
+        cell_consts,
+        cell_batched,
+        GroupedSufBuffers(T, lds, data.tsteps),
+    )
+end
+
+"""
+    _prepare_cell!(sws, state, cell)
+
+Point the shared workspace at one cell: swap in that cell's batched buffers and
+restore its aggregator constants.
+"""
+function _prepare_cell!(sws::SmoothWorkspace, state::GroupedFitState, cell::Int)
+    sws.batched = state.cell_batched[cell]
+    _restore_const_blocks!(sws, state.cell_consts[cell])
+    return sws
+end
+
+"""
+    _grouped_sws_pool(lds, data)
+
+Workspace pool shared by every cell of a grouped fit. Sized at the longest trial
+across all cells; `batched` stays `nothing` here because each cell's BLAS-3
+buffers are swapped in from the `GroupedFitState` by `_prepare_cell!`.
+
+Sharing the pool is what keeps a grouped fit's memory at the ungrouped fit's
+level: the O(D²·T) block-tridiagonal and shared-covariance storage is allocated
+once rather than once per group, which matters when the groups are recording
+sessions and there are dozens of them.
+"""
+function _grouped_sws_pool(lds::LinearDynamicalSystem{T}, data::Data{T}) where {T<:Real}
+    T_max = maximum(data.tsteps)
+    npool = min(Threads.maxthreadid(), length(data.y))
+    return [
+        SmoothWorkspace(
+            T, lds.latent_dim, lds.obs_dim, T_max; ux_dim=lds.ux_dim, uy_dim=lds.uy_dim
+        ) for _ in 1:npool
+    ]
+end
+
+"""
+    _grouped_smooth(lds, data, grp, y)
+
+Smooth each cell with its own parameters and reassemble the results in the
+original trial order. Results are copied out per cell before the next one runs:
+the equal-length fast path aliases every trial's `p_smooth` to the workspace's
+shared covariance cache, which the next cell overwrites.
+"""
+function _grouped_smooth(
+    lds::LinearDynamicalSystem{T}, data::Data{T}, grp::ParameterGrouping, y
+) where {T<:Real}
+    ntrials = length(data.y)
+    xs = Vector{Matrix{T}}(undef, ntrials)
+    Ps = Vector{Array{T,3}}(undef, ntrials)
+    sws_pool = _grouped_sws_pool(lds, data)
+
+    for c in 1:grp.ncells
+        trials = grp.cell_trials[c]
+        cell_data = _subset_data(data, trials)
+        tfs = initialize_FilterSmooth(lds, cell_data.tsteps)::TrialFilterSmooth{T}
+        smooth!(_cell_lds(lds, grp, c), tfs, cell_data, sws_pool)
+        for (i, n) in enumerate(trials)
+            xs[n] = copy(tfs[i].x_smooth)
+            Ps[n] = copy(tfs[i].p_smooth)
+        end
+    end
+
+    return _grouped_smooth_output(xs, Ps, y)
+end
+
+# Public-shape return convention, matching `_collect_smooth_output`.
+_grouped_smooth_output(xs, Ps, ::AbstractMatrix) = (xs[1], Ps[1])
+_grouped_smooth_output(xs, Ps, _) = (xs, Ps)
+
+"""
+    _units_by_slot(slots) -> Vector{Vector{Int}}
+
+Group unit indices by the parameter version they use, one entry per occupied
+version. A `depends_on` label that no unit uses is skipped rather than fitted
+from an empty sufficient statistic.
+"""
+function _units_by_slot(slots::AbstractVector{Int})
+    out = Vector{Int}[]
+    seen = Int[]
+    for (u, s) in enumerate(slots)
+        i = findfirst(isequal(s), seen)
+        if i === nothing
+            push!(seen, s)
+            push!(out, [u])
+        else
+            push!(out[i], u)
+        end
+    end
+    return out
+end
+
+"""
+    _distinct_by_slot(slots, units) -> Vector{Int}
+
+One representative unit per distinct value of `slots` within `units`. Used to
+add a prior term once per distinct parameter version when the prior's group is
+finer than the group being updated (e.g. several `[A b B]` sharing one `Q`).
+"""
+function _distinct_by_slot(slots::AbstractVector{Int}, units::AbstractVector{Int})
+    reps = Int[]
+    seen = Int[]
+    for u in units
+        s = slots[u]
+        if !(s in seen)
+            push!(seen, s)
+            push!(reps, u)
+        end
+    end
+    return reps
+end
+
+# ============================================================================
+# Grouped parameter updates
+# ============================================================================
+
+function _grouped_update_x0!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_initial_state_mean!(ldss[units[1]], _pool_init!(bufs, sufs, units))
+    end
+    return nothing
+end
+
+function _grouped_update_P0!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_x0::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_P0] || return nothing
+    S0 = sws.reg.S0_sum
+    for units in _units_by_slot(slots)
+        fill!(S0, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_init_scatter!(S0, ldss[u], sufs[u])
+            N += T(sufs[u].init_n)
+        end
+        for u in _distinct_by_slot(slots_x0, units)
+            _accumulate_x0_prior_scatter!(S0, ldss[u])
+        end
+        Symmetrize!(S0)
+        _finalize_P0!(ldss[units[1]], S0, N)
+    end
+    return nothing
+end
+
+function _grouped_update_A_b!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_A_b!(ldss[units[1]], _pool_dyn!(bufs, sufs, units), sws)
+    end
+    return nothing
+end
+
+function _grouped_update_Q!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_ab::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_Q] || return nothing
+    S_res = sws.reg.Q_sum
+    for units in _units_by_slot(slots)
+        fill!(S_res, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_dyn_scatter!(S_res, ldss[u], sufs[u], sws)
+            N += T(sufs[u].dyn_n)
+        end
+        for u in _distinct_by_slot(slots_ab, units)
+            _accumulate_ab_prior_scatter!(S_res, ldss[u], sws)
+        end
+        _finalize_Q!(ldss[units[1]], S_res, N)
+    end
+    return nothing
+end
+
+function _grouped_update_C_d!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    for units in _units_by_slot(slots)
+        update_C_d!(ldss[units[1]], _pool_obs!(bufs, sufs, units), sws)
+    end
+    return nothing
+end
+
+function _grouped_update_R!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Int},
+    slots_cd::AbstractVector{Int},
+    sws::SmoothWorkspace{T},
+) where {T<:Real}
+    ldss[1].fit_bool[_G_R] || return nothing
+    S_res = sws.elbo.obs_work
+    for units in _units_by_slot(slots)
+        fill!(S_res, zero(T))
+        N = zero(T)
+        for u in units
+            _accumulate_obs_scatter!(S_res, ldss[u], sufs[u], sws)
+            N += T(sufs[u].obs_n)
+        end
+        for u in _distinct_by_slot(slots_cd, units)
+            _accumulate_cd_prior_scatter!(S_res, ldss[u], sws)
+        end
+        _finalize_R!(ldss[units[1]], S_res, N)
+    end
+    return nothing
+end
+
+"""
+    _grouped_state_mstep!(ldss, sufs, slots, sws, bufs)
+
+The four state-side updates (`x0`, `P0`, `[A b B]`, `Q`) over a flat unit list.
+`slots[g][unit]` is the version of parameter group `g` that a unit uses. Shared
+by the Gaussian LDS, the Poisson LDS, and the SLDS.
+"""
+function _grouped_state_mstep!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Vector{Int}},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    _grouped_update_x0!(ldss, sufs, slots[_G_X0], bufs)
+    _grouped_update_P0!(ldss, sufs, slots[_G_P0], slots[_G_X0], sws)
+    _grouped_update_A_b!(ldss, sufs, slots[_G_AB], sws, bufs)
+    _grouped_update_Q!(ldss, sufs, slots[_G_Q], slots[_G_AB], sws)
+    return nothing
+end
+
+"""
+    _grouped_gaussian_obs_mstep!(ldss, sufs, slots, sws, bufs)
+
+The two Gaussian emission updates (`[C d D]`, `R`) over a flat unit list.
+"""
+function _grouped_gaussian_obs_mstep!(
+    ldss::AbstractVector,
+    sufs::AbstractVector,
+    slots::AbstractVector{Vector{Int}},
+    sws::SmoothWorkspace,
+    bufs::GroupedSufBuffers,
+)
+    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs)
+    _grouped_update_R!(ldss, sufs, slots[_G_R], slots[_G_CD], sws)
+    return nothing
+end
+
+# ============================================================================
+# Grouped prior log-density (the ELBO's `log p(θ)` term)
+# ============================================================================
+
+"""
+    _slot_representatives(slots) -> Vector{Int}
+
+One representative unit per occupied parameter version.
+"""
+_slot_representatives(slots::AbstractVector{Int}) = [u[1] for u in _units_by_slot(slots)]
+
+"""
+    _pair_slot_representatives(slots_a, slots_b) -> Vector{Int}
+
+One representative unit per distinct `(slots_a, slots_b)` pair. The MN priors
+couple a regression with its noise covariance (`x0` with `P0`, `[A b B]` with
+`Q`, `[C d D]` with `R`), so each distinct pair is one instance of that prior —
+which stays consistent with the M-step, where the same pairs decide how often
+the `Wm Λ Wm'` term is folded into the IW scale.
+"""
+function _pair_slot_representatives(
+    slots_a::AbstractVector{Int}, slots_b::AbstractVector{Int}
+)
+    seen = Tuple{Int,Int}[]
+    reps = Int[]
+    for u in eachindex(slots_a)
+        key = (slots_a[u], slots_b[u])
+        if !(key in seen)
+            push!(seen, key)
+            push!(reps, u)
+        end
+    end
+    return reps
+end
+
+"""
+    _grouped_state_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the state-side parameters of a grouped model: the IW terms once
+per covariance version, the MN terms once per distinct regression/covariance
+pair.
+"""
+function _grouped_state_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_P0])
+        sm = ldss[u].state_model
+        sm.P0_prior === nothing || (total += iw_logprior_term(sm.P0, sm.P0_prior))
+    end
+    for u in _slot_representatives(slots[_G_Q])
+        sm = ldss[u].state_model
+        sm.Q_prior === nothing || (total += iw_logprior_term(sm.Q, sm.Q_prior))
+    end
+    for u in _pair_slot_representatives(slots[_G_X0], slots[_G_P0])
+        sm = ldss[u].state_model
+        sm.x0_prior === nothing && continue
+        total += mn_logprior_term(reshape(sm.x0, :, 1), sm.P0, sm.x0_prior)
+    end
+    for u in _pair_slot_representatives(slots[_G_AB], slots[_G_Q])
+        lds = ldss[u]
+        sm = lds.state_model
+        sm.AB_prior === nothing && continue
+        D = lds.latent_dim
+        W_ab = _pack_dyn_W!(Matrix{T}(undef, D, D + 1 + lds.ux_dim), lds)
+        total += mn_logprior_term(W_ab, sm.Q, sm.AB_prior)
+    end
+    return total
+end
+
+"""
+    _grouped_gaussian_obs_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the Gaussian emission parameters of a grouped model.
+"""
+function _grouped_gaussian_obs_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_R])
+        om = ldss[u].obs_model
+        om.R_prior === nothing || (total += iw_logprior_term(om.R, om.R_prior))
+    end
+    for u in _pair_slot_representatives(slots[_G_CD], slots[_G_R])
+        lds = ldss[u]
+        om = lds.obs_model
+        om.CD_prior === nothing && continue
+        D = lds.latent_dim
+        W_cd = _pack_obs_V!(Matrix{T}(undef, lds.obs_dim, D + 1 + lds.uy_dim), lds)
+        total += mn_logprior_term(W_cd, om.R, om.CD_prior)
+    end
+    return total
+end

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -311,7 +311,7 @@ function _grouped_smooth(
     Ps = Vector{Array{T,3}}(undef, ntrials)
     sws_pool = _grouped_sws_pool(lds, data)
 
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         trials = grp.cell_trials[c]
         cell_data = _subset_data(data, trials)
         tfs = initialize_FilterSmooth(lds, cell_data.tsteps)::TrialFilterSmooth{T}

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -1,20 +1,15 @@
 #=============================================================================
 Grouped M-step and ELBO for models with `depends_on` set.
 
-The E-step needs no group-specific code: the trials of one cell share every
-parameter, so the ordinary smoother + sufficient-statistics aggregator runs on
-each cell's sub-`Data` unchanged (see `parameter_groups.jl`). What is left is
+The E-step needs no group-specific code — a cell's trials share every parameter,
+so the ordinary smoother runs on its sub-`Data` unchanged. What is left is
+pooling the per-cell sufficient statistics per parameter version, and evaluating
+the prior terms once per version rather than once per cell.
 
-  * pooling the per-cell sufficient statistics per parameter *version*, and
-  * evaluating the prior terms once per parameter version rather than once per
-    cell.
-
-Both are written against a flat list of "units". A unit is one thing that
-produced a `SufficientStatistics`: a cell for a `LinearDynamicalSystem`, or a
-(regime, cell) pair for an `SLDS`. Each unit carries the `LinearDynamicalSystem`
-holding its parameter arrays and, per parameter group, the slot index it uses.
-Parameters shared by several units are the *same array object*, so writing
-through any one of those units updates all of them.
+Both are written against a flat list of *units*: one thing that produced a
+`SufficientStatistics` — a cell for an LDS, a (regime, cell) pair for an SLDS.
+Parameters shared by several units are the same array object, so writing
+through any one updates all of them.
 =============================================================================#
 
 """
@@ -48,11 +43,8 @@ function GroupedSufBuffers(
     )
 end
 
-#=
-Pooling. A version backed by a single unit reuses that unit's statistics
-verbatim, which keeps a fit whose groups happen to be singletons numerically
-identical to the corresponding ungrouped fit.
-=#
+# Pooling. A version backed by one unit reuses its statistics verbatim, so
+# singleton groups stay numerically identical to the ungrouped fit.
 function _pool_init!(
     bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
 ) where {T<:Real}
@@ -210,11 +202,8 @@ function _grouped_fit_state(
     cell_lds = _cell_ldss(lds, grp)
     cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
 
-    #=
-    Per-trial smoother storage. `cov_alias` is decided per cell: the smoother
-    aliases every equal-length trial's `p_smooth` to the shared cache, so those
-    trials would otherwise each carry a dead (D, D, T) allocation.
-    =#
+    # `cov_alias` per cell: equal-length trials alias `p_smooth` to the shared
+    # cache, which would otherwise be a dead (D, D, T) allocation each.
     fs_all = Vector{FilterSmooth{T}}(undef, ntrials)
     cell_batched = Vector{Union{Nothing,BatchedBuffers{T}}}(undef, ncells)
     for c in 1:ncells
@@ -374,11 +363,9 @@ end
 """
     _shared_noise(noise_slots, units) -> Bool
 
-Whether every unit of a regression slot draws on the same noise version. When
-it does, that covariance is a common factor of the score and divides out, so
-pooling the units' statistics and solving the ordinary normal equations is
-exact. When it does not, the rows couple and the estimate has to come from
-[`_tied_gls_regression`](@ref).
+Whether every unit of a regression slot uses the same noise version. If so the
+covariance divides out of the score and pooled OLS is exact; otherwise the rows
+couple and the estimate comes from [`_tied_gls_regression`](@ref).
 """
 function _shared_noise(noise_slots::AbstractVector{Int}, units::AbstractVector{Int})
     length(units) == 1 && return true
@@ -389,32 +376,25 @@ end
 """
     _tied_gls_regression(Szz, Szy, Sigma, prior, Sigma_prior) -> W
 
-Fit one regression matrix `W` (`p x m`) shared by several units whose residual
-covariances `Sigma[u]` (`p x p`) differ. `Szz[u]` is the unit's `m x m`
-regressor Gram matrix and `Szy[u]` its `m x p` cross-product — the `*_xx` /
-`*_xy` blocks of a `SufficientStatistics`.
+One regression matrix `W` (`p x m`) shared by several units whose residual
+covariances `Sigma[u]` (`p x p`) differ. `Szz[u]` / `Szy[u]` are the unit's
+`*_xx` / `*_xy` sufficient-statistic blocks.
 
-Pooling the units' statistics and solving the ordinary normal equations
-maximizes the objective only when the units also share `Sigma`: held fixed, it
-divides out of the score. When it does not, the output rows couple,
+Pooled normal equations maximize the objective only when the units share
+`Sigma`, which then divides out of the score. Otherwise the rows couple,
 
     sum_u Sigma_u^-1 (Szy_u' - W Szz_u) = 0
 
-which vectorizes to the `(p*m)`-square system
+vectorizing to the `(p*m)`-square system
 
     [sum_u (Szz_u kron Sigma_u^-1)] vec(W) = vec(sum_u Sigma_u^-1 Szy_u')
 
-A matrix-normal `prior` on `W` contributes `Lambda kron Sigma_prior^-1` on the
-left and `Sigma_prior^-1 M0 Lambda` on the right. Its row scale is a residual
-covariance and there is no single one here, so the caller passes the
-representative it stores the fitted `W` on.
+An MN `prior` adds `Lambda kron Sigma_prior^-1` on the left and
+`Sigma_prior^-1 M0 Lambda` on the right; `Sigma_prior` is the representative
+covariance the caller stores `W` on.
 
-With every `Sigma[u]` equal this returns exactly [`mn_map`](@ref)'s answer — the
-common factor cancels from both sides — so the cheap pooled path is a special
-case of this one rather than a second estimator.
-
-Costs `O((p*m)^3)` time and `O((p*m)^2)` memory. For a wide emission that
-dominates the whole M-step, so callers reach for it only when the residual
+Reduces to [`mn_map`](@ref) exactly when every `Sigma[u]` is equal. Costs
+`O((p*m)^3)` time and `O((p*m)^2)` memory, so callers use it only when the
 covariance genuinely is not shared.
 """
 function _tied_gls_regression(

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -673,7 +673,7 @@ One `_cell_lds` per occupied cell.
 function _cell_ldss(
     lds::LinearDynamicalSystem{T,S,O}, grp::ParameterGrouping
 ) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
-    return [_cell_lds(lds, grp, c) for c in 1:grp.ncells]
+    return [_cell_lds(lds, grp, c) for c in 1:(grp.ncells)]
 end
 
 """

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -40,9 +40,8 @@ the ELBO need to know about groups.
 
 This file holds the declaration side of that design: validating `depends_on`,
 resolving it into per-parameter versions, building the `variants` storage, and
-computing the trial partition. The grouped E/M-step that consumes the partition
-lands separately; until it does, `_reject_unsupported_dependence` keeps the
-entry points from quietly ignoring a declared dependence.
+computing the trial partition. The grouped M-step and ELBO that consume the
+partition live in `grouped_em.jl`.
 =============================================================================#
 
 #=
@@ -607,19 +606,18 @@ end
     _reject_unsupported_dependence(model)
 
 **Internal, temporary.** Refuse to run an entry point that does not yet honour
-`depends_on`. The field, its validation and its accessors land ahead of the
-grouped E/M-step machinery, so in the interim a declared dependence must be an
-error rather than a silently pooled fit. Each entry point drops this call as
-its grouped path lands.
+`depends_on`. The grouped E/M-step lands one model family at a time, so in the
+interim a declared dependence must be an error rather than a silently pooled
+fit. Each entry point drops this call as its grouped path lands.
 """
 function _reject_unsupported_dependence(lds::LinearDynamicalSystem)
     _has_parameter_dependence(lds) || return nothing
     return throw(
         ArgumentError(
             "this model declares `depends_on`, but fitting and inference with " *
-            "condition-dependent parameters are not implemented yet — the grouped " *
-            "E/M-step lands in a follow-up. Unset `depends_on` to fit the model " *
-            "with one parameter set shared by every trial.",
+            "condition-dependent parameters are not implemented yet for this model " *
+            "family — the grouped E/M-step lands in a follow-up. Unset `depends_on` " *
+            "to fit the model with one parameter set shared by every trial.",
         ),
     )
 end
@@ -629,6 +627,62 @@ function _reject_unsupported_dependence(slds::SLDS)
         _reject_unsupported_dependence(lds)
     end
     return nothing
+end
+
+"""
+    _single_trial_group_error(what)
+
+`rand` with a scalar `tsteps` draws one trial, which a grouped model cannot
+assign to a parameter version on its own.
+"""
+function _single_trial_group_error(what::AbstractString)
+    return throw(
+        ArgumentError(
+            "rand(rng, $what, tsteps) samples a single trial, but this model's " *
+            "parameters depend on an ancillary variable — say which group the trial " *
+            "belongs to, e.g. `depends_on=(C=[:session_a],)`, or sample several trials " *
+            "at once with `rand(rng, $what, fill(tsteps, ntrials))`.",
+        ),
+    )
+end
+
+"""
+    _cell_lds(lds, grp, cell) -> LinearDynamicalSystem
+
+A view of `lds` restricted to one cell: the state and observation model objects
+holding that cell's parameter arrays. Construction is two immutable struct
+allocations — the parameter arrays are shared, never copied — so the existing
+kernels can be run per cell without any group awareness of their own.
+"""
+function _cell_lds(
+    lds::LinearDynamicalSystem{T,S,O}, grp::ParameterGrouping, cell::Int
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    sm = (lds.state_model.variants::Vector{S})[grp.cell_state[cell]]
+    om = (lds.obs_model.variants::Vector{O})[grp.cell_obs[cell]]
+    return LinearDynamicalSystem{T,S,O}(
+        sm, om, lds.latent_dim, lds.obs_dim, lds.ux_dim, lds.uy_dim, lds.fit_bool
+    )
+end
+
+"""
+    _cell_ldss(lds, grp) -> Vector{LinearDynamicalSystem}
+
+One `_cell_lds` per occupied cell.
+"""
+function _cell_ldss(
+    lds::LinearDynamicalSystem{T,S,O}, grp::ParameterGrouping
+) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
+    return [_cell_lds(lds, grp, c) for c in 1:grp.ncells]
+end
+
+"""
+    _subset_data(data, trials) -> Data
+
+The sub-`Data` holding only `trials`, sharing the per-trial matrices by
+reference (nothing is copied).
+"""
+function _subset_data(data::Data, trials::AbstractVector{Int})
+    return Data(data.y[trials], data.ux[trials], data.uy[trials], data.tsteps[trials])
 end
 
 # ============================================================================

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -712,7 +712,8 @@ function _single_trial_group_error(what::AbstractString)
         ArgumentError(
             "rand(rng, $what, tsteps) samples a single trial, but this model's " *
             "parameters depend on an ancillary variable — say which group the trial " *
-            "belongs to, e.g. `depends_on=(C=[:session_a],)`, or sample several trials " *
+            "belongs to, e.g. `depends_on=(C=[:session_a], d=[:session_a])`, or sample " *
+            "several trials " *
             "at once with `rand(rng, $what, fill(tsteps, ntrials))`.",
         ),
     )

--- a/src/lds/workspaces.jl
+++ b/src/lds/workspaces.jl
@@ -468,14 +468,19 @@ concern:
 - `agg`: TD sufficient-stats aggregator + shared-covariance storage
 - `batched`: batched mean-pass buffers, or `nothing` (only `sws_pool[1]` of a
   multi-trial equal-length fit carries one)
+
+Every field except `batched` is `const`. `batched` is reassignable so a grouped
+fit (see `parameter_groups.jl`) can swap in the buffers sized for the group of
+trials it is about to smooth, while sharing the expensive O(D²·T) storage — the
+block-tridiagonal workspace and the shared-covariance cache — across all groups.
 """
-struct SmoothWorkspace{T<:Real}
-    btd::BlockTridiagonalWorkspace{T}
-    consts::SmoothConstants{T}
-    opt::NewtonBuffers{T}
-    reg::RegressionBuffers{T}
-    elbo::ElboBuffers{T}
-    agg::TDAggBuffers{T}
+mutable struct SmoothWorkspace{T<:Real}
+    const btd::BlockTridiagonalWorkspace{T}
+    const consts::SmoothConstants{T}
+    const opt::NewtonBuffers{T}
+    const reg::RegressionBuffers{T}
+    const elbo::ElboBuffers{T}
+    const agg::TDAggBuffers{T}
     batched::Union{Nothing,BatchedBuffers{T}}
 end
 

--- a/src/stats/simulate.jl
+++ b/src/stats/simulate.jl
@@ -168,10 +168,11 @@ function Random.rand(
         obs_params = fill(_extract_obs_params(lds.obs_model), ntrials)
     else
         cell_state = [
-            _extract_state_params(_cell_lds(lds, grp, c).state_model) for c in 1:grp.ncells
+            _extract_state_params(_cell_lds(lds, grp, c).state_model) for
+            c in 1:(grp.ncells)
         ]
         cell_obs = [
-            _extract_obs_params(_cell_lds(lds, grp, c).obs_model) for c in 1:grp.ncells
+            _extract_obs_params(_cell_lds(lds, grp, c).obs_model) for c in 1:(grp.ncells)
         ]
         state_params = [cell_state[grp.trial_cell[n]] for n in 1:ntrials]
         obs_params = [cell_obs[grp.trial_cell[n]] for n in 1:ntrials]

--- a/src/stats/simulate.jl
+++ b/src/stats/simulate.jl
@@ -116,6 +116,10 @@ Optional input sequences:
 - `uy`: same shape for the observation input `D`. Required when
   `size(obs_model.D, 2) > 0`. Supported for both Gaussian and Poisson
   observation models.
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  models' stored `depends_on` for this call. When the model declares ancillary
+  parameter dependencies, each trial is sampled from its own group's parameters
+  — which is how you generate a synthetic multi-session dataset.
 """
 function Random.rand(
     rng::AbstractRNG,
@@ -123,10 +127,15 @@ function Random.rand(
     tsteps::Integer;
     ux::Union{Nothing,AbstractMatrix{T}}=nothing,
     uy::Union{Nothing,AbstractMatrix{T}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    _reject_unsupported_dependence(lds)
-    state_params = _extract_state_params(lds.state_model)
-    obs_params = _extract_obs_params(lds.obs_model)
+    if depends_on === nothing && _has_parameter_dependence(lds)
+        _single_trial_group_error("lds")
+    end
+    grp = parameter_grouping(lds, 1; depends_on=depends_on)
+    lds1 = grp === nothing ? lds : _cell_lds(lds, grp, grp.trial_cell[1])
+    state_params = _extract_state_params(lds1.state_model)
+    obs_params = _extract_obs_params(lds1.obs_model)
     Ti = Int(tsteps)
 
     ux_trial = _check_ux(ux, lds.ux_dim, Ti, "ux", T)
@@ -144,12 +153,30 @@ function Random.rand(
     tsteps_per_trial::AbstractVector{<:Integer};
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:AbstractObservationModel{T}}
-    _reject_unsupported_dependence(lds)
-    state_params = _extract_state_params(lds.state_model)
-    obs_params = _extract_obs_params(lds.obs_model)
-
     ntrials = length(tsteps_per_trial)
+    grp = parameter_grouping(lds, ntrials; depends_on=depends_on)
+
+    #=
+    Per-trial parameter sets. Ungrouped, every trial points at the same two
+    NamedTuples (which themselves reference the model's arrays); grouped, a
+    trial points at its cell's. Either way the sampler below is one code path.
+    =#
+    if grp === nothing
+        state_params = fill(_extract_state_params(lds.state_model), ntrials)
+        obs_params = fill(_extract_obs_params(lds.obs_model), ntrials)
+    else
+        cell_state = [
+            _extract_state_params(_cell_lds(lds, grp, c).state_model) for c in 1:grp.ncells
+        ]
+        cell_obs = [
+            _extract_obs_params(_cell_lds(lds, grp, c).obs_model) for c in 1:grp.ncells
+        ]
+        state_params = [cell_state[grp.trial_cell[n]] for n in 1:ntrials]
+        obs_params = [cell_obs[grp.trial_cell[n]] for n in 1:ntrials]
+    end
+
     x = Vector{Matrix{T}}(undef, ntrials)
     y = Vector{Matrix{T}}(undef, ntrials)
     for i in 1:ntrials
@@ -166,7 +193,14 @@ function Random.rand(
     # gets its own child RNG, indexed by chunk (not `threadid()`).
     if ntrials == 1
         _sample_trial!(
-            rng, x[1], y[1], state_params, obs_params, lds.obs_model, ux_seq[1], uy_seq[1]
+            rng,
+            x[1],
+            y[1],
+            state_params[1],
+            obs_params[1],
+            lds.obs_model,
+            ux_seq[1],
+            uy_seq[1],
         )
         return x, y
     end
@@ -185,8 +219,8 @@ function Random.rand(
                 trng,
                 x[trial],
                 y[trial],
-                state_params,
-                obs_params,
+                state_params[trial],
+                obs_params[trial],
                 lds.obs_model,
                 ux_seq[trial],
                 uy_seq[trial],

--- a/src/stats/simulate.jl
+++ b/src/stats/simulate.jl
@@ -158,11 +158,8 @@ function Random.rand(
     ntrials = length(tsteps_per_trial)
     grp = parameter_grouping(lds, ntrials; depends_on=depends_on)
 
-    #=
-    Per-trial parameter sets. Ungrouped, every trial points at the same two
-    NamedTuples (which themselves reference the model's arrays); grouped, a
-    trial points at its cell's. Either way the sampler below is one code path.
-    =#
+    # Per-trial parameter sets: one shared pair when ungrouped, the cell's when
+    # grouped. Either way the sampler below is one code path.
     if grp === nothing
         state_params = fill(_extract_state_params(lds.state_model), ntrials)
         obs_params = fill(_extract_obs_params(lds.obs_model), ntrials)
@@ -210,11 +207,8 @@ function Random.rand(
     chunksize = cld(ntrials, ntasks)
     task_rngs = [MersenneTwister(rand(rng, UInt64)) for _ in 1:ntasks]
 
-    #=
-    `state_params` / `obs_params` are assigned in both arms of the grouping
-    branch above, so sharing those bindings with the closure would box them,
-    which OhMyThreads rejects (same idiom as `fit_SLDS.jl`'s parallel E-step).
-    =#
+    # Assigned in both arms above, so sharing the bindings with the closure
+    # would box them, which OhMyThreads rejects.
     let state_params = state_params, obs_params = obs_params
         tforeach(1:ntasks) do i
             lo = (i - 1) * chunksize + 1

--- a/src/stats/simulate.jl
+++ b/src/stats/simulate.jl
@@ -209,22 +209,29 @@ function Random.rand(
     chunksize = cld(ntrials, ntasks)
     task_rngs = [MersenneTwister(rand(rng, UInt64)) for _ in 1:ntasks]
 
-    tforeach(1:ntasks) do i
-        lo = (i - 1) * chunksize + 1
-        hi = min(i * chunksize, ntrials)
-        lo > hi && return nothing
-        trng = task_rngs[i]
-        for trial in lo:hi
-            _sample_trial!(
-                trng,
-                x[trial],
-                y[trial],
-                state_params[trial],
-                obs_params[trial],
-                lds.obs_model,
-                ux_seq[trial],
-                uy_seq[trial],
-            )
+    #=
+    `state_params` / `obs_params` are assigned in both arms of the grouping
+    branch above, so sharing those bindings with the closure would box them,
+    which OhMyThreads rejects (same idiom as `fit_SLDS.jl`'s parallel E-step).
+    =#
+    let state_params = state_params, obs_params = obs_params
+        tforeach(1:ntasks) do i
+            lo = (i - 1) * chunksize + 1
+            hi = min(i * chunksize, ntrials)
+            lo > hi && return nothing
+            trng = task_rngs[i]
+            for trial in lo:hi
+                _sample_trial!(
+                    trng,
+                    x[trial],
+                    y[trial],
+                    state_params[trial],
+                    obs_params[trial],
+                    lds.obs_model,
+                    ux_seq[trial],
+                    uy_seq[trial],
+                )
+            end
         end
     end
 

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -1,11 +1,15 @@
 # Ancillary parameter dependencies (`depends_on`): declaring that some
 # parameters are estimated separately per group of trials.
 #
-# This file covers the declaration side — validation, the resolved trial
-# partition, and the accessors that read a fitted version back. The grouped
-# E/M-step that consumes the partition lands in a follow-up; until it does,
-# every entry point refuses a model that declares `depends_on` rather than
-# silently pooling it (`test_depends_on_rejected_until_supported`).
+# The load-bearing correctness check is
+# `test_fully_grouped_matches_independent_fits`: when *every* parameter depends
+# on the session label, a grouped fit over the pooled data must reproduce, to
+# floating point, what independent fits of each session produce. Everything
+# downstream of that (partial grouping, priors, held-out scoring) shares the
+# same machinery.
+#
+# The Poisson LDS and the SLDS are still on the interim guard; their grouped
+# fits land in follow-ups (`test_depends_on_rejected_until_supported`).
 
 const PD_LATENT_DIM = 2
 const PD_OBS_DIM = 2
@@ -39,6 +43,38 @@ function pd_lds(sm, om; fit_bool::Vector{Bool}=fill(true, 6))
 end
 
 pd_fresh_lds() = pd_lds(pd_state_model(), pd_obs_model())
+
+"""
+EM on the MAP objective is monotone in exact arithmetic; allow a relative slack
+so an accumulated rounding error in the ELBO sum is not read as a real decrease.
+"""
+function pd_is_monotone(elbos::AbstractVector)
+    length(elbos) < 2 && return true
+    slack = 1e-8 * max(1.0, maximum(abs, elbos))
+    return all(>=(-slack), diff(elbos))
+end
+
+"""
+Two-session ground truth: shared latent dynamics, session-specific emissions.
+Mirrors the stitching setup — one animal, two recording sessions.
+"""
+function pd_two_session_truth(; ntrials_per_session::Int=6)
+    labels = vcat(fill(:s1, ntrials_per_session), fill(:s2, ntrials_per_session))
+    sm = pd_state_model()
+    om = pd_obs_model()
+    om.depends_on = (C=labels, R=labels)
+    lds = pd_lds(sm, om)
+
+    # Session 2 sees different "neurons" and is much noisier.
+    C2 = group_parameter(om, :C, :s2)
+    C2 .= [0.4 -0.9; 1.1 0.5]
+    d2 = group_parameter(om, :d, :s2)
+    d2 .= [0.5, -0.5]
+    R2 = group_parameter(om, :R, :s2)
+    R2 .= Matrix(1.5 * I(PD_OBS_DIM))
+
+    return lds, labels
+end
 
 # ============================================================================
 # Validation
@@ -96,6 +132,59 @@ function test_depends_on_validated_at_construction()
     # A model built through the keyword constructor is still rejected when
     # `validate_LDS` is run on it.
     @test_throws ArgumentError validate_LDS(pd_lds(pd_state_model(), bad_obs))
+
+    return nothing
+end
+
+function test_depends_on_trial_count_and_override()
+    om = pd_obs_model()
+    om.depends_on = (C=[:a, :a, :b],)
+    lds = pd_lds(pd_state_model(), om)
+
+    rng = StableRNG(101)
+    y3 = [randn(rng, PD_OBS_DIM, 25) for _ in 1:3]
+    y2 = y3[1:2]
+
+    # Labels are written for 3 trials; 2 trials is a mismatch.
+    @test_throws SSD.DimensionMismatchError fit!(
+        lds, y2; max_iter=1, progress=false
+    )
+
+    # ... unless the call supplies its own labels.
+    @test fit!(lds, y2; depends_on=(C=[:a, :b],), max_iter=1, progress=false) isa Vector
+
+    # An override may only re-assign trials to groups the model already knows.
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :unseen],), max_iter=1, progress=false
+    )
+
+    # An override is meaningless without a declared dependence.
+    plain = pd_fresh_lds()
+    @test_throws ArgumentError fit!(
+        plain, y2; depends_on=(C=[:a, :b],), max_iter=1, progress=false
+    )
+
+    # A typo'd override key is rejected rather than silently ignored ...
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :b], nope=[:a, :a, :b]), max_iter=1, progress=false
+    )
+    # ... as is naming a parameter the model never declared as grouped.
+    @test_throws ArgumentError fit!(
+        lds, y3; depends_on=(C=[:a, :a, :b], R=[:a, :a, :b]), max_iter=1, progress=false
+    )
+
+    #=
+    An override is one NamedTuple resolved against *both* sub-models, so keys
+    belonging to the emission must not trip up the state model's resolution.
+    =#
+    sm = pd_state_model()
+    sm.depends_on = (Q=[:a, :a, :b],)
+    om2 = pd_obs_model()
+    om2.depends_on = (C=[:a, :a, :b],)
+    both = pd_lds(sm, om2)
+    @test fit!(
+        both, y2; depends_on=(Q=[:a, :b], C=[:a, :b]), max_iter=1, progress=false
+    ) isa Vector
 
     return nothing
 end
@@ -192,6 +281,222 @@ function test_override_key_validation()
 end
 
 # ============================================================================
+# Equivalences
+# ============================================================================
+
+"""
+A `depends_on` whose labels are all identical adds no parameters, so it must
+reproduce the ungrouped fit.
+"""
+function test_single_group_matches_ungrouped()
+    rng = StableRNG(202)
+    truth = pd_fresh_lds()
+    _, y = rand(rng, truth, fill(40, 5))
+
+    plain = pd_fresh_lds()
+    elbos_plain = fit!(plain, y; max_iter=8, tol=0.0, progress=false)
+
+    om = pd_obs_model()
+    om.depends_on = (C=fill(:only, 5), R=fill(:only, 5))
+    grouped = pd_lds(pd_state_model(), om)
+    elbos_grouped = fit!(grouped, y; max_iter=8, tol=0.0, progress=false)
+
+    @test elbos_grouped ≈ elbos_plain
+    @test grouped.obs_model.C ≈ plain.obs_model.C
+    @test grouped.obs_model.R ≈ plain.obs_model.R
+    @test grouped.state_model.A ≈ plain.state_model.A
+    @test grouped.state_model.Q ≈ plain.state_model.Q
+    @test grouped.state_model.x0 ≈ plain.state_model.x0
+
+    return nothing
+end
+
+"""
+When *every* parameter depends on the session, the sessions share nothing, so a
+grouped fit must equal two independent fits — same ELBO trace (summed) and same
+fitted parameters. This is the sharpest check that the per-cell E-step and the
+slot-wise M-step pooling agree with the ordinary path.
+"""
+function test_fully_grouped_matches_independent_fits()
+    rng = StableRNG(303)
+
+    truth1 = pd_fresh_lds()
+    _, y1 = rand(rng, truth1, fill(35, 4))
+
+    truth2 = pd_fresh_lds()
+    truth2.obs_model.C .= [0.3 -1.0; 1.2 0.4]
+    truth2.obs_model.R .= Matrix(0.9 * I(PD_OBS_DIM))
+    truth2.state_model.A .= [0.7 0.3; -0.3 0.7]
+    _, y2 = rand(rng, truth2, fill(35, 4))
+
+    y = vcat(y1, y2)
+    labels = vcat(fill(:s1, 4), fill(:s2, 4))
+
+    fit_kwargs = (; max_iter=6, tol=0.0, progress=false)
+
+    lds1 = pd_fresh_lds()
+    elbos1 = fit!(lds1, y1; fit_kwargs...)
+    lds2 = pd_fresh_lds()
+    elbos2 = fit!(lds2, y2; fit_kwargs...)
+
+    sm = pd_state_model()
+    sm.depends_on = (x0=labels, P0=labels, A=labels, Q=labels)
+    om = pd_obs_model()
+    om.depends_on = (C=labels, R=labels)
+    grouped = pd_lds(sm, om)
+    elbos_g = fit!(grouped, y; fit_kwargs...)
+
+    @test elbos_g ≈ elbos1 .+ elbos2
+
+    for (label, ref) in ((:s1, lds1), (:s2, lds2))
+        @test group_parameter(grouped.obs_model, :C, label) ≈ ref.obs_model.C
+        @test group_parameter(grouped.obs_model, :d, label) ≈ ref.obs_model.d
+        @test group_parameter(grouped.obs_model, :R, label) ≈ ref.obs_model.R
+        @test group_parameter(grouped.state_model, :A, label) ≈ ref.state_model.A
+        @test group_parameter(grouped.state_model, :b, label) ≈ ref.state_model.b
+        @test group_parameter(grouped.state_model, :Q, label) ≈ ref.state_model.Q
+        @test group_parameter(grouped.state_model, :x0, label) ≈ ref.state_model.x0
+        @test group_parameter(grouped.state_model, :P0, label) ≈ ref.state_model.P0
+    end
+
+    return nothing
+end
+
+"""
+Ragged trial lengths inside a group take the per-trial smoother fallback rather
+than the shared-covariance fast path; the answer must not depend on which.
+"""
+function test_grouped_handles_ragged_trial_lengths()
+    rng = StableRNG(404)
+    lds, labels = pd_two_session_truth(; ntrials_per_session=3)
+    _, y = rand(rng, lds, [30, 41, 27, 33, 30, 38])
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    elbos = fit!(fitted, y; max_iter=10, tol=0.0, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    return nothing
+end
+
+# ============================================================================
+# Fitting behaviour
+# ============================================================================
+
+function test_grouped_elbo_increases_and_recovers_noise()
+    rng = StableRNG(505)
+    truth, labels = pd_two_session_truth(; ntrials_per_session=8)
+    _, y = rand(rng, truth, fill(80, length(labels)))
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    elbos = fit!(fitted, y; max_iter=60, tol=1e-8, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    #=
+    `C` is identifiable only up to a shared linear transform of the latent
+    space, so compare what is identifiable: session 2 was simulated 7.5x
+    noisier, and each session's noise covariance must come back that way rather
+    than being averaged into one.
+    =#
+    R1 = group_parameter(fitted.obs_model, :R, :s1)
+    R2 = group_parameter(fitted.obs_model, :R, :s2)
+    @test isposdef(R1)
+    @test isposdef(R2)
+    @test tr(R2) > 3 * tr(R1)
+
+    # Letting the emissions differ by session must fit at least as well as
+    # forcing them to be shared.
+    shared = pd_fresh_lds()
+    fit!(shared, y; max_iter=60, tol=1e-8, progress=false)
+    @test loglikelihood(fitted, y) > loglikelihood(shared, y)
+
+    return nothing
+end
+
+function test_grouped_smooth_loglikelihood_and_heldout()
+    rng = StableRNG(606)
+    truth, labels = pd_two_session_truth(; ntrials_per_session=4)
+    _, y = rand(rng, truth, fill(45, length(labels)))
+
+    fitted = pd_lds(pd_state_model(), pd_obs_model())
+    fitted.obs_model.depends_on = (C=labels, R=labels)
+    fit!(fitted, y; max_iter=15, tol=1e-8, progress=false)
+
+    xs, Ps = smooth(fitted, y)
+    @test length(xs) == length(y)
+    @test size(xs[1]) == (PD_LATENT_DIM, 45)
+    @test size(Ps[1]) == (PD_LATENT_DIM, PD_LATENT_DIM, 45)
+    @test all(x -> all(isfinite, x), xs)
+
+    #=
+    Each cell's smoothed covariance is computed once and shared within the
+    cell, but the two sessions have different emissions, so their covariances
+    must differ — i.e. sharing is per group, not global.
+    =#
+    @test Ps[1] ≈ Ps[2]
+    @test !(Ps[1] ≈ Ps[end])
+
+    @test isfinite(loglikelihood(fitted, y))
+    @test isfinite(elbo(fitted, y))
+
+    # Held-out scoring: a different trial count needs a `depends_on` override.
+    y_new = y[[1, 5, 6]]
+    lab_new = labels[[1, 5, 6]]
+    @test_throws SSD.DimensionMismatchError loglikelihood(fitted, y_new)
+    @test isfinite(loglikelihood(fitted, y_new; depends_on=(C=lab_new, R=lab_new)))
+    xs_new, _ = smooth(fitted, y_new; depends_on=(C=lab_new, R=lab_new))
+    @test length(xs_new) == 3
+
+    return nothing
+end
+
+function test_grouped_integer_labels_and_priors()
+    rng = StableRNG(707)
+    labels = [1, 1, 2, 2, 2]          # integers, not Symbols
+    truth = pd_fresh_lds()
+    _, y = rand(rng, truth, fill(40, 5))
+
+    sm = pd_state_model()
+    sm.Q_prior = IWPrior(; Ψ=Matrix(0.01 * I(PD_LATENT_DIM)), ν=6.0)
+    om = pd_obs_model()
+    om.R_prior = IWPrior(; Ψ=Matrix(0.05 * I(PD_OBS_DIM)), ν=6.0)
+    om.depends_on = (C=labels, R=labels)
+    fitted = pd_lds(sm, om)
+
+    elbos = fit!(fitted, y; max_iter=25, tol=1e-9, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    @test group_labels(om, :C) == [1, 2]
+    # Each version of `R` gets its own prior term and its own MAP update.
+    @test isposdef(group_parameter(om, :R, 1))
+    @test isposdef(group_parameter(om, :R, 2))
+
+    return nothing
+end
+
+function test_grouped_rand_needs_a_label_for_one_trial()
+    truth, labels = pd_two_session_truth(; ntrials_per_session=2)
+    rng = StableRNG(808)
+
+    # A single trial cannot be assigned to a group on its own.
+    @test_throws ArgumentError rand(rng, truth, 20)
+    x, y = rand(rng, truth, 20; depends_on=(C=[:s2], R=[:s2]))
+    @test size(y) == (PD_OBS_DIM, 20)
+
+    # Multi-trial sampling uses the model's own labels.
+    _, ys = rand(rng, truth, fill(20, length(labels)))
+    @test length(ys) == length(labels)
+
+    return nothing
+end
+
+# ============================================================================
 # Interim guard (removed as each model family's grouped fit lands)
 # ============================================================================
 
@@ -202,18 +507,6 @@ function test_depends_on_rejected_until_supported()
 
     om = pd_obs_model()
     om.depends_on = (C=labels,)
-    lds = pd_lds(pd_state_model(), om)
-
-    @test_throws ArgumentError fit!(lds, y; max_iter=1, progress=false)
-    @test_throws ArgumentError smooth(lds, y)
-    @test_throws ArgumentError elbo(lds, y)
-    @test_throws ArgumentError loglikelihood(lds, y)
-    @test_throws ArgumentError rand(rng, lds, 20)
-    @test_throws ArgumentError rand(rng, lds, fill(20, 3))
-
-    # A model that declares nothing is untouched by any of this.
-    plain = pd_fresh_lds()
-    @test fit!(plain, y; max_iter=1, progress=false) isa Vector
 
     pom = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
     pom.depends_on = (C=labels,)
@@ -228,6 +521,10 @@ function test_depends_on_rejected_until_supported()
     @test_throws ArgumentError fit!(plds, counts; max_iter=1, progress=false)
     @test_throws ArgumentError smooth(plds, counts)
     @test_throws ArgumentError elbo(plds, counts)
+
+    # Sampling is shared with the Gaussian path and is already grouped.
+    _, ys = rand(rng, plds, fill(20, 3))
+    @test length(ys) == 3
 
     slds = SLDS(;
         A=[0.9 0.1; 0.1 0.9],

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -144,9 +144,7 @@ function test_depends_on_trial_count_and_override()
     y2 = y3[1:2]
 
     # Labels are written for 3 trials; 2 trials is a mismatch.
-    @test_throws SSD.DimensionMismatchError fit!(
-        lds, y2; max_iter=1, progress=false
-    )
+    @test_throws SSD.DimensionMismatchError fit!(lds, y2; max_iter=1, progress=false)
 
     # ... unless the call supplies its own labels.
     @test fit!(lds, y2; depends_on=(C=[:a, :b],), max_iter=1, progress=false) isa Vector

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -552,3 +552,130 @@ function test_grouped_show()
 
     return nothing
 end
+
+#=
+A parameter that does *not* vary is fit from every trial that carries it, even
+when the trials fall in different cells. Grouping `:R` alone is the case that
+exercises it: `[C d D]` stays pooled, so both cells share one emission slot and
+their observation sufficient statistics have to be summed before the M-step
+solves for it.
+=#
+function test_grouped_pools_obs_stats_across_cells()
+    rng = StableRNG(808)
+    labels = [:a, :a, :a, :b, :b, :b]
+    _, y = rand(rng, pd_fresh_lds(), fill(40, length(labels)))
+
+    om = pd_obs_model()
+    om.depends_on = (R=labels,)
+    fitted = pd_lds(pd_state_model(), om)
+    elbos = fit!(fitted, y; max_iter=15, tol=1e-9, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    @test length(om.variants) == 2
+    # One `[C d D]`, shared by reference across both cells...
+    @test om.variants[1].C === om.variants[2].C
+    @test om.variants[1].d === om.variants[2].d
+    # ... while each cell keeps its own noise covariance.
+    @test !(om.variants[1].R ≈ om.variants[2].R)
+    @test isposdef(group_parameter(om, :R, :a))
+    @test isposdef(group_parameter(om, :R, :b))
+    return nothing
+end
+
+#=
+`smooth` keeps the shape convention of its input: a single trial handed over as
+a plain matrix comes back as one `x`/`P` pair rather than one-element vectors.
+Grouped models go through their own smoother, so the convention is re-asserted
+here.
+=#
+function test_grouped_smooth_accepts_a_single_trial_matrix()
+    rng = StableRNG(809)
+    labels = [:a, :a, :a, :b, :b, :b]
+    _, y = rand(rng, pd_fresh_lds(), fill(30, length(labels)))
+
+    om = pd_obs_model()
+    om.depends_on = (C=labels,)
+    fitted = pd_lds(pd_state_model(), om)
+    fit!(fitted, y; max_iter=3, progress=false)
+
+    x1, P1 = smooth(fitted, y[1]; depends_on=(C=[:a],))
+    @test x1 isa AbstractMatrix
+    @test size(x1) == (PD_LATENT_DIM, size(y[1], 2))
+    @test size(P1) == (PD_LATENT_DIM, PD_LATENT_DIM, size(y[1], 2))
+
+    # The vector form of the same trial agrees, and keeps the vector shape.
+    xs, Ps = smooth(fitted, [y[1]]; depends_on=(C=[:a],))
+    @test xs isa AbstractVector
+    @test xs[1] ≈ x1
+    @test Ps[1] ≈ P1
+    return nothing
+end
+
+#=
+The matrix-normal priors contribute a term per *pair* of slots — `[A b B]` with
+`Q`, `[C d D]` with `R`, `x0` with `P0` — because each term needs both halves.
+`test_grouped_integer_labels_and_priors` covers the inverse-Wishart ones, which
+are indexed by a single slot; these are the paired ones.
+=#
+function test_grouped_matrix_normal_priors()
+    rng = StableRNG(810)
+    labels = [:a, :a, :a, :b, :b, :b]
+    _, y = rand(rng, pd_fresh_lds(), fill(40, length(labels)))
+
+    sm = pd_state_model()
+    sm.x0_prior = x0_mean_prior(zeros(PD_LATENT_DIM); κ₀=1.0)
+    sm.AB_prior = StateSpaceDynamics.MNPrior(;
+        M₀=zeros(PD_LATENT_DIM, PD_LATENT_DIM + 1), Λ=Matrix(0.1 * I(PD_LATENT_DIM + 1))
+    )
+    om = pd_obs_model()
+    om.CD_prior = StateSpaceDynamics.MNPrior(;
+        M₀=zeros(PD_OBS_DIM, PD_LATENT_DIM + 1), Λ=Matrix(0.1 * I(PD_LATENT_DIM + 1))
+    )
+    om.depends_on = (C=labels, R=labels)
+    fitted = pd_lds(sm, om)
+
+    elbos = fit!(fitted, y; max_iter=15, tol=1e-9, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    # The prior terms are part of the objective, so the ELBO stays below the
+    # unpenalised one on the same data.
+    om_free = pd_obs_model()
+    om_free.depends_on = (C=labels, R=labels)
+    free = pd_lds(pd_state_model(), om_free)
+    free_elbos = fit!(free, y; max_iter=15, tol=1e-9, progress=false)
+    @test isfinite(free_elbos[end])
+    @test elbos[end] < free_elbos[end]
+    return nothing
+end
+
+#=
+The EM loop returns as soon as the ELBO stops moving, and the vector it hands
+back is truncated to the iterations actually run rather than padded to
+`max_iter`. `progress=true` drives the meter alongside it.
+=#
+function test_grouped_fit_stops_early_and_reports_progress()
+    rng = StableRNG(811)
+    labels = [:a, :a, :a, :b, :b, :b]
+    _, y = rand(rng, pd_fresh_lds(), fill(40, length(labels)))
+
+    om = pd_obs_model()
+    om.depends_on = (C=labels,)
+    fitted = pd_lds(pd_state_model(), om)
+    max_iter = 50
+    elbos = fit!(fitted, y; max_iter=max_iter, tol=1e-1, progress=true)
+
+    @test length(elbos) < max_iter
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    # It really did stop on the tolerance, not on an accident of length.
+    @test abs(elbos[end] - elbos[end - 1]) < 1e-1
+
+    # Running to `max_iter` instead returns the full vector.
+    om2 = pd_obs_model()
+    om2.depends_on = (C=labels,)
+    fitted2 = pd_lds(pd_state_model(), om2)
+    @test length(fit!(fitted2, y; max_iter=4, tol=0.0, progress=false)) == 4
+    return nothing
+end

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -147,11 +147,16 @@ function test_depends_on_trial_count_and_override()
     @test_throws SSD.DimensionMismatchError fit!(lds, y2; max_iter=1, progress=false)
 
     # ... unless the call supplies its own labels.
-    @test fit!(lds, y2; depends_on=(C=[:a, :b], d=[:a, :b]), max_iter=1, progress=false) isa Vector
+    @test fit!(lds, y2; depends_on=(C=[:a, :b], d=[:a, :b]), max_iter=1, progress=false) isa
+        Vector
 
     # An override may only re-assign trials to groups the model already knows.
     @test_throws ArgumentError fit!(
-        lds, y3; depends_on=(C=[:a, :a, :unseen], d=[:a, :a, :unseen]), max_iter=1, progress=false
+        lds,
+        y3;
+        depends_on=(C=[:a, :a, :unseen], d=[:a, :a, :unseen]),
+        max_iter=1,
+        progress=false,
     )
 
     # An override is meaningless without a declared dependence.
@@ -162,11 +167,19 @@ function test_depends_on_trial_count_and_override()
 
     # A typo'd override key is rejected rather than silently ignored ...
     @test_throws ArgumentError fit!(
-        lds, y3; depends_on=(C=[:a, :a, :b], d=[:a, :a, :b], nope=[:a, :a, :b]), max_iter=1, progress=false
+        lds,
+        y3;
+        depends_on=(C=[:a, :a, :b], d=[:a, :a, :b], nope=[:a, :a, :b]),
+        max_iter=1,
+        progress=false,
     )
     # ... as is naming a parameter the model never declared as grouped.
     @test_throws ArgumentError fit!(
-        lds, y3; depends_on=(C=[:a, :a, :b], d=[:a, :a, :b], R=[:a, :a, :b]), max_iter=1, progress=false
+        lds,
+        y3;
+        depends_on=(C=[:a, :a, :b], d=[:a, :a, :b], R=[:a, :a, :b]),
+        max_iter=1,
+        progress=false,
     )
 
     #=
@@ -179,7 +192,11 @@ function test_depends_on_trial_count_and_override()
     om2.depends_on = (C=[:a, :a, :b], d=[:a, :a, :b])
     both = pd_lds(sm, om2)
     @test fit!(
-        both, y2; depends_on=(Q=[:a, :b], C=[:a, :b], d=[:a, :b]), max_iter=1, progress=false
+        both,
+        y2;
+        depends_on=(Q=[:a, :b], C=[:a, :b], d=[:a, :b]),
+        max_iter=1,
+        progress=false,
     ) isa Vector
 
     return nothing
@@ -448,7 +465,9 @@ function test_grouped_smooth_loglikelihood_and_heldout()
     y_new = y[[1, 5, 6]]
     lab_new = labels[[1, 5, 6]]
     @test_throws SSD.DimensionMismatchError loglikelihood(fitted, y_new)
-    @test isfinite(loglikelihood(fitted, y_new; depends_on=(C=lab_new, d=lab_new, R=lab_new)))
+    @test isfinite(
+        loglikelihood(fitted, y_new; depends_on=(C=lab_new, d=lab_new, R=lab_new))
+    )
     xs_new, _ = smooth(fitted, y_new; depends_on=(C=lab_new, d=lab_new, R=lab_new))
     @test length(xs_new) == 3
 
@@ -681,6 +700,10 @@ function test_grouped_fit_stops_early_and_reports_progress()
     om2.depends_on = (C=labels, d=labels)
     fitted2 = pd_lds(pd_state_model(), om2)
     @test length(fit!(fitted2, y; max_iter=4, tol=0.0, progress=false)) == 4
+    return nothing
+end
+
+#=
 `[A b B]` and `[C d D]` are each fit as one regression, so grouping any member
 groups them all. Naming one and leaving the rest out reads as though only that
 one varies — the opposite of what happens — so it is rejected rather than
@@ -703,7 +726,7 @@ function test_depends_on_requires_the_whole_group()
 
     # The message names what is missing and shows the complete form.
     om = pd_obs_model()
-    om.depends_on = (C=labels, d=labels)
+    om.depends_on = (C=labels,)
     msg = try
         SSD._resolve_dependence(om)
         ""
@@ -777,8 +800,120 @@ function test_depends_on_override_requires_the_whole_group()
     lds = pd_lds(pd_state_model(), om)
 
     swapped = [:b, :b, :a, :a]
-    @test_throws ArgumentError SSD.parameter_grouping(lds, 4; depends_on=(C=swapped, d=swapped))
+    @test_throws ArgumentError SSD.parameter_grouping(lds, 4; depends_on=(C=swapped,))
     @test_throws ArgumentError SSD.parameter_grouping(lds, 4; depends_on=(d=swapped,))
     @test SSD.parameter_grouping(lds, 4; depends_on=(C=swapped, d=swapped)) !== nothing
+    return nothing
+end
+
+#=
+Pooling several units' statistics and solving the ordinary normal equations
+maximizes the objective only when those units also share the residual
+covariance — held fixed, it divides out of the score. `_tied_gls_regression`
+handles the case where it does not, and reduces to exactly the pooled answer
+when it does, so the cheap path is a special case rather than a second
+estimator.
+=#
+function test_tied_gls_reduces_to_pooled_ols()
+    rng = StableRNG(5)
+    p, m = 3, 4
+    function stats()
+        Z = randn(rng, m, 60)
+        return (Matrix(Symmetric(Z * Z' + 5I)), randn(rng, m, p))
+    end
+    Szz1, Szy1 = stats()
+    Szz2, Szy2 = stats()
+    A = randn(rng, p, p)
+    Σ = Matrix(Symmetric(A * A' + 2I))
+
+    # One unit is the ordinary solve, whatever its covariance.
+    @test SSD._tied_gls_regression([Szz1], [Szy1], [Σ], nothing, Σ) ≈
+        SSD.mn_map(PDMat(Szz1), Szy1, nothing)
+
+    # Several units sharing one covariance is the pooled solve.
+    pooled_zz = PDMat(Matrix(Symmetric(Szz1 + Szz2)))
+    @test SSD._tied_gls_regression([Szz1, Szz2], [Szy1, Szy2], [Σ, Σ], nothing, Σ) ≈
+        SSD.mn_map(pooled_zz, Szy1 + Szy2, nothing)
+
+    # ... including under a matrix-normal prior.
+    prior = SSD.MNPrior(; M₀=randn(rng, p, m), Λ=Matrix(0.3I, m, m))
+    @test SSD._tied_gls_regression([Szz1, Szz2], [Szy1, Szy2], [Σ, Σ], prior, Σ) ≈
+        SSD.mn_map(pooled_zz, Szy1 + Szy2, prior)
+
+    # With covariances that genuinely differ it is a different estimate.
+    B = randn(rng, p, p)
+    Σ2 = Matrix(Symmetric(B * B' + 0.05I))
+    @test !isapprox(
+        SSD._tied_gls_regression([Szz1, Szz2], [Szy1, Szy2], [Σ, Σ2], nothing, Σ),
+        SSD.mn_map(pooled_zz, Szy1 + Szy2, nothing);
+        rtol=1e-3,
+    )
+
+    # `_shared_noise` is what picks between the two.
+    @test SSD._shared_noise([1, 1, 2], [1, 2])
+    @test SSD._shared_noise([1, 1, 2], [3])
+    @test !SSD._shared_noise([1, 1, 2], [1, 3])
+    return nothing
+end
+
+#=
+Grouping `:R` but not `[C d D]` is the configuration where the two disagree:
+one emission is fit from sessions whose noise levels differ, so the pooled
+normal equations do not maximize the ELBO and the fit walks downhill. The
+load-bearing assertion is monotonicity — that is what a wrong estimator breaks.
+=#
+function test_grouped_gls_when_emission_and_noise_disagree()
+    labels = vcat(fill(:a, 4), fill(:b, 4))
+    quiet, loud = 0.02, 2.0
+
+    om_q = pd_obs_model()
+    om_q.R = Matrix(quiet * I(PD_OBS_DIM))
+    om_l = pd_obs_model()
+    om_l.R = Matrix(loud * I(PD_OBS_DIM))
+    _, y_q = rand(StableRNG(21), pd_lds(pd_state_model(), om_q), fill(40, 4))
+    _, y_l = rand(StableRNG(22), pd_lds(pd_state_model(), om_l), fill(40, 4))
+    y = vcat(y_q, y_l)
+
+    om = pd_obs_model()
+    om.depends_on = (R=labels,)
+    fitted = pd_lds(pd_state_model(), om)
+    elbos = fit!(fitted, y; max_iter=30, tol=0.0, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    # One emission shared by both sessions...
+    @test om.variants[1].C === om.variants[2].C
+    # ... and each session's noise recovered on its own scale.
+    R_a = group_parameter(om, :R, :a)
+    R_b = group_parameter(om, :R, :b)
+    @test tr(R_a) / PD_OBS_DIM < tr(R_b) / PD_OBS_DIM
+    @test isposdef(R_a)
+    @test isposdef(R_b)
+    return nothing
+end
+
+#=
+The same disagreement on the state side: `:Q` grouped with `[A b B]` pooled.
+=#
+function test_grouped_gls_when_dynamics_and_noise_disagree()
+    labels = vcat(fill(:a, 4), fill(:b, 4))
+
+    sm_q = pd_state_model()
+    sm_q.Q = Matrix(0.005 * I(PD_LATENT_DIM))
+    sm_l = pd_state_model()
+    sm_l.Q = Matrix(0.5 * I(PD_LATENT_DIM))
+    _, y_q = rand(StableRNG(23), pd_lds(sm_q, pd_obs_model()), fill(40, 4))
+    _, y_l = rand(StableRNG(24), pd_lds(sm_l, pd_obs_model()), fill(40, 4))
+    y = vcat(y_q, y_l)
+
+    sm = pd_state_model()
+    sm.depends_on = (Q=labels,)
+    fitted = pd_lds(sm, pd_obs_model())
+    elbos = fit!(fitted, y; max_iter=30, tol=0.0, progress=false)
+
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    @test sm.variants[1].A === sm.variants[2].A
+    @test tr(group_parameter(sm, :Q, :a)) < tr(group_parameter(sm, :Q, :b))
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,12 +259,26 @@ using SSDTest
                 test_depends_on_validation()
                 test_depends_on_validated_at_construction()
                 test_override_key_validation()
+                test_depends_on_trial_count_and_override()
             end
 
             @testset "Accessors and partition" begin
                 test_group_accessors_and_aliasing()
                 test_grouping_is_the_join_of_label_vectors()
                 test_grouped_show()
+            end
+
+            @testset "Equivalences" begin
+                test_single_group_matches_ungrouped()
+                test_fully_grouped_matches_independent_fits()
+                test_grouped_handles_ragged_trial_lengths()
+            end
+
+            @testset "Gaussian fitting" begin
+                test_grouped_elbo_increases_and_recovers_noise()
+                test_grouped_smooth_loglikelihood_and_heldout()
+                test_grouped_integer_labels_and_priors()
+                test_grouped_rand_needs_a_label_for_one_trial()
             end
 
             @testset "Not yet honoured by fitting" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,6 +278,9 @@ using SSDTest
             end
 
             @testset "Gaussian fitting" begin
+                test_tied_gls_reduces_to_pooled_ols()
+                test_grouped_gls_when_emission_and_noise_disagree()
+                test_grouped_gls_when_dynamics_and_noise_disagree()
                 test_grouped_pools_obs_stats_across_cells()
                 test_grouped_smooth_accepts_a_single_trial_matrix()
                 test_grouped_matrix_normal_priors()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,6 +275,10 @@ using SSDTest
             end
 
             @testset "Gaussian fitting" begin
+                test_grouped_pools_obs_stats_across_cells()
+                test_grouped_smooth_accepts_a_single_trial_matrix()
+                test_grouped_matrix_normal_priors()
+                test_grouped_fit_stops_early_and_reports_progress()
                 test_grouped_elbo_increases_and_recovers_noise()
                 test_grouped_smooth_loglikelihood_and_heldout()
                 test_grouped_integer_labels_and_priors()


### PR DESCRIPTION
**3 of 5 — splitting #165 into reviewable pieces.** Stacked on #167 (which is stacked on #166); the diff here is only this PR's changes. Base retargets as the parents merge.

`fit!`, `smooth`, `elbo`, `loglikelihood` and `rand` now honour a Gaussian LDS's `depends_on` instead of rejecting it. The Poisson LDS and the SLDS keep the interim guard until PRs 4 and 5.

### Design

A **cell** is a maximal set of trials sharing every parameter — the common refinement of all the label vectors. Trials in a cell are governed by a single `LinearDynamicalSystem`, so **the E-step runs on each cell's sub-`Data` completely unchanged**; only the M-step and the ELBO become group-aware.

Two consequences worth checking in review:

- The equal-length shared-covariance fast path stays alive *within* each group. Parameters differ between cells, so their smoothed covariances genuinely differ — sharing one across the whole dataset would be wrong, sharing one per cell is exactly as valid as the ungrouped case.
- The `O(D²·T)` workspace storage (block-tridiagonal + shared-covariance cache) is allocated **once** and reused across cells, so a grouped fit's memory tracks an ungrouped one's rather than scaling with the number of sessions. A cell's smoothed covariances are consumed by its own aggregation before the next cell overwrites them. What must survive between iterations is the small per-cell aggregator constants (`Σyy'`, the bias/input blocks) — those have no `tsteps` dimension, so they are cached per cell and copied back in before each cell's aggregation.

`SmoothWorkspace` becomes `mutable` in its `batched` field only (every other field is `const`), so each cell's BLAS-3 mean-pass buffers can be swapped in while the expensive storage stays shared.

### `grouped_em.jl`

Holds what PRs 4 and 5 also need. Everything is written against a flat list of **units** — a unit is one thing that produced a `SufficientStatistics`: a cell for an LDS, or a (regime, cell) pair for an SLDS. Parameters shared by several units are the *same array object*, so writing through any one of them updates all.

- pooling per-cell sufficient statistics per parameter version. Only the blocks the regression updates read are pooled; the covariance updates never need a pooled `*_yy`, which also avoids a Cholesky of a possibly rank-deficient pooled `obs_yy` for a small group. A version backed by a single unit reuses that unit's statistics verbatim, which is what keeps singleton groups numerically identical to the ungrouped fit.
- the grouped state-side and Gaussian-emission M-steps, built on the accumulate/finalize halves from #166: residual scatter is summed cell by cell, **each with its own regression matrix**, so a grouping of `C` finer than that of `R` comes out right.
- the grouped prior log-density: IW terms once per covariance version, MN terms once per distinct regression/covariance pair — consistent with the M-step, where the same pairs decide how often `Wm Λ Wm'` is folded into the IW scale.

### Held-out scoring

Every entry point takes a `depends_on` keyword overriding the model's stored labels for that call, so a test set with a different trial count can be scored without mutating the model:

```julia
ll = loglikelihood(lds, Y_test; depends_on = (C = session_test, R = session_test))
```

### Tests

The load-bearing check is `test_fully_grouped_matches_independent_fits`: with *every* parameter depending on the session label, the sessions share nothing, so a grouped fit over the pooled data must equal two independent fits — same summed ELBO trace and same fitted parameters, to floating point. Its mirror image is `test_single_group_matches_ungrouped`: a `depends_on` whose labels are all identical adds no parameters and must reproduce the ungrouped fit exactly. Everything else downstream shares that machinery.

Also: ragged trial lengths (which take the per-trial smoother fallback rather than the fast path), ELBO monotonicity, per-group noise recovery, grouped `smooth` returning per-cell-shared covariances, held-out scoring through the override, integer labels combined with priors, and the single-trial `rand` error.

### Note on `rand`

Sampling lives in `simulate.jl` and is shared by the Gaussian and Poisson emissions, so a Poisson LDS can already be *sampled* with `depends_on` after this PR even though it cannot yet be *fitted*. That is intentional — it makes the synthetic multi-session dataset for PR 4's tests available — and PR 4 removes the remaining Poisson guards.

### Follow-ups in this series

4. Grouped EM for the Poisson LDS
5. Grouped EM for the SLDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgmEbyHewqUYTJLFegAoK5)_