### PR TITLE
feature / grouped EM for the Poisson LDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     with the new exported `group_labels(model, name)` and
     `group_parameter(model, name, label)`
   * `show` reports the declared groups for a model that has any
-  * Honoured by the **Gaussian LDS** across `fit!`, `smooth`, `elbo`,
-    `loglikelihood` and `rand`, each of which also accepts a `depends_on`
-    keyword overriding the model's stored labels so a held-out set with a
-    different trial count can be scored without mutating the model. All
+  * Honoured by the **Gaussian LDS** and the **Poisson LDS** across `fit!`,
+    `smooth`, `elbo`, `loglikelihood` and `rand`, each of which also accepts a
+    `depends_on` keyword overriding the model's stored labels so a held-out set
+    with a different trial count can be scored without mutating the model. All
     versions of a parameter share the model's prior; each version contributes
     its own log-prior term to the ELBO
   * The efficiency of same-length epochs is preserved *within* each group:
@@ -45,10 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     storage is allocated once and reused across cells, so a grouped fit's
     memory tracks an ungrouped one's instead of scaling with the number of
     groups
-  * **The Poisson LDS and the SLDS are not wired up yet.** Their grouped
-    E/M-steps land in follow-ups; until then their `fit!`, `smooth` and `elbo`
-    throw an `ArgumentError` on a model that declares `depends_on` rather than
-    silently fitting one pooled parameter set
+  * For the Poisson emission there is no sufficient-statistic form, so the
+    M-step runs one LBFGS solve per version of `[C d D]`, over the trials of
+    every cell that shares that version
+  * **The SLDS is not wired up yet.** Its grouped E/M-step lands in a
+    follow-up; until then its `fit!`, `elbo` and `rand` throw an
+    `ArgumentError` on a model that declares `depends_on` rather than silently
+    fitting one pooled parameter set
   * With `depends_on` unset, every entry point takes its original code path
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS

--- a/docs/src/LinearDynamicalSystems.md
+++ b/docs/src/LinearDynamicalSystems.md
@@ -448,6 +448,12 @@ All versions of a parameter share the model's prior (`Q_prior`, `R_prior`,
 `CD_prior`, …), and each version contributes its own log-prior term to the
 ELBO.
 
+A Poisson LDS supports the same field on its emission — `(C = session,)` fits
+one `[C d D]` per session. The Poisson emission is not conjugate, so its M-step
+runs one LBFGS solve per version of `[C d D]`, over the trials of every group
+that shares that version; the state side flows through the pooled sufficient
+statistics exactly as in the Gaussian case.
+
 Grouping does not give up the efficiency of equal-length epochs. Trials that
 share every parameter form a *cell*, and the smoother computes one covariance
 per cell and shares it across that cell's trials, exactly as it does across all

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -749,6 +749,10 @@ This is the same quantity `fit!` reports per iteration — a lower bound on the
 # Keywords
 - `newton_max_iter` / `newton_tol`: Newton-smoother iteration cap and
   convergence tolerance (as in `fit!`).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -759,9 +763,17 @@ function elbo(
     uy=nothing,
     newton_max_iter::Int=20,
     newton_tol::Float64=1e-6,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    _reject_unsupported_dependence(plds)
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    if grp !== nothing
+        sws_pool = _grouped_sws_pool(plds, data)
+        state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+        return _grouped_estep_elbo_poisson!(
+            state, grp, sws_pool; max_iter=newton_max_iter, tol=T(newton_tol)
+        )
+    end
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
     npool = min(Threads.maxthreadid(), length(data.y))
     sws_pool = [
@@ -793,6 +805,10 @@ iterative-Newton `smooth!`).
 - `y`: observed counts — a `(obs_dim, T)` matrix (single trial), a
   `(obs_dim, T, ntrials)` array, or a `Vector{<:AbstractMatrix}` of per-trial
   `(obs_dim, T_i)` matrices (ragged lengths allowed).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 # Returns
 For a single-trial (matrix) `y`:
@@ -806,9 +822,11 @@ function smooth(
     y::Union{AbstractMatrix{T},AbstractArray{T,3},AbstractVector{<:AbstractMatrix{T}}};
     ux=nothing,
     uy=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    _reject_unsupported_dependence(plds)
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _grouped_smooth(plds, data, grp, y)
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
     # Cap the pool at the trial count — workspaces beyond ntrials are never
     # touched and each carries O(D²·T) of block-tridiagonal storage.
@@ -852,6 +870,10 @@ Fit a Poisson LDS via Laplace-EM.
 - `progress`: show progress bar
 - `newton_max_iter`: Newton iterations per E-step inner solve
 - `newton_tol`: Newton convergence tolerance
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 """
 function fit!(
     plds::LinearDynamicalSystem{T,S,O},
@@ -863,9 +885,20 @@ function fit!(
     progress=true,
     newton_max_iter::Int=20,
     newton_tol::Float64=1e-6,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
-    _reject_unsupported_dependence(plds)
     data = Data(plds, y; ux=ux, uy=uy)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp === nothing || return _fit_plds_grouped!(
+        plds,
+        data,
+        grp;
+        max_iter=max_iter,
+        tol=tol,
+        progress=progress,
+        newton_max_iter=newton_max_iter,
+        newton_tol=newton_tol,
+    )
     T_max = maximum(data.tsteps)
 
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
@@ -908,6 +941,129 @@ function fit!(
         prog !== nothing && next!(prog)
 
         # check convergence
+        if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
+            prog !== nothing && finish!(prog)
+            resize!(elbos, iter)
+            return elbos
+        end
+    end
+
+    prog !== nothing && finish!(prog)
+    return elbos
+end
+
+"""
+    _grouped_estep_elbo_poisson!(state, grp, sws_pool; max_iter, tol)
+
+One grouped Laplace E-step for a Poisson LDS: smooth and aggregate each cell
+with its own parameters, and return the total ELBO. Mirrors
+`_grouped_estep_elbo_gaussian!`, but the observation-side Q-term stays a
+per-trial loop (the Poisson emission has no sufficient-statistic form).
+"""
+function _grouped_estep_elbo_poisson!(
+    state::GroupedFitState{T,L},
+    grp::ParameterGrouping,
+    sws_pool::Vector{SmoothWorkspace{T}};
+    max_iter::Int=20,
+    tol::T=T(1e-6),
+) where {
+    T<:Real,
+    L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:PoissonObservationModel{T}},
+}
+    total = zero(T)
+    for c in 1:grp.ncells
+        lds_c = state.cell_lds[c]
+        suf_c = state.sufs[c]
+        tfs_c = state.cell_tfs[c]
+        _prepare_cell!(sws_pool[1], state, c)
+        estep!(
+            lds_c, suf_c, tfs_c, state.cell_data[c], sws_pool; max_iter=max_iter, tol=tol
+        )
+
+        compute_smooth_constants!(sws_pool[1], lds_c)
+        total += Q_state!(sws_pool[1], lds_c, suf_c)
+        total += _poisson_q_obs_total(lds_c, tfs_c, state.cell_data[c], sws_pool)
+        for fs in tfs_c.FilterSmooths
+            total += fs.entropy
+        end
+    end
+    total += _grouped_state_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    total += _grouped_poisson_obs_prior_logdensity(state.cell_lds, grp.cell_slot, T)
+    return total
+end
+
+"""
+    _grouped_update_observation_model!(state, grp, data, sws_pool)
+
+Poisson emission M-step, once per version of `[C d D]`: the LBFGS solve runs on
+the trials of every cell that shares that version, so a `[C d D]` shared across
+cells is still fit from all of their data.
+"""
+function _grouped_update_observation_model!(
+    state::GroupedFitState{T},
+    grp::ParameterGrouping,
+    data::Data{T},
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {T<:Real}
+    for units in _units_by_slot(grp.cell_slot[_G_CD])
+        trials = Int[]
+        for c in units
+            append!(trials, grp.cell_trials[c])
+        end
+        sort!(trials)
+        tfs = TrialFilterSmooth([state.tfs_all[n] for n in trials])
+        update_observation_model!(
+            state.cell_lds[units[1]], tfs, data.y[trials], sws_pool; uy=data.uy[trials]
+        )
+    end
+    return nothing
+end
+
+"""
+    _fit_plds_grouped!(plds, data, grp; ...)
+
+Laplace-EM driver for a Poisson LDS whose parameters depend on an ancillary
+variable. Same structure as the ungrouped `fit!`: the state side flows through
+the pooled sufficient statistics, the emission through one LBFGS solve per
+`[C d D]` version.
+"""
+function _fit_plds_grouped!(
+    plds::LinearDynamicalSystem{T,S,O},
+    data::Data{T},
+    grp::ParameterGrouping;
+    max_iter::Int=100,
+    tol::Float64=1e-6,
+    progress=true,
+    newton_max_iter::Int=20,
+    newton_tol::Float64=1e-6,
+) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
+    sws_pool = _grouped_sws_pool(plds, data)
+    state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+    elbos = Vector{T}(undef, max_iter)
+
+    prog = if progress
+        Progress(
+            max_iter;
+            desc="Fitting grouped Poisson LDS via LaPlaceEM...",
+            barlen=50,
+            showspeed=true,
+        )
+    else
+        nothing
+    end
+
+    for iter in 1:max_iter
+        elbos[iter] = _grouped_estep_elbo_poisson!(
+            state, grp, sws_pool; max_iter=newton_max_iter, tol=T(newton_tol)
+        )
+
+        _grouped_state_mstep!(
+            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+        )
+        _grouped_update_observation_model!(state, grp, data, sws_pool)
+
+        prog !== nothing && next!(prog)
+
         if iter > 1 && abs(elbos[iter] - elbos[iter - 1]) < tol
             prog !== nothing && finish!(prog)
             resize!(elbos, iter)

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -1012,11 +1012,8 @@ function _grouped_update_observation_model!(
         end
         sort!(trials)
         tfs = TrialFilterSmooth([state.tfs_all[n] for n in trials])
-
-        # solve using the pooled workspace for each cell
-        cell_pool = _prepare_cell!(sws_pool, state, units[1])
         update_observation_model!(
-            state.cell_lds[units[1]], tfs, data.y[trials], cell_pool; uy=data.uy[trials]
+            state.cell_lds[units[1]], tfs, data.y[trials], sws_pool; uy=data.uy[trials]
         )
     end
     return nothing

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -1012,8 +1012,11 @@ function _grouped_update_observation_model!(
         end
         sort!(trials)
         tfs = TrialFilterSmooth([state.tfs_all[n] for n in trials])
+
+        # solve using the pooled workspace for each cell
+        cell_pool = _prepare_cell!(sws_pool, state, units[1])
         update_observation_model!(
-            state.cell_lds[units[1]], tfs, data.y[trials], sws_pool; uy=data.uy[trials]
+            state.cell_lds[units[1]], tfs, data.y[trials], cell_pool; uy=data.uy[trials]
         )
     end
     return nothing

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -967,11 +967,10 @@ function _grouped_estep_elbo_poisson!(
     max_iter::Int=20,
     tol::T=T(1e-6),
 ) where {
-    T<:Real,
-    L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:PoissonObservationModel{T}},
+    T<:Real,L<:LinearDynamicalSystem{T,<:GaussianStateModel{T},<:PoissonObservationModel{T}}
 }
     total = zero(T)
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         lds_c = state.cell_lds[c]
         suf_c = state.sufs[c]
         tfs_c = state.cell_tfs[c]

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -617,3 +617,26 @@ function _grouped_gaussian_obs_prior_logdensity(
     end
     return total
 end
+
+"""
+    _grouped_poisson_obs_prior_logdensity(ldss, slots)
+
+`log p(θ)` for the Poisson emission parameters of a grouped model. Poisson has
+no observation-noise covariance, so the MN prior on `[C d D]` contributes the
+bare quadratic that the LBFGS emission objective penalizes, once per version.
+"""
+function _grouped_poisson_obs_prior_logdensity(
+    ldss::AbstractVector, slots::AbstractVector{Vector{Int}}, ::Type{T}
+) where {T<:Real}
+    total = zero(T)
+    for u in _slot_representatives(slots[_G_CD])
+        lds = ldss[u]
+        om = lds.obs_model
+        om.CD_prior === nothing && continue
+        D = lds.latent_dim
+        W_cd = _pack_obs_V!(Matrix{T}(undef, lds.obs_dim, D + 1 + lds.uy_dim), lds)
+        Wm = W_cd .- om.CD_prior.M₀
+        total -= T(0.5) * sum(Wm .* (Wm * om.CD_prior.Λ))
+    end
+    return total
+end

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -8,8 +8,8 @@
 # downstream of that (partial grouping, priors, held-out scoring) shares the
 # same machinery.
 #
-# The Poisson LDS and the SLDS are still on the interim guard; their grouped
-# fits land in follow-ups (`test_depends_on_rejected_until_supported`).
+# The SLDS is still on the interim guard; its grouped fit lands in a follow-up
+# (`test_depends_on_rejected_until_supported`).
 
 const PD_LATENT_DIM = 2
 const PD_OBS_DIM = 2
@@ -497,6 +497,55 @@ function test_grouped_rand_needs_a_label_for_one_trial()
 end
 
 # ============================================================================
+# Poisson
+# ============================================================================
+
+function test_grouped_poisson_fit()
+    rng = StableRNG(909)
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+
+    sm = pd_state_model()
+    om = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
+    om.depends_on = (C=labels,)
+    truth = LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+    C2 = group_parameter(om, :C, :s2)
+    C2 .= [-0.4 0.7; 0.5 -0.3]
+    d2 = group_parameter(om, :d, :s2)
+    d2 .= [0.2, 1.4]
+
+    _, y = rand(rng, truth, fill(40, length(labels)))
+
+    om_fit = PoissonObservationModel([0.5 0.0; 0.0 0.5], [1.0, 1.0])
+    om_fit.depends_on = (C=labels,)
+    fitted = LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om_fit,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+
+    elbos = fit!(fitted, y; max_iter=8, tol=0.0, progress=false)
+    @test all(isfinite, elbos)
+    @test elbos[end] > elbos[1]
+
+    # The two sessions really did get separate emission parameters.
+    @test !(group_parameter(om_fit, :C, :s1) ≈ group_parameter(om_fit, :C, :s2))
+    @test isfinite(elbo(fitted, y))
+
+    xs, _ = smooth(fitted, y)
+    @test length(xs) == length(y)
+
+    return nothing
+end
+
+# ============================================================================
 # Interim guard (removed as each model family's grouped fit lands)
 # ============================================================================
 
@@ -507,24 +556,6 @@ function test_depends_on_rejected_until_supported()
 
     om = pd_obs_model()
     om.depends_on = (C=labels,)
-
-    pom = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
-    pom.depends_on = (C=labels,)
-    plds = LinearDynamicalSystem(;
-        state_model=pd_state_model(),
-        obs_model=pom,
-        latent_dim=PD_LATENT_DIM,
-        obs_dim=PD_OBS_DIM,
-        fit_bool=fill(true, 5),
-    )
-    counts = [Float64.(rand(rng, 0:3, PD_OBS_DIM, 20)) for _ in 1:3]
-    @test_throws ArgumentError fit!(plds, counts; max_iter=1, progress=false)
-    @test_throws ArgumentError smooth(plds, counts)
-    @test_throws ArgumentError elbo(plds, counts)
-
-    # Sampling is shared with the Gaussian path and is already grouped.
-    _, ys = rand(rng, plds, fill(20, 3))
-    @test length(ys) == 3
 
     slds = SLDS(;
         A=[0.9 0.1; 0.1 0.9],

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -710,3 +710,94 @@ function test_grouped_fit_stops_early_and_reports_progress()
     @test length(fit!(fitted2, y; max_iter=4, tol=0.0, progress=false)) == 4
     return nothing
 end
+
+# A grouped Poisson truth: two sessions sharing dynamics, each with its own
+# emission, matching `test_grouped_poisson_fit`'s setup.
+function pd_grouped_poisson_data(seed::Int; ntrials_per::Int=3, tsteps::Int=40)
+    labels = vcat(fill(:s1, ntrials_per), fill(:s2, ntrials_per))
+    om = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
+    om.depends_on = (C=labels,)
+    truth = LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+    group_parameter(om, :C, :s2) .= [-0.4 0.7; 0.5 -0.3]
+    group_parameter(om, :d, :s2) .= [0.2, 1.4]
+    _, y = rand(StableRNG(seed), truth, fill(tsteps, length(labels)))
+    return labels, y
+end
+
+function pd_grouped_poisson_lds(labels; Λ::Real=0.0)
+    om = PoissonObservationModel([0.6 0.1; -0.2 0.5], [1.0, 0.8])
+    if Λ > 0
+        om.CD_prior = StateSpaceDynamics.MNPrior(;
+            M₀=zeros(PD_OBS_DIM, PD_LATENT_DIM + 1), Λ=Matrix(Λ * I(PD_LATENT_DIM + 1))
+        )
+    end
+    om.depends_on = (C=labels,)
+    return LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om,
+        latent_dim=PD_LATENT_DIM,
+        obs_dim=PD_OBS_DIM,
+        fit_bool=fill(true, 5),
+    )
+end
+
+#=
+A Poisson emission has no noise covariance, so its `[C d D]` prior cannot be the
+conjugate matrix-normal update the Gaussian side uses; it enters the objective
+as a bare quadratic penalty, once per version of `[C d D]`. The test drives it
+from the outside: with `M₀ = 0`, tightening `Λ` has to pull every group's
+emission towards zero and cost ELBO for doing so.
+=#
+function test_grouped_poisson_cd_prior()
+    labels, y = pd_grouped_poisson_data(909)
+
+    function emission_norm(om)
+        return sum(
+            norm(hcat(group_parameter(om, :C, l), group_parameter(om, :d, l))) for
+            l in group_labels(om, :C)
+        )
+    end
+
+    results = map((0.0, 10.0, 200.0)) do Λ
+        fitted = pd_grouped_poisson_lds(labels; Λ=Λ)
+        elbos = fit!(fitted, y; max_iter=25, tol=0.0, progress=false)
+        @test all(isfinite, elbos)
+        @test pd_is_monotone(elbos)
+        (elbos[end], emission_norm(fitted.obs_model))
+    end
+
+    # Tighter prior, emission pulled harder towards `M₀ = 0`.
+    @test results[1][2] > results[2][2] > results[3][2]
+    # ... and the penalty it pays shows up in the objective.
+    @test results[1][1] > results[2][1] > results[3][1]
+    return nothing
+end
+
+#=
+The Laplace-EM loop returns as soon as the ELBO stops moving, truncating the
+vector to the iterations actually run rather than padding to `max_iter`.
+`progress=true` drives the meter alongside it. The Gaussian driver has its own
+copy of this loop, covered separately.
+=#
+function test_grouped_poisson_stops_early_and_reports_progress()
+    labels, y = pd_grouped_poisson_data(910)
+    fitted = pd_grouped_poisson_lds(labels)
+
+    max_iter = 40
+    elbos = fit!(fitted, y; max_iter=max_iter, tol=1e-1, progress=true)
+    @test length(elbos) < max_iter
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    @test abs(elbos[end] - elbos[end - 1]) < 1e-1
+
+    # Running to `max_iter` instead returns the full vector.
+    full = fit!(pd_grouped_poisson_lds(labels), y; max_iter=4, tol=0.0, progress=false)
+    @test length(full) == 4
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,6 +287,8 @@ using SSDTest
 
             @testset "Poisson fitting" begin
                 test_grouped_poisson_fit()
+                test_grouped_poisson_cd_prior()
+                test_grouped_poisson_stops_early_and_reports_progress()
             end
 
             @testset "Not yet honoured by fitting" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,6 +281,10 @@ using SSDTest
                 test_grouped_rand_needs_a_label_for_one_trial()
             end
 
+            @testset "Poisson fitting" begin
+                test_grouped_poisson_fit()
+            end
+
             @testset "Not yet honoured by fitting" begin
                 test_depends_on_rejected_until_supported()
             end


### PR DESCRIPTION
**4 of 5 — splitting #165 into reviewable pieces.** Stacked on #168; the diff here is only this PR's changes.

`fit!`, `smooth` and `elbo` now honour a Poisson LDS's `depends_on` instead of rejecting it. The smallest PR in the series: the state side is entirely reused from #168.

### What is and isn't new

The state side — per-cell Laplace E-step, pooled sufficient statistics per parameter version, `x0`/`P0`/`[A b B]`/`Q` updates — is identical to the Gaussian path and reuses `grouped_em.jl` unchanged. So the only genuinely new logic is the emission:

**The Poisson emission is non-conjugate**, with no sufficient-statistic form, so it cannot be pooled the way the Gaussian regression is. Instead the M-step runs **one LBFGS solve per version of `[C d D]`**, over the trials of every cell that shares that version — so a `[C d D]` shared across cells is still fit from all of their data, and a per-session `[C d D]` is fit only from that session's.

The ELBO mirrors `_grouped_estep_elbo_gaussian!`, with the observation-side Q-term left as the per-trial loop extracted in #166. Its prior term adds one contribution per distinct `[C d D]`: the bare quadratic that the LBFGS objective penalizes, since a Poisson emission has no noise covariance for the MN prior to pair with.

### Tests

`test_grouped_poisson_fit` — a two-session ground truth with genuinely different emissions per session, fitted from a shared starting point: the ELBO is finite and increases, the two sessions come out with different `[C d]`, and `elbo`/`smooth` work on the fitted grouped model.

### Follow-up in this series

5. Grouped EM for the SLDS — after which the interim guard from #167 is gone entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgmEbyHewqUYTJLFegAoK5)_