### PR TITLE
feature / grouped EM for the SLDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Ancillary parameter dependencies, declaration side: every
+- Ancillary parameter dependencies: every
   `AbstractStateModel` and `AbstractObservationModel` now carries a
   `depends_on` field (default `nothing`). Setting it to a `NamedTuple` of
   per-trial label vectors — e.g. `obs_model.depends_on = (C = session, R =
@@ -32,12 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     with the new exported `group_labels(model, name)` and
     `group_parameter(model, name, label)`
   * `show` reports the declared groups for a model that has any
-  * Honoured by the **Gaussian LDS** and the **Poisson LDS** across `fit!`,
-    `smooth`, `elbo`, `loglikelihood` and `rand`, each of which also accepts a
-    `depends_on` keyword overriding the model's stored labels so a held-out set
-    with a different trial count can be scored without mutating the model. All
-    versions of a parameter share the model's prior; each version contributes
-    its own log-prior term to the ELBO
+  * Supported for the **Gaussian LDS**, the **Poisson LDS** and the **SLDS**
+    across `fit!`, `smooth`, `elbo`, `loglikelihood` and `rand`, each of which
+    also accepts a `depends_on` keyword overriding the model's stored labels so
+    a held-out set with a different trial count can be scored without mutating
+    the model. All versions of a parameter share the model's prior; each
+    version contributes its own log-prior term to the ELBO
   * The efficiency of same-length epochs is preserved *within* each group:
     trials sharing every parameter form a cell, and the smoothed covariance is
     computed once per cell and shared across it (parameters differ between
@@ -48,10 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * For the Poisson emission there is no sufficient-statistic form, so the
     M-step runs one LBFGS solve per version of `[C d D]`, over the trials of
     every cell that shares that version
-  * **The SLDS is not wired up yet.** Its grouped E/M-step lands in a
-    follow-up; until then its `fit!`, `elbo` and `rand` throw an
-    `ArgumentError` on a model that declares `depends_on` rather than silently
-    fitting one pooled parameter set
+  * For an `SLDS` every regime must declare the same labels — the trial
+    partition is a property of the data, not of a regime — and mismatched
+    declarations raise an `ArgumentError`; `x0`/`P0` stay tied across regimes
+    as they are for an ungrouped SLDS
   * With `depends_on` unset, every entry point takes its original code path
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS

--- a/docs/src/LinearDynamicalSystems.md
+++ b/docs/src/LinearDynamicalSystems.md
@@ -442,7 +442,7 @@ ll = loglikelihood(lds, Y_test; depends_on = (C = session_test, R = session_test
 An override re-assigns trials to groups the model already declares; it cannot
 introduce a new parameter set.
 
-### Priors and cost
+### Priors, SLDS, and cost
 
 All versions of a parameter share the model's prior (`Q_prior`, `R_prior`,
 `CD_prior`, …), and each version contributes its own log-prior term to the
@@ -453,6 +453,11 @@ one `[C d D]` per session. The Poisson emission is not conjugate, so its M-step
 runs one LBFGS solve per version of `[C d D]`, over the trials of every group
 that shares that version; the state side flows through the pooled sufficient
 statistics exactly as in the Gaussian case.
+
+An `SLDS` supports the same field on each regime's sub-models. The grouping of
+trials is a property of the data, so every regime must declare the same labels;
+only the fitted values differ per regime. `x0` and `P0` stay tied across
+regimes, as they are for an ungrouped SLDS.
 
 Grouping does not give up the efficiency of equal-length epochs. Trials that
 share every parameter form a *cell*, and the smoother computes one covariance

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -70,8 +70,8 @@ function Random.rand(
     tsteps::Integer;
     ux::Union{Nothing,AbstractMatrix{T}}=nothing,
     uy::Union{Nothing,AbstractMatrix{T}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
-    _reject_unsupported_dependence(slds)
     lds1 = slds.LDSs[1]
     latent_dim = lds1.latent_dim
     obs_dim = lds1.obs_dim
@@ -84,8 +84,18 @@ function Random.rand(
     x = Matrix{T}(undef, latent_dim, Ti)
     y = Matrix{T}(undef, obs_dim, Ti)
 
-    state_params = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
-    obs_params = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+    if depends_on === nothing && _has_parameter_dependence(lds1)
+        _single_trial_group_error("slds")
+    end
+    grp = _slds_parameter_grouping(slds, 1; depends_on=depends_on)
+    regimes = if grp === nothing
+        slds.LDSs
+    else
+        _slds_cell_sldss(slds, grp)[grp.trial_cell[1]].LDSs
+    end
+
+    state_params = [_extract_state_params(lds.state_model) for lds in regimes]
+    obs_params = [_extract_obs_params(lds.obs_model) for lds in regimes]
 
     _sample_slds_trial!(
         rng,
@@ -110,8 +120,8 @@ function Random.rand(
     tsteps_per_trial::AbstractVector{<:Integer};
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
-    _reject_unsupported_dependence(slds)
     lds1 = slds.LDSs[1]
     latent_dim = lds1.latent_dim
     obs_dim = lds1.obs_dim
@@ -124,8 +134,27 @@ function Random.rand(
     x = Vector{Matrix{T}}(undef, ntrials)
     y = Vector{Matrix{T}}(undef, ntrials)
 
-    state_params = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
-    obs_params = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+    #=
+    Per-trial, per-regime parameter sets: one entry per trial, each a vector
+    over regimes. Ungrouped, every trial shares the same vector.
+    =#
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    if grp === nothing
+        base_state = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
+        base_obs = [_extract_obs_params(lds.obs_model) for lds in slds.LDSs]
+        state_of = fill(base_state, ntrials)
+        obs_of = fill(base_obs, ntrials)
+    else
+        cell_slds = _slds_cell_sldss(slds, grp)
+        cell_state = [
+            [_extract_state_params(lds.state_model) for lds in sc.LDSs] for sc in cell_slds
+        ]
+        cell_obs = [
+            [_extract_obs_params(lds.obs_model) for lds in sc.LDSs] for sc in cell_slds
+        ]
+        state_of = [cell_state[grp.trial_cell[n]] for n in 1:ntrials]
+        obs_of = [cell_obs[grp.trial_cell[n]] for n in 1:ntrials]
+    end
 
     for trial in 1:ntrials
         Ti = Int(tsteps_per_trial[trial])
@@ -139,8 +168,8 @@ function Random.rand(
             y[trial],
             slds.A,
             slds.πₖ,
-            state_params,
-            obs_params,
+            state_of[trial],
+            obs_of[trial],
             lds1.obs_model,
             ux_seq[trial],
             uy_seq[trial],
@@ -1056,6 +1085,10 @@ reproducibility. This matches the first entry of the ELBO trace returned by
   matrices (ragged lengths allowed).
 - `ux` / `uy`: optional control inputs in the same shape family as `y`
   (`nothing` when the regimes carry no `B` / `D`). See [`fit!`](@ref).
+- `depends_on`: optional `NamedTuple` of per-trial label vectors overriding the
+  `depends_on` declared on the models for this call (see the ancillary parameter
+  dependency docs). Needed when this dataset's trial count differs from the one
+  the labels on the model were written for.
 
 Returns a scalar.
 """
@@ -1065,8 +1098,8 @@ function elbo(
     ux=nothing,
     uy=nothing,
     rng::AbstractRNG=Random.default_rng(),
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
-    _reject_unsupported_dependence(slds)
     # `Data` centralizes shape validation and canonicalizes the three
     # observation/input forms (regime dims are uniform, so validating against
     # LDSs[1] covers all regimes). Absent ux/uy become zero-row matrices.
@@ -1081,6 +1114,9 @@ function elbo(
     total_T = last(seq_ends)
     T_max = maximum(data.tsteps)
 
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
+
     tfs = initialize_FilterSmooth(slds.LDSs[1], data.tsteps)::TrialFilterSmooth{T}
     dl = SLDSDiscreteLayer(slds.A, slds.πₖ, zeros(T, K, total_T))
     fb_storage = _make_slds_fb_storage(dl, seq_ends)
@@ -1091,18 +1127,54 @@ function elbo(
 
     # Warm-start q(x) with uniform weights, drawing the sample the E-step's
     # discrete update consumes (mirrors the fit! warm-start).
-    for trial in 1:ntrials
-        w_uniform = fill(one(T) / K, K, data.tsteps[trial])
-        smooth!(
-            slds,
-            tfs[trial],
-            y_seq[trial],
-            w_uniform;
-            ws=slds_ws,
-            x_sample=x_samples[trial],
+    _slds_warmstart!(
+        slds,
+        cell_slds,
+        grp,
+        tfs,
+        y_seq,
+        x_samples,
+        slds_ws,
+        data.tsteps,
+        K;
+        rng=rng,
+        ux=ux_seq,
+        uy=uy_seq,
+    )
+
+    if grp !== nothing
+        #=
+        Narrow the `Union{Nothing,...}` locals so the grouped helpers below are
+        called at their declared argument types.
+        =#
+        grouping = grp::ParameterGrouping
+        cells = cell_slds::Vector
+        _estep_grouped!(
+            cells,
+            grouping,
+            tfs,
+            fb_storage,
+            dl,
+            y_seq,
+            x_samples,
+            slds_ws;
             rng=rng,
-            ux=ux_seq[trial],
-            uy=uy_seq[trial],
+            obs_seq=obs_seq,
+            control_seq=control_seq,
+            seq_ends=seq_ends,
+            ux=ux_seq,
+            uy=uy_seq,
+        )
+        return _elbo_grouped!(
+            cells,
+            grouping,
+            tfs,
+            fb_storage,
+            y_seq,
+            slds_ws;
+            seq_ends=seq_ends,
+            ux=ux_seq,
+            uy=uy_seq,
         )
     end
 
@@ -1279,6 +1351,11 @@ Optional control inputs `ux` / `uy` accept the same shape family as `y`
 — the active regime `zₜ` selects which per-regime `Bₖ` / `Dₖ` multiplies the
 input — and are re-estimated per regime alongside the other parameters. The
 input dimensions must match across regimes (enforced by `validate_SLDS`).
+
+Pass `depends_on` (a `NamedTuple` of per-trial label vectors) to override the
+`depends_on` declared on the regimes' sub-models for this call. Every regime
+must declare the same labels — the grouping of trials is a property of the data
+— and `x0`/`P0` stay tied across regimes as usual.
 """
 function fit!(
     slds::SLDS{T,S,O},
@@ -1288,8 +1365,8 @@ function fit!(
     max_iter::Int=50,
     progress::Bool=true,
     rng::AbstractRNG=Random.default_rng(),
+    depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel}
-    _reject_unsupported_dependence(slds)
     #=
     `Data` centralizes shape validation and canonicalizes the three
     observation/input forms (regime dims are uniform, so validating against
@@ -1309,6 +1386,13 @@ function fit!(
     seq_ends = cumsum(tsteps_per_trial)
     total_T = last(seq_ends)
     T_max = maximum(tsteps_per_trial)
+
+    #=
+    Ancillary parameter dependencies. `grp === nothing` (no regime declares
+    `depends_on`) keeps every step on its original code path.
+    =#
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
 
     # Continuous-state smoother storage (per-trial sized).
     tfs = initialize_FilterSmooth(slds.LDSs[1], tsteps_per_trial)::TrialFilterSmooth{T}
@@ -1348,21 +1432,20 @@ function fit!(
     Warm-start: smooth each trial once with uniform weights, drawing the first
     sample into x_samples for the first E-step to consume.
     =#
-    for trial in 1:ntrials
-        Ti = tsteps_per_trial[trial]
-        w_uniform = fill(one(T) / K, K, Ti)
-        smooth!(
-            slds,
-            tfs[trial],
-            y_seq[trial],
-            w_uniform;
-            ws=slds_ws,
-            x_sample=x_samples[trial],
-            rng=rng,
-            ux=ux_seq[trial],
-            uy=uy_seq[trial],
-        )
-    end
+    _slds_warmstart!(
+        slds,
+        cell_slds,
+        grp,
+        tfs,
+        y_seq,
+        x_samples,
+        slds_ws,
+        tsteps_per_trial,
+        K;
+        rng=rng,
+        ux=ux_seq,
+        uy=uy_seq,
+    )
 
     for iter in 1:max_iter
 
@@ -1370,41 +1453,93 @@ function fit!(
         E-step: fill q(z) from the current samples, run forward-backward,
         re-smooth q(x), and draw the next samples for the following iteration.
         =#
-        estep!(
-            slds,
-            tfs,
-            fb_storage,
-            dl,
-            y_seq,
-            x_samples,
-            slds_ws;
-            rng=rng,
-            obs_seq=obs_seq,
-            control_seq=control_seq,
-            seq_ends=seq_ends,
-            ux=ux_seq,
-            uy=uy_seq,
-        )
+        if grp === nothing
+            estep!(
+                slds,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                x_samples,
+                slds_ws;
+                rng=rng,
+                obs_seq=obs_seq,
+                control_seq=control_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
 
-        # Compute the ELBO at the current posteriors.
-        elbos[iter] = elbo!(
-            slds, tfs, fb_storage, y_seq, slds_ws; seq_ends=seq_ends, ux=ux_seq, uy=uy_seq
-        )
+            # Compute the ELBO at the current posteriors.
+            elbos[iter] = elbo!(
+                slds,
+                tfs,
+                fb_storage,
+                y_seq,
+                slds_ws;
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
 
-        # M-step: update discrete and continuous parameters.
-        mstep!(
-            slds,
-            tfs,
-            fb_storage,
-            dl,
-            y_seq,
-            sws;
-            obs_seq=obs_seq,
-            seq_ends=seq_ends,
-            ux=ux_seq,
-            uy=uy_seq,
-        )
-        refresh_slds_constants!(slds_ws, slds)
+            # M-step: update discrete and continuous parameters.
+            mstep!(
+                slds,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                sws;
+                obs_seq=obs_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+            refresh_slds_constants!(slds_ws, slds)
+        else
+            grouping = grp::ParameterGrouping
+            cells = cell_slds::Vector
+            _estep_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                dl,
+                y_seq,
+                x_samples,
+                slds_ws;
+                rng=rng,
+                obs_seq=obs_seq,
+                control_seq=control_seq,
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+
+            elbos[iter] = _elbo_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                y_seq,
+                slds_ws;
+                seq_ends=seq_ends,
+                ux=ux_seq,
+                uy=uy_seq,
+            )
+
+            _mstep_grouped!(
+                cells,
+                grouping,
+                tfs,
+                fb_storage,
+                dl,
+                data,
+                sws;
+                obs_seq=obs_seq,
+                seq_ends=seq_ends,
+            )
+        end
 
         prog !== nothing && next!(prog)
     end
@@ -1413,4 +1548,411 @@ function fit!(
         finish!(prog)
     end
     return elbos
+end
+
+# ============================================================================
+# Ancillary parameter dependencies (`depends_on`) for the SLDS.
+#
+# The trial partition is a property of the *dataset*, so it must be identical
+# across regimes; only the parameter values differ per regime. Given that, each
+# cell is governed by one ordinary `SLDS` whose sub-LDSs hold that cell's
+# parameter arrays, and the existing smoother / weighted aggregator run on it
+# unchanged. Regime constants are refreshed once per cell rather than once per
+# trial, so the per-cell overhead is K Cholesky sets per pass.
+# ============================================================================
+
+"""
+    _slds_warmstart!(slds, cell_slds, grp, tfs, y, x_samples, slds_ws, tsteps, K; ...)
+
+Smooth every trial once with uniform discrete weights, drawing the first
+posterior sample the E-step's discrete update consumes. When `grp === nothing`
+this is the plain per-trial loop; otherwise trials are visited cell by cell so
+the regime constants are refreshed once per cell.
+"""
+function _slds_warmstart!(
+    slds::SLDS{T},
+    cell_slds::Union{Nothing,AbstractVector},
+    grp::Union{Nothing,ParameterGrouping},
+    tfs::TrialFilterSmooth{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T},
+    tsteps::AbstractVector{Int},
+    K::Int;
+    rng::AbstractRNG=Random.default_rng(),
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    function w_of(trial)
+        return fill(one(T) / K, K, tsteps[trial])
+    end
+
+    if grp === nothing || cell_slds === nothing
+        for trial in eachindex(y)
+            smooth!(
+                slds,
+                tfs[trial],
+                y[trial],
+                w_of(trial);
+                ws=slds_ws,
+                x_sample=x_samples[trial],
+                rng=rng,
+                ux=(ux === nothing ? nothing : ux[trial]),
+                uy=(uy === nothing ? nothing : uy[trial]),
+            )
+        end
+        return nothing
+    end
+
+    for c in 1:grp.ncells
+        _slds_smooth_cell!(
+            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+        )
+    end
+    return nothing
+end
+
+"""
+    _slds_parameter_grouping(slds, ntrials; depends_on=nothing)
+
+Trial partition for an `SLDS`, or `nothing` when no regime declares
+`depends_on`. Throws when the regimes disagree about the partition.
+"""
+function _slds_parameter_grouping(
+    slds::SLDS, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing
+)
+    grp = parameter_grouping(slds.LDSs[1], ntrials; depends_on=depends_on)
+    grp === nothing && return nothing
+    for k in 2:length(slds.LDSs)
+        grp_k = parameter_grouping(slds.LDSs[k], ntrials; depends_on=depends_on)
+        ok =
+            grp_k !== nothing &&
+            grp_k.nslots == grp.nslots &&
+            grp_k.cell_state == grp.cell_state &&
+            grp_k.cell_obs == grp.cell_obs &&
+            grp_k.trial_cell == grp.trial_cell
+        ok || throw(
+            ArgumentError(
+                "SLDS: every regime must declare the same `depends_on` labels; regime " *
+                "$k disagrees with regime 1. The grouping of trials is a property of " *
+                "the data and is shared across regimes — only the fitted parameter " *
+                "values differ per regime.",
+            ),
+        )
+    end
+    return grp
+end
+
+"""
+    _slds_cell_sldss(slds, grp) -> Vector{SLDS}
+
+One `SLDS` view per cell, sharing `A` and `πₖ` by reference (so the discrete
+M-step still updates the single shared chain) and holding each regime's
+per-cell parameter arrays.
+"""
+function _slds_cell_sldss(
+    slds::SLDS{T,S,O,TM,ISV}, grp::ParameterGrouping
+) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel,TM,ISV}
+    K = length(slds.LDSs)
+    return [
+        SLDS{T,S,O,TM,ISV}(
+            slds.A, slds.πₖ, [_cell_lds(slds.LDSs[k], grp, c) for k in 1:K]
+        ) for c in 1:grp.ncells
+    ]
+end
+
+"""
+    _slds_smooth_cell!(cell_slds, grp, cell, tfs, y, x_samples, slds_ws, w_of; rng, ux, uy)
+
+Smooth every trial of one cell after refreshing the workspace's regime constants
+for that cell's parameters. `w_of(trial)` supplies the `K × T` responsibilities.
+"""
+function _slds_smooth_cell!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    cell::Int,
+    tfs::TrialFilterSmooth{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T},
+    w_of;
+    rng::AbstractRNG=Random.default_rng(),
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    slds_c = cell_slds[cell]
+    refresh_slds_constants!(slds_ws, slds_c)
+    for trial in grp.cell_trials[cell]
+        smooth!(
+            slds_c,
+            tfs[trial],
+            y[trial],
+            w_of(trial);
+            ws=slds_ws,
+            x_sample=x_samples[trial],
+            rng=rng,
+            ux=(ux === nothing ? nothing : ux[trial]),
+            uy=(uy === nothing ? nothing : uy[trial]),
+        )
+    end
+    return nothing
+end
+
+"""
+    _estep_grouped!(cell_slds, grp, tfs, fb_storage, dl, y, x_samples, slds_ws; ...)
+
+Grouped SLDS E-step. Same three moves as `estep!` — fill `dl.logL` from the
+previous posterior sample, run forward-backward, re-smooth `q(x)` — but each
+pass iterates cells so the regime constants are refreshed once per cell. The
+forward-backward call stays global: the discrete chain is shared by all trials.
+"""
+function _estep_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    dl::SLDSDiscreteLayer{T},
+    y::AbstractVector{<:AbstractMatrix{T}},
+    x_samples::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T};
+    rng::AbstractRNG=Random.default_rng(),
+    obs_seq::AbstractVector,
+    control_seq::AbstractVector,
+    seq_ends::AbstractVector{Int},
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+
+    for c in 1:grp.ncells
+        slds_c = cell_slds[c]
+        refresh_slds_constants!(slds_ws, slds_c)
+        for trial in grp.cell_trials[c]
+            t1, t2 = HMMs.seq_limits(seq_ends, trial)
+            for k in 1:K
+                joint_loglikelihood!(
+                    view(dl.logL, k, t1:t2),
+                    slds_ws,
+                    slds_ws.consts[k],
+                    slds_c.LDSs[k],
+                    x_samples[trial],
+                    y[trial],
+                    (ux === nothing ? nothing : ux[trial]),
+                    (uy === nothing ? nothing : uy[trial]),
+                )
+            end
+        end
+    end
+
+    HMMs.forward_backward!(
+        fb_storage, dl, obs_seq, control_seq; seq_ends=seq_ends, transition_marginals=true
+    )
+
+    function w_of(trial)
+        t1, t2 = HMMs.seq_limits(seq_ends, trial)
+        return view(fb_storage.γ, :, t1:t2)
+    end
+
+    for c in 1:grp.ncells
+        _slds_smooth_cell!(
+            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+        )
+    end
+
+    return nothing
+end
+
+"""
+    _grouped_slds_prior_logdensity(cell_slds, grp, T)
+
+`log p(θ)` for a grouped SLDS: the per-regime terms of
+[`_slds_prior_logdensity`](@ref), counted once per distinct parameter version
+instead of once per regime.
+"""
+function _grouped_slds_prior_logdensity(
+    cell_slds::AbstractVector, grp::ParameterGrouping, ::Type{T}
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+    total = zero(T)
+    for k in 1:K
+        ldss = [cell_slds[c].LDSs[k] for c in 1:grp.ncells]
+        total += _grouped_state_prior_logdensity(ldss, grp.cell_slot, T)
+        if ldss[1].obs_model isa GaussianObservationModel
+            total += _grouped_gaussian_obs_prior_logdensity(ldss, grp.cell_slot, T)
+        else
+            total += _grouped_poisson_obs_prior_logdensity(ldss, grp.cell_slot, T)
+        end
+    end
+    return total
+end
+
+"""
+    _elbo_grouped!(cell_slds, grp, tfs, fb_storage, y, slds_ws; seq_ends, ux, uy)
+
+Grouped SLDS ELBO: each trial's contribution evaluated against its cell's
+parameters, plus one prior term per distinct parameter version.
+"""
+function _elbo_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    y::AbstractVector{<:AbstractMatrix{T}},
+    slds_ws::SLDSSmoothWorkspace{T};
+    seq_ends::AbstractVector{Int},
+    ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+) where {T<:Real}
+    total_elbo = zero(T)
+    for c in 1:grp.ncells
+        slds_c = cell_slds[c]
+        refresh_slds_constants!(slds_ws, slds_c)
+        for trial in grp.cell_trials[c]
+            t1, t2 = HMMs.seq_limits(seq_ends, trial)
+            total_elbo += _slds_trial_elbo(
+                slds_c,
+                tfs[trial],
+                fb_storage,
+                y[trial],
+                slds_ws,
+                t1,
+                t2,
+                (ux === nothing ? nothing : ux[trial]),
+                (uy === nothing ? nothing : uy[trial]),
+            )
+        end
+    end
+    return total_elbo + _grouped_slds_prior_logdensity(cell_slds, grp, T)
+end
+
+"""
+    _broadcast_initial_state!(cell_slds, K, do_x0, do_P0)
+
+Copy regime 1's initial-state parameters into every other regime. `x0`/`P0` are
+tied across regimes, and the grouped update writes only into regime 1's
+variants, so this restores the tie — including before the `P0` update, whose
+scatter reads each unit's own `x0`.
+"""
+function _broadcast_initial_state!(
+    cell_slds::AbstractVector, K::Int, do_x0::Bool, do_P0::Bool
+)
+    (do_x0 || do_P0) || return nothing
+    for slds_c in cell_slds
+        src = slds_c.LDSs[1].state_model
+        for k in 2:K
+            dst = slds_c.LDSs[k].state_model
+            do_x0 && copyto!(dst.x0, src.x0)
+            do_P0 && copyto!(dst.P0, src.P0)
+        end
+    end
+    return nothing
+end
+
+"""
+    _mstep_grouped!(cell_slds, grp, tfs, fb_storage, dl, data, sws; obs_seq, seq_ends)
+
+Grouped SLDS M-step.
+
+The discrete layer and the trial partition are shared, so the work is one
+γ-weighted sufficient statistic per (regime, cell). Dynamics and emissions are
+per regime, so they are pooled across the cells that share a version *within* a
+regime; `x0`/`P0` are tied across regimes, so they are pooled across every
+(regime, cell) unit that shares a version.
+
+Units are laid out regime-major, which makes the first unit of any parameter
+version belong to regime 1 — the update writes there and
+`_broadcast_initial_state!` restores the tie.
+"""
+function _mstep_grouped!(
+    cell_slds::AbstractVector,
+    grp::ParameterGrouping,
+    tfs::TrialFilterSmooth{T},
+    fb_storage::HMMs.ForwardBackwardStorage,
+    dl::SLDSDiscreteLayer{T},
+    data::Data{T},
+    sws::SmoothWorkspace{T};
+    obs_seq::AbstractVector,
+    seq_ends::AbstractVector{Int},
+) where {T<:Real}
+    K = length(cell_slds[1].LDSs)
+    ncells = grp.ncells
+    lds1 = cell_slds[1].LDSs[1]
+
+    # Discrete-layer M-step (slds.A, slds.πₖ are updated in place via dl).
+    StatsAPI.fit!(dl, fb_storage, obs_seq; seq_ends=seq_ends)
+
+    cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
+    cell_tfs = [
+        TrialFilterSmooth([tfs[n] for n in grp.cell_trials[c]]) for c in 1:ncells
+    ]
+    bufs = GroupedSufBuffers(T, lds1, data.tsteps)
+
+    function γ_view(k, trial)
+        t1, t2 = HMMs.seq_limits(seq_ends, trial)
+        return view(fb_storage.γ, k, t1:t2)
+    end
+
+    unit_lds = [cell_slds[c].LDSs[k] for k in 1:K for c in 1:ncells]
+    unit_suf = [
+        _initialize_td_sufficient_statistics(T, lds1, cell_data[c].tsteps) for k in 1:K for
+        c in 1:ncells
+    ]
+
+    for k in 1:K
+        for c in 1:ncells
+            u = (k - 1) * ncells + c
+            weights = [γ_view(k, n) for n in grp.cell_trials[c]]
+            _aggregate_td_suff_stats_weighted!(
+                unit_suf[u], cell_tfs[c], unit_lds[u], cell_data[c], weights, sws
+            )
+        end
+
+        rows = ((k - 1) * ncells + 1):(k * ncells)
+        ldss_k = view(unit_lds, rows)
+        sufs_k = view(unit_suf, rows)
+
+        _grouped_update_A_b!(ldss_k, sufs_k, grp.cell_slot[_G_AB], sws, bufs)
+        _grouped_update_Q!(ldss_k, sufs_k, grp.cell_slot[_G_Q], grp.cell_slot[_G_AB], sws)
+
+        if lds1.obs_model isa GaussianObservationModel{T}
+            _grouped_update_C_d!(ldss_k, sufs_k, grp.cell_slot[_G_CD], sws, bufs)
+            _grouped_update_R!(
+                ldss_k, sufs_k, grp.cell_slot[_G_R], grp.cell_slot[_G_CD], sws
+            )
+        elseif lds1.obs_model isa PoissonObservationModel{T}
+            # Non-conjugate: one LBFGS solve per `[C d D]` version, over the
+            # γ-weighted trials of every cell sharing that version.
+            for units in _units_by_slot(grp.cell_slot[_G_CD])
+                trials = Int[]
+                for c in units
+                    append!(trials, grp.cell_trials[c])
+                end
+                sort!(trials)
+                update_observation_model!(
+                    ldss_k[units[1]],
+                    TrialFilterSmooth([tfs[n] for n in trials]),
+                    data.y[trials],
+                    [sws],
+                    [γ_view(k, n) for n in trials];
+                    uy=data.uy[trials],
+                )
+            end
+        else
+            throw(ArgumentError("Unsupported observation model $(typeof(lds1.obs_model))"))
+        end
+    end
+
+    #=
+    Tied initial state, pooled over every (regime, cell) unit. Since
+    Σₖ γₖ(t=1) = 1, summing the per-regime weighted init stats reproduces the
+    unit-weight pooled statistic the ungrouped path uses.
+    =#
+    slots_x0 = repeat(grp.cell_slot[_G_X0], K)
+    slots_P0 = repeat(grp.cell_slot[_G_P0], K)
+    _grouped_update_x0!(unit_lds, unit_suf, slots_x0, bufs)
+    _broadcast_initial_state!(cell_slds, K, lds1.fit_bool[_G_X0], false)
+    _grouped_update_P0!(unit_lds, unit_suf, slots_P0, slots_x0, sws)
+    _broadcast_initial_state!(cell_slds, K, false, lds1.fit_bool[_G_P0])
+
+    return nothing
 end

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -1604,7 +1604,7 @@ function _slds_warmstart!(
         return nothing
     end
 
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         _slds_smooth_cell!(
             cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
         )
@@ -1655,9 +1655,8 @@ function _slds_cell_sldss(
 ) where {T<:Real,S<:AbstractStateModel,O<:AbstractObservationModel,TM,ISV}
     K = length(slds.LDSs)
     return [
-        SLDS{T,S,O,TM,ISV}(
-            slds.A, slds.πₖ, [_cell_lds(slds.LDSs[k], grp, c) for k in 1:K]
-        ) for c in 1:grp.ncells
+        SLDS{T,S,O,TM,ISV}(slds.A, slds.πₖ, [_cell_lds(slds.LDSs[k], grp, c) for k in 1:K])
+        for c in 1:(grp.ncells)
     ]
 end
 
@@ -1724,7 +1723,7 @@ function _estep_grouped!(
 ) where {T<:Real}
     K = length(cell_slds[1].LDSs)
 
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         slds_c = cell_slds[c]
         refresh_slds_constants!(slds_ws, slds_c)
         for trial in grp.cell_trials[c]
@@ -1753,7 +1752,7 @@ function _estep_grouped!(
         return view(fb_storage.γ, :, t1:t2)
     end
 
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         _slds_smooth_cell!(
             cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
         )
@@ -1775,7 +1774,7 @@ function _grouped_slds_prior_logdensity(
     K = length(cell_slds[1].LDSs)
     total = zero(T)
     for k in 1:K
-        ldss = [cell_slds[c].LDSs[k] for c in 1:grp.ncells]
+        ldss = [cell_slds[c].LDSs[k] for c in 1:(grp.ncells)]
         total += _grouped_state_prior_logdensity(ldss, grp.cell_slot, T)
         if ldss[1].obs_model isa GaussianObservationModel
             total += _grouped_gaussian_obs_prior_logdensity(ldss, grp.cell_slot, T)
@@ -1804,7 +1803,7 @@ function _elbo_grouped!(
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
 ) where {T<:Real}
     total_elbo = zero(T)
-    for c in 1:grp.ncells
+    for c in 1:(grp.ncells)
         slds_c = cell_slds[c]
         refresh_slds_constants!(slds_ws, slds_c)
         for trial in grp.cell_trials[c]
@@ -1882,9 +1881,7 @@ function _mstep_grouped!(
     StatsAPI.fit!(dl, fb_storage, obs_seq; seq_ends=seq_ends)
 
     cell_data = [_subset_data(data, grp.cell_trials[c]) for c in 1:ncells]
-    cell_tfs = [
-        TrialFilterSmooth([tfs[n] for n in grp.cell_trials[c]]) for c in 1:ncells
-    ]
+    cell_tfs = [TrialFilterSmooth([tfs[n] for n in grp.cell_trials[c]]) for c in 1:ncells]
     bufs = GroupedSufBuffers(T, lds1, data.tsteps)
 
     function γ_view(k, trial)

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -134,10 +134,8 @@ function Random.rand(
     x = Vector{Matrix{T}}(undef, ntrials)
     y = Vector{Matrix{T}}(undef, ntrials)
 
-    #=
-    Per-trial, per-regime parameter sets: one entry per trial, each a vector
-    over regimes. Ungrouped, every trial shares the same vector.
-    =#
+    # One entry per trial, each a vector over regimes; ungrouped, every trial
+    # shares the same vector.
     grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
     if grp === nothing
         base_state = [_extract_state_params(lds.state_model) for lds in slds.LDSs]
@@ -1143,10 +1141,7 @@ function elbo(
     )
 
     if grp !== nothing
-        #=
-        Narrow the `Union{Nothing,...}` locals so the grouped helpers below are
-        called at their declared argument types.
-        =#
+        # Narrow the `Union{Nothing,...}` locals to the helpers' argument types.
         grouping = grp::ParameterGrouping
         cells = cell_slds::Vector
         _estep_grouped!(
@@ -1387,10 +1382,8 @@ function fit!(
     total_T = last(seq_ends)
     T_max = maximum(tsteps_per_trial)
 
-    #=
-    Ancillary parameter dependencies. `grp === nothing` (no regime declares
-    `depends_on`) keeps every step on its original code path.
-    =#
+    # `grp === nothing` (no regime declares `depends_on`) keeps every step on
+    # its original code path.
     grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
     cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
 
@@ -1943,11 +1936,8 @@ function _mstep_grouped!(
         end
     end
 
-    #=
-    Tied initial state, pooled over every (regime, cell) unit. Since
-    Σₖ γₖ(t=1) = 1, summing the per-regime weighted init stats reproduces the
-    unit-weight pooled statistic the ungrouped path uses.
-    =#
+    # Tied initial state, pooled over every (regime, cell) unit: Σₖ γₖ(t=1) = 1,
+    # so summing the weighted init stats gives the unit-weight statistic.
     slots_x0 = repeat(grp.cell_slot[_G_X0], K)
     slots_P0 = repeat(grp.cell_slot[_G_P0], K)
     _grouped_update_x0!(unit_lds, unit_suf, slots_x0, bufs)

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -603,33 +603,6 @@ function _has_parameter_dependence(lds::LinearDynamicalSystem)
 end
 
 """
-    _reject_unsupported_dependence(model)
-
-**Internal, temporary.** Refuse to run an entry point that does not yet honour
-`depends_on`. The grouped E/M-step lands one model family at a time, so in the
-interim a declared dependence must be an error rather than a silently pooled
-fit. Each entry point drops this call as its grouped path lands.
-"""
-function _reject_unsupported_dependence(lds::LinearDynamicalSystem)
-    _has_parameter_dependence(lds) || return nothing
-    return throw(
-        ArgumentError(
-            "this model declares `depends_on`, but fitting and inference with " *
-            "condition-dependent parameters are not implemented yet for this model " *
-            "family — the grouped E/M-step lands in a follow-up. Unset `depends_on` " *
-            "to fit the model with one parameter set shared by every trial.",
-        ),
-    )
-end
-
-function _reject_unsupported_dependence(slds::SLDS)
-    for lds in slds.LDSs
-        _reject_unsupported_dependence(lds)
-    end
-    return nothing
-end
-
-"""
     _single_trial_group_error(what)
 
 `rand` with a scalar `tsteps` draws one trial, which a grouped model cannot

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -846,3 +846,79 @@ function test_grouped_poisson_stops_early_and_reports_progress()
     @test length(full) == 4
     return nothing
 end
+
+# A Poisson-emission SLDS, the counterpart of `pd_slds`. Only `[C d]` can be
+# grouped — a Poisson emission has no `:R`.
+function pd_poisson_slds(labels; K::Int=2)
+    ldss = map(1:K) do k
+        sm = pd_state_model()
+        sm.A .= k == 1 ? [0.95 0.05; -0.05 0.95] : [0.60 0.30; -0.30 0.60]
+        om = PoissonObservationModel([0.6 0.1; -0.2 0.5], [0.5, 0.3])
+        labels === nothing || (om.depends_on = (C=labels,))
+        return LinearDynamicalSystem(;
+            state_model=sm,
+            obs_model=om,
+            latent_dim=PD_LATENT_DIM,
+            obs_dim=PD_OBS_DIM,
+            fit_bool=fill(true, 5),
+        )
+    end
+    return SLDS(; A=[0.9 0.1; 0.1 0.9], πₖ=[0.5, 0.5], LDSs=ldss)
+end
+
+#=
+The SLDS carries its own grouped emission M-step, dispatched on the observation
+model. `test_grouped_slds_fit` takes the Gaussian branch; this one takes the
+Poisson branch, where the emission solve runs once per version of `[C d D]` over
+the trials of every cell sharing it, and the prior term is the bare quadratic
+rather than the conjugate update.
+=#
+function test_grouped_poisson_slds_fit()
+    rng = StableRNG(1011)
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+
+    truth = pd_poisson_slds(labels)
+    for k in 1:2
+        group_parameter(truth.LDSs[k].obs_model, :C, :s2) .= [0.2 -0.9; 1.0 0.3]
+        group_parameter(truth.LDSs[k].obs_model, :d, :s2) .= [0.4, -0.2]
+    end
+    _, _, y = rand(rng, truth, fill(35, length(labels)))
+
+    fitted = pd_poisson_slds(labels)
+    elbos = fit!(fitted, y; max_iter=5, progress=false, rng=StableRNG(11))
+    @test length(elbos) == 5
+    @test all(isfinite, elbos)
+
+    # Each regime keeps a separate emission per session.
+    for k in 1:2
+        om = fitted.LDSs[k].obs_model
+        @test !(group_parameter(om, :C, :s1) ≈ group_parameter(om, :C, :s2))
+        @test !(group_parameter(om, :d, :s1) ≈ group_parameter(om, :d, :s2))
+        @test all(isfinite, group_parameter(om, :C, :s1))
+        @test all(isfinite, group_parameter(om, :d, :s2))
+    end
+
+    # x0/P0 stay tied across regimes, as they are for an ungrouped SLDS.
+    @test fitted.LDSs[2].state_model.x0 ≈ fitted.LDSs[1].state_model.x0
+    @test fitted.LDSs[2].state_model.P0 ≈ fitted.LDSs[1].state_model.P0
+
+    @test isfinite(elbo(fitted, y; rng=StableRNG(12)))
+    return nothing
+end
+
+#=
+`rand(rng, slds, tsteps)` draws one trial, which a grouped model cannot place in
+a group on its own — the same guard the LDS entry points carry.
+=#
+function test_grouped_slds_rand_needs_a_label_for_one_trial()
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+    slds = pd_slds(labels)
+    @test_throws ArgumentError rand(StableRNG(1012), slds, 30)
+
+    # Saying which group the trial belongs to is enough.
+    z, x, y = rand(StableRNG(1012), slds, 30; depends_on=(C=[:s2], R=[:s2]))
+    @test size(y) == (PD_OBS_DIM, 30)
+    @test size(x) == (PD_LATENT_DIM, 30)
+    @test length(z) == 30
+    return nothing
+end

--- a/test/LinearDynamicalSystems/ParameterDependencies.jl
+++ b/test/LinearDynamicalSystems/ParameterDependencies.jl
@@ -7,9 +7,6 @@
 # floating point, what independent fits of each session produce. Everything
 # downstream of that (partial grouping, priors, held-out scoring) shares the
 # same machinery.
-#
-# The SLDS is still on the interim guard; its grouped fit lands in a follow-up
-# (`test_depends_on_rejected_until_supported`).
 
 const PD_LATENT_DIM = 2
 const PD_OBS_DIM = 2
@@ -546,25 +543,73 @@ function test_grouped_poisson_fit()
 end
 
 # ============================================================================
-# Interim guard (removed as each model family's grouped fit lands)
+# SLDS
 # ============================================================================
 
-function test_depends_on_rejected_until_supported()
-    rng = StableRNG(101)
-    labels = [:a, :a, :b]
-    y = [randn(rng, PD_OBS_DIM, 20) for _ in 1:3]
+function pd_slds(labels; K::Int=2)
+    ldss = map(1:K) do k
+        sm = pd_state_model()
+        sm.A .= k == 1 ? [0.95 0.05; -0.05 0.95] : [0.60 0.30; -0.30 0.60]
+        om = pd_obs_model()
+        if labels !== nothing
+            om.depends_on = (C=labels, R=labels)
+        end
+        return pd_lds(sm, om)
+    end
+    A = [0.9 0.1; 0.1 0.9]
+    πₖ = [0.5, 0.5]
+    return SLDS(; A=A, πₖ=πₖ, LDSs=ldss)
+end
 
-    om = pd_obs_model()
-    om.depends_on = (C=labels,)
+function test_grouped_slds_fit()
+    rng = StableRNG(1010)
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
 
-    slds = SLDS(;
-        A=[0.9 0.1; 0.1 0.9],
-        πₖ=[0.5, 0.5],
-        LDSs=[pd_fresh_lds(), pd_lds(pd_state_model(), om)],
-    )
-    @test_throws ArgumentError fit!(slds, y; max_iter=1, progress=false)
-    @test_throws ArgumentError elbo(slds, y)
-    @test_throws ArgumentError rand(rng, slds, 20)
+    truth = pd_slds(labels)
+    for k in 1:2
+        C2 = group_parameter(truth.LDSs[k].obs_model, :C, :s2)
+        C2 .= [0.2 -0.9; 1.0 0.3]
+        R2 = group_parameter(truth.LDSs[k].obs_model, :R, :s2)
+        R2 .= Matrix(1.0 * I(PD_OBS_DIM))
+    end
+    _, _, y = rand(rng, truth, fill(35, length(labels)))
+
+    fitted = pd_slds(labels)
+    elbos = fit!(fitted, y; max_iter=6, progress=false, rng=StableRNG(11))
+    @test length(elbos) == 6
+    @test all(isfinite, elbos)
+
+    # Each regime keeps a separate emission per session.
+    for k in 1:2
+        om = fitted.LDSs[k].obs_model
+        @test !(group_parameter(om, :C, :s1) ≈ group_parameter(om, :C, :s2))
+        @test isposdef(group_parameter(om, :R, :s1))
+        @test isposdef(group_parameter(om, :R, :s2))
+    end
+
+    # x0/P0 stay tied across regimes even when grouped.
+    @test fitted.LDSs[2].state_model.x0 ≈ fitted.LDSs[1].state_model.x0
+    @test fitted.LDSs[2].state_model.P0 ≈ fitted.LDSs[1].state_model.P0
+
+    @test isfinite(elbo(fitted, y; rng=StableRNG(12)))
+
+    return nothing
+end
+
+function test_grouped_slds_requires_matching_labels()
+    labels = vcat(fill(:s1, 3), fill(:s2, 3))
+    slds = pd_slds(labels)
+    # Regime 2 disagrees about how trials are grouped.
+    slds.LDSs[2].obs_model.depends_on = (C=vcat(fill(:s1, 4), fill(:s2, 2)),)
+    @test_throws ArgumentError SSD._slds_parameter_grouping(slds, 6)
+
+    # A regime that declares nothing at all is also a disagreement.
+    slds2 = pd_slds(labels)
+    slds2.LDSs[2].obs_model.depends_on = nothing
+    @test_throws ArgumentError SSD._slds_parameter_grouping(slds2, 6)
+
+    # No regime declaring anything is simply the ungrouped path.
+    @test SSD._slds_parameter_grouping(pd_slds(nothing), 6) === nothing
 
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,6 +294,8 @@ using SSDTest
             @testset "SLDS fitting" begin
                 test_grouped_slds_fit()
                 test_grouped_slds_requires_matching_labels()
+                test_grouped_poisson_slds_fit()
+                test_grouped_slds_rand_needs_a_label_for_one_trial()
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,8 +285,9 @@ using SSDTest
                 test_grouped_poisson_fit()
             end
 
-            @testset "Not yet honoured by fitting" begin
-                test_depends_on_rejected_until_supported()
+            @testset "SLDS fitting" begin
+                test_grouped_slds_fit()
+                test_grouped_slds_requires_matching_labels()
             end
         end
     end


### PR DESCRIPTION
**5 of 5 — splitting #165 into reviewable pieces.** Stacked on #169; the diff here is only this PR's changes. With this one in, the whole of #165 has landed and the interim guard from #167 is gone.

`fit!`, `elbo` and `rand` now honour an SLDS's `depends_on`.

### The one structural constraint

**The trial partition is a property of the dataset, so it must be identical across regimes** — only the parameter *values* differ per regime. Every regime must therefore declare the same labels, and a disagreement raises an `ArgumentError` (including the case where one regime declares nothing at all). Given that, each cell is governed by one ordinary `SLDS` whose sub-LDSs hold that cell's parameter arrays and which shares `A` and `πₖ` **by reference**, so the discrete M-step still updates the single shared chain and the existing smoother and weighted aggregator run on it unchanged.

Regime constants are refreshed once per cell rather than once per trial, so the per-cell overhead is K Cholesky sets per pass. Forward-backward stays global — the discrete chain is shared by all trials.

### The M-step, and the tied initial state

The work is one γ-weighted sufficient statistic per **(regime, cell)** unit. From there:

- **Dynamics and emissions are per regime**, so they pool across the cells that share a version *within* a regime.
- **`x0`/`P0` are tied across regimes**, so they pool across every (regime, cell) unit that shares a version. This is valid because `Σₖ γₖ(t=1) = 1`: summing the per-regime weighted init statistics reproduces the unit-weight pooled statistic the ungrouped path uses.

Units are laid out regime-major, which makes the first unit of any parameter version belong to regime 1 — the update writes there, and `_broadcast_initial_state!` restores the tie. It runs **twice**: once after the `x0` update and once after `P0`, because the `P0` scatter reads each unit's own `x0`, so the tie has to hold before that update, not only after it.

The prior log-density counts the per-regime terms once per distinct parameter version instead of once per regime.

### Tests

- `test_grouped_slds_fit` — two sessions with genuinely different emissions, K=2 regimes: finite ELBO trace, each regime keeps a separate `[C d]` and a positive-definite `R` per session, and `x0`/`P0` stay tied across regimes.
- `test_grouped_slds_requires_matching_labels` — regimes disagreeing about the partition, and a regime declaring nothing while another does, are both errors; no regime declaring anything is simply the ungrouped path.

### Known gap, unchanged from #165

The single-trial `smooth(slds, y, w)` wrapper takes one trial plus explicit responsibilities and has no way to say which group that trial belongs to, so it still uses the base parameter arrays. It is not part of the grouped API here. Worth a follow-up if that entry point matters for grouped models — say the word and I'll add the same label-or-error treatment `rand` got.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgmEbyHewqUYTJLFegAoK5)_