### PR TITLE
Stitching: per-session observation dimensions

### DIFF
--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -945,6 +945,12 @@ function _fit_tridiag_grouped!(
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     sws_pool = _grouped_sws_pool(lds, data)
     state = _grouped_fit_state(lds, data, grp, sws_pool; batched=true)
+    #=
+    The emission M-step regresses per parameter version, and `[C d D]` / `R` are
+    `obs_dim`-shaped, so each cell's own workspace has to be used. With uniform
+    widths every entry is `sws_pool[1]` itself.
+    =#
+    cell_ws1 = [p[1] for p in state.cell_sws]
     elbos = Vector{T}(undef, max_iter)
 
     prog = if progress
@@ -960,7 +966,12 @@ function _fit_tridiag_grouped!(
             state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
         )
         _grouped_gaussian_obs_mstep!(
-            state.cell_lds, state.sufs, grp.cell_slot, sws_pool[1], state.bufs
+            state.cell_lds,
+            state.sufs,
+            grp.cell_slot,
+            sws_pool[1],
+            state.bufs;
+            unit_sws=cell_ws1,
         )
 
         prog !== nothing && next!(prog)

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -789,7 +789,7 @@ function elbo(
     grp = parameter_grouping(lds, length(data.y); depends_on=depends_on, y=data.y)
     if grp !== nothing
         sws_pool = _grouped_sws_pool(lds, data)
-        state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+        state = _grouped_fit_state(lds, data, grp, sws_pool; batched=true)
         return _grouped_estep_elbo_gaussian!(state, grp, sws_pool)
     end
     tfs = initialize_FilterSmooth(lds, data.tsteps)::TrialFilterSmooth{T}
@@ -907,17 +907,17 @@ function _grouped_estep_elbo_gaussian!(
     for c in 1:grp.ncells
         lds_c = state.cell_lds[c]
         suf_c = state.sufs[c]
-        _prepare_cell!(sws_pool[1], state, c)
-        estep!(lds_c, suf_c, state.cell_tfs[c], state.cell_data[c], sws_pool)
+        cell_pool = _prepare_cell!(sws_pool, state, c)
+        estep!(lds_c, suf_c, state.cell_tfs[c], state.cell_data[c], cell_pool)
 
         #=
-        `estep!` leaves the cell's constants on `sws_pool[1]` already, but the
+        `estep!` leaves the cell's constants on `cell_pool[1]` already, but the
         parallel per-trial fallback reaches that state through a task, so
         recompute explicitly rather than rely on which chunk ran last.
         =#
-        compute_smooth_constants!(sws_pool[1], lds_c)
-        total += Q_state!(sws_pool[1], lds_c, suf_c)
-        total += Q_obs!(sws_pool[1], lds_c, suf_c)
+        compute_smooth_constants!(cell_pool[1], lds_c)
+        total += Q_state!(cell_pool[1], lds_c, suf_c)
+        total += Q_obs!(cell_pool[1], lds_c, suf_c)
         for fs in state.cell_tfs[c].FilterSmooths
             total += fs.entropy
         end
@@ -944,7 +944,7 @@ function _fit_tridiag_grouped!(
     progress::Bool=true,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     sws_pool = _grouped_sws_pool(lds, data)
-    state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
+    state = _grouped_fit_state(lds, data, grp, sws_pool; batched=true)
     elbos = Vector{T}(undef, max_iter)
 
     prog = if progress

--- a/src/lds/fit_LDS.jl
+++ b/src/lds/fit_LDS.jl
@@ -129,7 +129,7 @@ function smooth(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on, y=data.y)
     grp === nothing || return _grouped_smooth(lds, data, grp, y)
     tfs = _smooth_data(lds, data)
     return _collect_smooth_output(tfs, y)
@@ -786,7 +786,7 @@ function elbo(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on, y=data.y)
     if grp !== nothing
         sws_pool = _grouped_sws_pool(lds, data)
         state = _grouped_fit_state(lds, data, grp, sws_pool[1]; batched=true)
@@ -874,7 +874,7 @@ function fit!(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on, y=data.y)
     grp === nothing || return _fit_tridiag_grouped!(
         lds, data, grp; max_iter=max_iter, tol=tol, progress=progress
     )
@@ -1227,7 +1227,7 @@ function StatsAPI.loglikelihood(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,SM<:GaussianStateModel{T},OM<:GaussianObservationModel{T}}
     data = Data(lds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(lds, length(data.y); depends_on=depends_on, y=data.y)
 
     #=
     The filter's covariance pass depends only on the parameters and the trial

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -769,7 +769,7 @@ function elbo(
     grp = parameter_grouping(plds, length(data.y); depends_on=depends_on, y=data.y)
     if grp !== nothing
         sws_pool = _grouped_sws_pool(plds, data)
-        state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+        state = _grouped_fit_state(plds, data, grp, sws_pool)
         return _grouped_estep_elbo_poisson!(
             state, grp, sws_pool; max_iter=newton_max_iter, tol=T(newton_tol)
         )
@@ -975,14 +975,14 @@ function _grouped_estep_elbo_poisson!(
         lds_c = state.cell_lds[c]
         suf_c = state.sufs[c]
         tfs_c = state.cell_tfs[c]
-        _prepare_cell!(sws_pool[1], state, c)
+        cell_pool = _prepare_cell!(sws_pool, state, c)
         estep!(
-            lds_c, suf_c, tfs_c, state.cell_data[c], sws_pool; max_iter=max_iter, tol=tol
+            lds_c, suf_c, tfs_c, state.cell_data[c], cell_pool; max_iter=max_iter, tol=tol
         )
 
-        compute_smooth_constants!(sws_pool[1], lds_c)
-        total += Q_state!(sws_pool[1], lds_c, suf_c)
-        total += _poisson_q_obs_total(lds_c, tfs_c, state.cell_data[c], sws_pool)
+        compute_smooth_constants!(cell_pool[1], lds_c)
+        total += Q_state!(cell_pool[1], lds_c, suf_c)
+        total += _poisson_q_obs_total(lds_c, tfs_c, state.cell_data[c], cell_pool)
         for fs in tfs_c.FilterSmooths
             total += fs.entropy
         end
@@ -1038,7 +1038,7 @@ function _fit_plds_grouped!(
     newton_tol::Float64=1e-6,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     sws_pool = _grouped_sws_pool(plds, data)
-    state = _grouped_fit_state(plds, data, grp, sws_pool[1])
+    state = _grouped_fit_state(plds, data, grp, sws_pool)
     elbos = Vector{T}(undef, max_iter)
 
     prog = if progress

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -766,7 +766,7 @@ function elbo(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on, y=data.y)
     if grp !== nothing
         sws_pool = _grouped_sws_pool(plds, data)
         state = _grouped_fit_state(plds, data, grp, sws_pool[1])
@@ -825,7 +825,7 @@ function smooth(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on, y=data.y)
     grp === nothing || return _grouped_smooth(plds, data, grp, y)
     tfs = initialize_FilterSmooth(plds, data.tsteps)::TrialFilterSmooth{T}
     # Cap the pool at the trial count — workspaces beyond ntrials are never
@@ -888,7 +888,7 @@ function fit!(
     depends_on::Union{Nothing,NamedTuple}=nothing,
 ) where {T<:Real,S<:GaussianStateModel{T},O<:PoissonObservationModel{T}}
     data = Data(plds, y; ux=ux, uy=uy)
-    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on)
+    grp = parameter_grouping(plds, length(data.y); depends_on=depends_on, y=data.y)
     grp === nothing || return _fit_plds_grouped!(
         plds,
         data,

--- a/src/lds/fit_PLDS.jl
+++ b/src/lds/fit_PLDS.jl
@@ -1011,8 +1011,11 @@ function _grouped_update_observation_model!(
         end
         sort!(trials)
         tfs = TrialFilterSmooth([state.tfs_all[n] for n in trials])
+
+        # solve using the pooled workspace for each cell
+        cell_pool = _prepare_cell!(sws_pool, state, units[1])
         update_observation_model!(
-            state.cell_lds[units[1]], tfs, data.y[trials], sws_pool; uy=data.uy[trials]
+            state.cell_lds[units[1]], tfs, data.y[trials], cell_pool; uy=data.uy[trials]
         )
     end
     return nothing

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -1535,7 +1535,7 @@ function fit!(
                 seq_ends=seq_ends,
                 ux=ux_seq,
                 uy=uy_seq,
-            cell_ws=cell_ws,
+                cell_ws=cell_ws,
             )
 
             elbos[iter] = _elbo_grouped!(
@@ -1548,7 +1548,7 @@ function fit!(
                 seq_ends=seq_ends,
                 ux=ux_seq,
                 uy=uy_seq,
-            cell_ws=cell_ws,
+                cell_ws=cell_ws,
             )
 
             _mstep_grouped!(
@@ -2031,9 +2031,8 @@ function _mstep_grouped!(
     differ per unit. Identical to `lds1` whenever the widths agree.
     =#
     unit_suf = [
-        _initialize_td_sufficient_statistics(
-            T, cell_slds[c].LDSs[k], cell_data[c].tsteps
-        ) for k in 1:K for c in 1:ncells
+        _initialize_td_sufficient_statistics(T, cell_slds[c].LDSs[k], cell_data[c].tsteps)
+        for k in 1:K for c in 1:ncells
     ]
 
     for k in 1:K

--- a/src/lds/fit_SLDS.jl
+++ b/src/lds/fit_SLDS.jl
@@ -1114,7 +1114,7 @@ function elbo(
     total_T = last(seq_ends)
     T_max = maximum(data.tsteps)
 
-    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on, y=y_seq)
     cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
 
     tfs = initialize_FilterSmooth(slds.LDSs[1], data.tsteps)::TrialFilterSmooth{T}
@@ -1123,6 +1123,11 @@ function elbo(
     obs_seq = collect(1:total_T)
     control_seq = fill(nothing, total_T)
     slds_ws = SLDSSmoothWorkspace(T, slds, T_max)
+    #=
+    Per-cell workspaces for a stitching fit; `nothing` when ungrouped, and the
+    base workspace itself when every session has the same channel count.
+    =#
+    cell_ws = _slds_cell_workspaces(slds, cell_slds, slds_ws, T_max)
     x_samples = [Matrix{T}(undef, slds.LDSs[1].latent_dim, Ti) for Ti in data.tsteps]
 
     # Warm-start q(x) with uniform weights, drawing the sample the E-step's
@@ -1140,6 +1145,7 @@ function elbo(
         rng=rng,
         ux=ux_seq,
         uy=uy_seq,
+        cell_ws=cell_ws,
     )
 
     if grp !== nothing
@@ -1164,6 +1170,7 @@ function elbo(
             seq_ends=seq_ends,
             ux=ux_seq,
             uy=uy_seq,
+            cell_ws=cell_ws,
         )
         return _elbo_grouped!(
             cells,
@@ -1175,6 +1182,7 @@ function elbo(
             seq_ends=seq_ends,
             ux=ux_seq,
             uy=uy_seq,
+            cell_ws=cell_ws,
         )
     end
 
@@ -1391,7 +1399,7 @@ function fit!(
     Ancillary parameter dependencies. `grp === nothing` (no regime declares
     `depends_on`) keeps every step on its original code path.
     =#
-    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on)
+    grp = _slds_parameter_grouping(slds, ntrials; depends_on=depends_on, y=y_seq)
     cell_slds = grp === nothing ? nothing : _slds_cell_sldss(slds, grp)
 
     # Continuous-state smoother storage (per-trial sized).
@@ -1419,6 +1427,18 @@ function fit!(
         uy_dim=slds.LDSs[1].uy_dim,
     )
     slds_ws = SLDSSmoothWorkspace(T, slds, T_max)
+    #=
+    Per-cell workspaces for a stitching fit; `nothing` when ungrouped, and the
+    base workspace itself when every session has the same channel count.
+    =#
+    cell_ws = _slds_cell_workspaces(slds, cell_slds, slds_ws, T_max)
+    #=
+    The M-step's regression buffers are shaped by `obs_dim` too, so a stitching
+    fit needs one per cell. `_cell_workspace` shares the block-tridiagonal and
+    smoothed-covariance storage, and `nothing` here keeps the single-workspace
+    path for every fit whose cells have the parent's width.
+    =#
+    cell_mstep_sws = _slds_cell_mstep_workspaces(slds, cell_slds, sws, T_max)
     x_samples = [Matrix{T}(undef, latent_dim, Ti) for Ti in tsteps_per_trial]
 
     prog = if progress
@@ -1445,6 +1465,7 @@ function fit!(
         rng=rng,
         ux=ux_seq,
         uy=uy_seq,
+        cell_ws=cell_ws,
     )
 
     for iter in 1:max_iter
@@ -1514,6 +1535,7 @@ function fit!(
                 seq_ends=seq_ends,
                 ux=ux_seq,
                 uy=uy_seq,
+            cell_ws=cell_ws,
             )
 
             elbos[iter] = _elbo_grouped!(
@@ -1526,6 +1548,7 @@ function fit!(
                 seq_ends=seq_ends,
                 ux=ux_seq,
                 uy=uy_seq,
+            cell_ws=cell_ws,
             )
 
             _mstep_grouped!(
@@ -1538,6 +1561,7 @@ function fit!(
                 sws;
                 obs_seq=obs_seq,
                 seq_ends=seq_ends,
+                cell_sws=cell_mstep_sws,
             )
         end
 
@@ -1582,6 +1606,7 @@ function _slds_warmstart!(
     rng::AbstractRNG=Random.default_rng(),
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    cell_ws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     function w_of(trial)
         return fill(one(T) / K, K, tsteps[trial])
@@ -1606,7 +1631,18 @@ function _slds_warmstart!(
 
     for c in 1:grp.ncells
         _slds_smooth_cell!(
-            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+            cell_slds,
+            grp,
+            c,
+            tfs,
+            y,
+            x_samples,
+            slds_ws,
+            w_of;
+            rng=rng,
+            ux=ux,
+            uy=uy,
+            cell_ws=cell_ws,
         )
     end
     return nothing
@@ -1619,12 +1655,12 @@ Trial partition for an `SLDS`, or `nothing` when no regime declares
 `depends_on`. Throws when the regimes disagree about the partition.
 """
 function _slds_parameter_grouping(
-    slds::SLDS, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing
+    slds::SLDS, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing, y=nothing
 )
-    grp = parameter_grouping(slds.LDSs[1], ntrials; depends_on=depends_on)
+    grp = parameter_grouping(slds.LDSs[1], ntrials; depends_on=depends_on, y=y)
     grp === nothing && return nothing
     for k in 2:length(slds.LDSs)
-        grp_k = parameter_grouping(slds.LDSs[k], ntrials; depends_on=depends_on)
+        grp_k = parameter_grouping(slds.LDSs[k], ntrials; depends_on=depends_on, y=y)
         ok =
             grp_k !== nothing &&
             grp_k.nslots == grp.nslots &&
@@ -1662,6 +1698,87 @@ function _slds_cell_sldss(
 end
 
 """
+    _cell_slds_workspace(base, slds_c, tsteps) -> SLDSSmoothWorkspace
+
+One cell's SLDS workspace for a stitching fit. Reuses `base`'s
+block-tridiagonal storage and per-timestep log-density scratch — the O(D²·T)
+and O(T) parts, neither of which depends on `obs_dim` — and allocates fresh
+per-regime constants and Newton buffers at this cell's channel count.
+
+Safe for the same reason the LDS side is: cells run one at a time, and a cell's
+Hessian blocks are consumed before the next cell overwrites them.
+"""
+function _cell_slds_workspace(
+    base::SLDSSmoothWorkspace{T}, slds_c::SLDS, tsteps::Int
+) where {T<:Real}
+    lds1 = slds_c.LDSs[1]
+    latent_dim = lds1.latent_dim
+    obs_dim = lds1.obs_dim
+    K = length(slds_c.LDSs)
+    ws = SLDSSmoothWorkspace{T}(
+        base.btd,                                          # shared O(D²·T)
+        [SmoothConstants(T, latent_dim, obs_dim) for _ in 1:K],
+        NewtonBuffers(T, latent_dim, obs_dim, tsteps),
+        base.ll_tmp,                                       # shared, length T_max
+    )
+    refresh_slds_constants!(ws, slds_c)
+    return ws
+end
+
+"""
+    _slds_cell_workspaces(slds, cell_slds, base, tsteps) -> Vector or nothing
+
+One workspace per cell. When every cell has the parent's `obs_dim` — which
+includes every SLDS fit that is not stitching sessions of differing width —
+each entry is `base` itself, so nothing extra is allocated and the previous
+code path is what runs.
+"""
+function _slds_cell_workspaces(
+    slds::SLDS,
+    cell_slds::Union{Nothing,AbstractVector},
+    base::SLDSSmoothWorkspace{T},
+    tsteps::Int,
+) where {T<:Real}
+    cell_slds === nothing && return nothing
+    p0 = slds.LDSs[1].obs_dim
+    all(sc -> sc.LDSs[1].obs_dim == p0, cell_slds) && return [base for _ in cell_slds]
+    return [_cell_slds_workspace(base, sc, tsteps) for sc in cell_slds]
+end
+
+_slds_ws_for(::Nothing, base::SLDSSmoothWorkspace, ::Int) = base
+_slds_ws_for(cell_ws::AbstractVector, ::SLDSSmoothWorkspace, c::Int) = cell_ws[c]
+
+"""
+    _slds_cell_mstep_workspaces(slds, cell_slds, base, tsteps) -> Vector or nothing
+
+One M-step `SmoothWorkspace` per cell, or `nothing` when every cell has the
+parent's `obs_dim`. The regression buffers that fit `[Cₖ dₖ Dₖ]` and the
+residual scatter `R` accumulates into are both shaped by the cell's channel
+count; everything expensive is shared with `base`.
+"""
+function _slds_cell_mstep_workspaces(
+    slds::SLDS,
+    cell_slds::Union{Nothing,AbstractVector},
+    base::SmoothWorkspace{T},
+    tsteps::Int,
+) where {T<:Real}
+    cell_slds === nothing && return nothing
+    lds1 = slds.LDSs[1]
+    p0 = lds1.obs_dim
+    all(sc -> sc.LDSs[1].obs_dim == p0, cell_slds) && return nothing
+    return [
+        _cell_workspace(
+            base,
+            lds1.latent_dim,
+            sc.LDSs[1].obs_dim,
+            tsteps;
+            ux_dim=lds1.ux_dim,
+            uy_dim=lds1.uy_dim,
+        ) for sc in cell_slds
+    ]
+end
+
+"""
     _slds_smooth_cell!(cell_slds, grp, cell, tfs, y, x_samples, slds_ws, w_of; rng, ux, uy)
 
 Smooth every trial of one cell after refreshing the workspace's regime constants
@@ -1679,16 +1796,18 @@ function _slds_smooth_cell!(
     rng::AbstractRNG=Random.default_rng(),
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    cell_ws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     slds_c = cell_slds[cell]
-    refresh_slds_constants!(slds_ws, slds_c)
+    ws_c = _slds_ws_for(cell_ws, slds_ws, cell)
+    refresh_slds_constants!(ws_c, slds_c)
     for trial in grp.cell_trials[cell]
         smooth!(
             slds_c,
             tfs[trial],
             y[trial],
             w_of(trial);
-            ws=slds_ws,
+            ws=ws_c,
             x_sample=x_samples[trial],
             rng=rng,
             ux=(ux === nothing ? nothing : ux[trial]),
@@ -1721,19 +1840,21 @@ function _estep_grouped!(
     seq_ends::AbstractVector{Int},
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    cell_ws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     K = length(cell_slds[1].LDSs)
 
     for c in 1:grp.ncells
         slds_c = cell_slds[c]
-        refresh_slds_constants!(slds_ws, slds_c)
+        ws_c = _slds_ws_for(cell_ws, slds_ws, c)
+        refresh_slds_constants!(ws_c, slds_c)
         for trial in grp.cell_trials[c]
             t1, t2 = HMMs.seq_limits(seq_ends, trial)
             for k in 1:K
                 joint_loglikelihood!(
                     view(dl.logL, k, t1:t2),
-                    slds_ws,
-                    slds_ws.consts[k],
+                    ws_c,
+                    ws_c.consts[k],
                     slds_c.LDSs[k],
                     x_samples[trial],
                     y[trial],
@@ -1755,7 +1876,18 @@ function _estep_grouped!(
 
     for c in 1:grp.ncells
         _slds_smooth_cell!(
-            cell_slds, grp, c, tfs, y, x_samples, slds_ws, w_of; rng=rng, ux=ux, uy=uy
+            cell_slds,
+            grp,
+            c,
+            tfs,
+            y,
+            x_samples,
+            slds_ws,
+            w_of;
+            rng=rng,
+            ux=ux,
+            uy=uy,
+            cell_ws=cell_ws,
         )
     end
 
@@ -1802,11 +1934,13 @@ function _elbo_grouped!(
     seq_ends::AbstractVector{Int},
     ux::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
+    cell_ws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     total_elbo = zero(T)
     for c in 1:grp.ncells
         slds_c = cell_slds[c]
-        refresh_slds_constants!(slds_ws, slds_c)
+        ws_c = _slds_ws_for(cell_ws, slds_ws, c)
+        refresh_slds_constants!(ws_c, slds_c)
         for trial in grp.cell_trials[c]
             t1, t2 = HMMs.seq_limits(seq_ends, trial)
             total_elbo += _slds_trial_elbo(
@@ -1814,7 +1948,7 @@ function _elbo_grouped!(
                 tfs[trial],
                 fb_storage,
                 y[trial],
-                slds_ws,
+                ws_c,
                 t1,
                 t2,
                 (ux === nothing ? nothing : ux[trial]),
@@ -1873,6 +2007,7 @@ function _mstep_grouped!(
     sws::SmoothWorkspace{T};
     obs_seq::AbstractVector,
     seq_ends::AbstractVector{Int},
+    cell_sws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     K = length(cell_slds[1].LDSs)
     ncells = grp.ncells
@@ -1893,9 +2028,15 @@ function _mstep_grouped!(
     end
 
     unit_lds = [cell_slds[c].LDSs[k] for k in 1:K for c in 1:ncells]
+    #=
+    Sized from the unit's own LDS rather than cell 1's: under stitching each
+    cell contributes a different number of channels, so `obs_xy` / `obs_yy`
+    differ per unit. Identical to `lds1` whenever the widths agree.
+    =#
     unit_suf = [
-        _initialize_td_sufficient_statistics(T, lds1, cell_data[c].tsteps) for k in 1:K for
-        c in 1:ncells
+        _initialize_td_sufficient_statistics(
+            T, cell_slds[c].LDSs[k], cell_data[c].tsteps
+        ) for k in 1:K for c in 1:ncells
     ]
 
     for k in 1:K
@@ -1903,7 +2044,12 @@ function _mstep_grouped!(
             u = (k - 1) * ncells + c
             weights = [γ_view(k, n) for n in grp.cell_trials[c]]
             _aggregate_td_suff_stats_weighted!(
-                unit_suf[u], cell_tfs[c], unit_lds[u], cell_data[c], weights, sws
+                unit_suf[u],
+                cell_tfs[c],
+                unit_lds[u],
+                cell_data[c],
+                weights,
+                _unit_ws(cell_sws, sws, c),
             )
         end
 
@@ -1915,9 +2061,16 @@ function _mstep_grouped!(
         _grouped_update_Q!(ldss_k, sufs_k, grp.cell_slot[_G_Q], grp.cell_slot[_G_AB], sws)
 
         if lds1.obs_model isa GaussianObservationModel{T}
-            _grouped_update_C_d!(ldss_k, sufs_k, grp.cell_slot[_G_CD], sws, bufs)
+            _grouped_update_C_d!(
+                ldss_k, sufs_k, grp.cell_slot[_G_CD], sws, bufs; unit_sws=cell_sws
+            )
             _grouped_update_R!(
-                ldss_k, sufs_k, grp.cell_slot[_G_R], grp.cell_slot[_G_CD], sws
+                ldss_k,
+                sufs_k,
+                grp.cell_slot[_G_R],
+                grp.cell_slot[_G_CD],
+                sws;
+                unit_sws=cell_sws,
             )
         elseif lds1.obs_model isa PoissonObservationModel{T}
             # Non-conjugate: one LBFGS solve per `[C d D]` version, over the
@@ -1932,7 +2085,7 @@ function _mstep_grouped!(
                     ldss_k[units[1]],
                     TrialFilterSmooth([tfs[n] for n in trials]),
                     data.y[trials],
-                    [sws],
+                    [_unit_ws(cell_sws, sws, units[1])],
                     [γ_view(k, n) for n in trials];
                     uy=data.uy[trials],
                 )

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -595,15 +595,26 @@ function _grouped_update_Q!(
     return nothing
 end
 
+#=
+Which workspace a unit's emission regression runs on. Ungrouped and
+equal-width fits pass `nothing` and share one; a stitching fit passes one
+workspace per unit, since `[C d D]` and `R` are shaped by the unit's width.
+=#
+_unit_ws(::Nothing, sws::SmoothWorkspace, ::Int) = sws
+_unit_ws(v::AbstractVector, ::SmoothWorkspace, u::Int) = v[u]
+
 function _grouped_update_C_d!(
     ldss::AbstractVector,
     sufs::AbstractVector,
     slots::AbstractVector{Int},
     sws::SmoothWorkspace,
-    bufs::GroupedSufBuffers,
+    bufs::GroupedSufBuffers;
+    unit_sws::Union{Nothing,AbstractVector}=nothing,
 )
     for units in _units_by_slot(slots)
-        update_C_d!(ldss[units[1]], _pool_obs!(bufs, sufs, units), sws)
+        update_C_d!(
+            ldss[units[1]], _pool_obs!(bufs, sufs, units), _unit_ws(unit_sws, sws, units[1])
+        )
     end
     return nothing
 end
@@ -613,19 +624,22 @@ function _grouped_update_R!(
     sufs::AbstractVector,
     slots::AbstractVector{Int},
     slots_cd::AbstractVector{Int},
-    sws::SmoothWorkspace{T},
+    sws::SmoothWorkspace{T};
+    unit_sws::Union{Nothing,AbstractVector}=nothing,
 ) where {T<:Real}
     ldss[1].fit_bool[_G_R] || return nothing
-    S_res = sws.elbo.obs_work
     for units in _units_by_slot(slots)
+        # `obs_work` is (p, p), so the scratch has to be this slot's width.
+        ws = _unit_ws(unit_sws, sws, units[1])
+        S_res = ws.elbo.obs_work
         fill!(S_res, zero(T))
         N = zero(T)
         for u in units
-            _accumulate_obs_scatter!(S_res, ldss[u], sufs[u], sws)
+            _accumulate_obs_scatter!(S_res, ldss[u], sufs[u], _unit_ws(unit_sws, sws, u))
             N += T(sufs[u].obs_n)
         end
         for u in _distinct_by_slot(slots_cd, units)
-            _accumulate_cd_prior_scatter!(S_res, ldss[u], sws)
+            _accumulate_cd_prior_scatter!(S_res, ldss[u], _unit_ws(unit_sws, sws, u))
         end
         _finalize_R!(ldss[units[1]], S_res, N)
     end

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -32,6 +32,16 @@ struct GroupedSufBuffers{T<:Real}
     init_yy::Matrix{T}
     dyn_xx::Matrix{T}
     obs_xx::Matrix{T}
+    #=
+    Pooling writes `obs_xy`, whose column count is the slot's channel count. A
+    stitching fit has more than one of those, so the odd-width scratch is built
+    on first use and cached for the rest of the fit — bounded by the number of
+    distinct widths, and never re-allocated per iteration. Stays empty whenever
+    every slot has the model's own `obs_dim`.
+    =#
+    obs_alt::Dict{Int,SufficientStatistics{T}}
+    proto::LinearDynamicalSystem{T}
+    tsteps::Vector{Int}
 end
 
 function GroupedSufBuffers(
@@ -45,7 +55,26 @@ function GroupedSufBuffers(
         zeros(T, D, D),
         zeros(T, dyn_reg_dim, dyn_reg_dim),
         zeros(T, obs_reg_dim, obs_reg_dim),
+        Dict{Int,SufficientStatistics{T}}(),
+        lds,
+        collect(tsteps_per_trial),
     )
+end
+
+#=
+The pooling target for a slot of width `p`: the preallocated one when it
+already matches, otherwise this fit's cached scratch for that width.
+=#
+function _obs_pool_target(bufs::GroupedSufBuffers{T}, p::Int) where {T<:Real}
+    size(bufs.suf.obs_xy, 2) == p && return bufs.suf
+    return get!(bufs.obs_alt, p) do
+        lds = bufs.proto
+        om = lds.obs_model
+        wide = LinearDynamicalSystem{T,typeof(lds.state_model),typeof(om)}(
+            lds.state_model, om, lds.latent_dim, p, lds.ux_dim, lds.uy_dim, lds.fit_bool
+        )
+        _initialize_td_sufficient_statistics(T, wide, bufs.tsteps)
+    end
 end
 
 #=
@@ -98,7 +127,7 @@ function _pool_obs!(
     bufs::GroupedSufBuffers{T}, sufs::AbstractVector, units::AbstractVector{Int}
 ) where {T<:Real}
     length(units) == 1 && return sufs[units[1]]
-    suf = bufs.suf
+    suf = _obs_pool_target(bufs, size(sufs[units[1]].obs_xy, 2))
     n = zero(T)
     fill!(suf.obs_xy, zero(T))
     XX = bufs.obs_xx
@@ -187,11 +216,12 @@ struct GroupedFitState{T<:Real,L,DT}
     sufs::Vector{SufficientStatistics{T}}
     cell_consts::Vector{CellConstBlocks{T}}
     cell_batched::Vector{Union{Nothing,BatchedBuffers{T}}}
+    cell_sws::Vector{Vector{SmoothWorkspace{T}}}
     bufs::GroupedSufBuffers{T}
 end
 
 """
-    _grouped_fit_state(lds, data, grp, sws; batched=false)
+    _grouped_fit_state(lds, data, grp, sws_pool; batched=false)
 
 Build the per-cell fit state. `batched=true` additionally allocates each cell's
 BLAS-3 mean-pass buffers (Gaussian path only, and only for cells whose trials
@@ -202,7 +232,7 @@ function _grouped_fit_state(
     lds::LinearDynamicalSystem{T,S,O},
     data::Data{T},
     grp::ParameterGrouping,
-    sws::SmoothWorkspace{T};
+    sws_pool::Vector{SmoothWorkspace{T}};
     batched::Bool=false,
 ) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
     ncells = grp.ncells
@@ -253,7 +283,15 @@ function _grouped_fit_state(
         _initialize_td_sufficient_statistics(T, cell_lds[c], cell_data[c].tsteps) for
         c in 1:ncells
     ]
-    cell_consts = [_cache_const_blocks!(sws, cell_lds[c], cell_data[c]) for c in 1:ncells]
+    #=
+    Each cell's constants are cached from that cell's own workspace, whose
+    aggregator blocks are already the right width. With uniform `obs_dim` every
+    cell aliases the shared pool, so this is the previous behaviour exactly.
+    =#
+    cell_sws = _cell_sws_pools(lds, data, grp, cell_lds, sws_pool)
+    cell_consts = [
+        _cache_const_blocks!(cell_sws[c][1], cell_lds[c], cell_data[c]) for c in 1:ncells
+    ]
 
     return GroupedFitState(
         cell_lds,
@@ -263,20 +301,114 @@ function _grouped_fit_state(
         sufs,
         cell_consts,
         cell_batched,
+        cell_sws,
         GroupedSufBuffers(T, lds, data.tsteps),
     )
 end
 
 """
-    _prepare_cell!(sws, state, cell)
+    _cell_workspace(base, latent_dim, obs_dim, tsteps; ux_dim, uy_dim)
 
-Point the shared workspace at one cell: swap in that cell's batched buffers and
-restore its aggregator constants.
+A `SmoothWorkspace` for one cell of a stitching fit, reusing every expensive
+buffer in `base` and allocating only the ones whose shape depends on the cell's
+channel count.
+
+The shared storage is the O(D²·T) part — the block-tridiagonal solver and the
+two smoothed-covariance caches — and it is safe to share for exactly the reason
+the pool itself is: a cell's covariances are consumed by its own aggregation
+before the next cell runs. What cannot be shared is anything shaped by
+`obs_dim`, since under stitching that differs per session.
+
+These are built once per fit, not per iteration, so a long fit allocates no
+more than a short one.
 """
-function _prepare_cell!(sws::SmoothWorkspace, state::GroupedFitState, cell::Int)
-    sws.batched = state.cell_batched[cell]
-    _restore_const_blocks!(sws, state.cell_consts[cell])
-    return sws
+function _cell_workspace(
+    base::SmoothWorkspace{T},
+    latent_dim::Int,
+    obs_dim::Int,
+    tsteps::Int;
+    ux_dim::Int=0,
+    uy_dim::Int=0,
+) where {T<:Real}
+    dyn_reg_dim = latent_dim + 1 + ux_dim
+    obs_reg_dim = latent_dim + 1 + uy_dim
+    agg = TDAggBuffers{T}(
+        base.agg.p_smooth_shared,                  # shared (D, D, T)
+        base.agg.p_smooth_tt1_shared,              # shared (D, D, T)
+        zeros(T, 1, latent_dim),                   # init_xy
+        zeros(T, dyn_reg_dim, latent_dim),         # dyn_xy
+        zeros(T, obs_reg_dim, obs_dim),            # obs_xy
+        zeros(T, latent_dim, latent_dim),          # sum_smooth_cov_prev
+        zeros(T, latent_dim, latent_dim),          # sum_smooth_cov_next
+        zeros(T, latent_dim, latent_dim),          # sum_smooth_cov_all
+        zeros(T, latent_dim, latent_dim),          # sum_smooth_xcov
+        zeros(T, obs_dim, obs_dim),                # obs_yy_const
+        zeros(T, obs_reg_dim, obs_dim),            # obs_xy_const
+        zeros(T, obs_reg_dim, obs_reg_dim),        # obs_xx_const
+        zeros(T, dyn_reg_dim, dyn_reg_dim),        # dyn_xx_const
+    )
+    return SmoothWorkspace{T}(
+        base.btd,                                  # shared block-tridiagonal storage
+        SmoothConstants(T, latent_dim, obs_dim),
+        NewtonBuffers(T, latent_dim, obs_dim, tsteps),
+        RegressionBuffers(T, latent_dim, obs_dim; ux_dim=ux_dim, uy_dim=uy_dim),
+        ElboBuffers(T, latent_dim, obs_dim),
+        agg,
+        nothing,                                   # set by `_prepare_cell!`
+    )
+end
+
+"""
+    _cell_sws_pools(lds, data, grp, cell_lds, sws_pool)
+
+One workspace pool per cell, parallel to `sws_pool`.
+
+When every cell has the parent's `obs_dim` — which includes every fit that does
+not use `depends_on` at all, and every grouped fit whose sessions have the same
+width — each cell simply aliases `sws_pool`, so nothing extra is allocated and
+the code path is the one that existed before stitching. Only a genuinely ragged
+fit builds per-cell workspaces, and even then the O(D²·T) storage is shared.
+"""
+function _cell_sws_pools(
+    lds::LinearDynamicalSystem{T},
+    data::Data{T},
+    grp::ParameterGrouping,
+    cell_lds::AbstractVector,
+    sws_pool::Vector{SmoothWorkspace{T}},
+) where {T<:Real}
+    all(c -> cell_lds[c].obs_dim == lds.obs_dim, 1:(grp.ncells)) &&
+        return [sws_pool for _ in 1:(grp.ncells)]
+
+    T_max = maximum(data.tsteps)
+    return [
+        [
+            _cell_workspace(
+                base,
+                lds.latent_dim,
+                cell_lds[c].obs_dim,
+                T_max;
+                ux_dim=lds.ux_dim,
+                uy_dim=lds.uy_dim,
+            ) for base in sws_pool
+        ] for c in 1:(grp.ncells)
+    ]
+end
+
+"""
+    _prepare_cell!(sws_pool, state, cell) -> Vector{SmoothWorkspace}
+
+Point the workspaces at one cell: swap in that cell's batched buffers and
+restore its aggregator constants. Returns the pool the cell's E-step should
+run on, which is `sws_pool` itself unless the fit stitches sessions of
+differing width.
+"""
+function _prepare_cell!(
+    sws_pool::Vector{SmoothWorkspace{T}}, state::GroupedFitState, cell::Int
+) where {T<:Real}
+    pool = state.cell_sws[cell]
+    pool[1].batched = state.cell_batched[cell]
+    _restore_const_blocks!(pool[1], state.cell_consts[cell])
+    return pool
 end
 
 """
@@ -322,12 +454,14 @@ function _grouped_smooth(
     xs = Vector{Matrix{T}}(undef, ntrials)
     Ps = Vector{Array{T,3}}(undef, ntrials)
     sws_pool = _grouped_sws_pool(lds, data)
+    cell_lds = _cell_ldss(lds, grp)
+    cell_pools = _cell_sws_pools(lds, data, grp, cell_lds, sws_pool)
 
     for c in 1:grp.ncells
         trials = grp.cell_trials[c]
         cell_data = _subset_data(data, trials)
-        tfs = initialize_FilterSmooth(lds, cell_data.tsteps)::TrialFilterSmooth{T}
-        smooth!(_cell_lds(lds, grp, c), tfs, cell_data, sws_pool)
+        tfs = initialize_FilterSmooth(cell_lds[c], cell_data.tsteps)::TrialFilterSmooth{T}
+        smooth!(cell_lds[c], tfs, cell_data, cell_pools[c])
         for (i, n) in enumerate(trials)
             xs[n] = copy(tfs[i].x_smooth)
             Ps[n] = copy(tfs[i].p_smooth)

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -677,10 +677,13 @@ function _grouped_gaussian_obs_mstep!(
     sufs::AbstractVector,
     slots::AbstractVector{Vector{Int}},
     sws::SmoothWorkspace,
-    bufs::GroupedSufBuffers,
+    bufs::GroupedSufBuffers;
+    unit_sws::Union{Nothing,AbstractVector}=nothing,
 )
-    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs)
-    _grouped_update_R!(ldss, sufs, slots[_G_R], slots[_G_CD], sws)
+    _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs; unit_sws=unit_sws)
+    _grouped_update_R!(
+        ldss, sufs, slots[_G_R], slots[_G_CD], sws; unit_sws=unit_sws
+    )
     return nothing
 end
 

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -681,9 +681,7 @@ function _grouped_gaussian_obs_mstep!(
     unit_sws::Union{Nothing,AbstractVector}=nothing,
 )
     _grouped_update_C_d!(ldss, sufs, slots[_G_CD], sws, bufs; unit_sws=unit_sws)
-    _grouped_update_R!(
-        ldss, sufs, slots[_G_R], slots[_G_CD], sws; unit_sws=unit_sws
-    )
+    _grouped_update_R!(ldss, sufs, slots[_G_R], slots[_G_CD], sws; unit_sws=unit_sws)
     return nothing
 end
 

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -226,10 +226,16 @@ function _grouped_fit_state(
             fs_all[n] = initialize_FilterSmooth(lds, tsteps[i]; cov_alias=alias)
         end
         cell_batched[c] = if batched && equal_len
+            #=
+            The cell's own channel count, not the parent's: these buffers hold
+            that cell's `y`, which under stitching is one session's channels.
+            Identical to `lds.obs_dim` whenever every session has the same
+            width, so the uniform case is unchanged.
+            =#
             BatchedBuffers(
                 T,
                 lds.latent_dim,
-                lds.obs_dim,
+                cell_lds[c].obs_dim,
                 tsteps[1],
                 length(trials);
                 ux_dim=lds.ux_dim,

--- a/src/lds/grouped_em.jl
+++ b/src/lds/grouped_em.jl
@@ -288,9 +288,15 @@ sessions and there are dozens of them.
 function _grouped_sws_pool(lds::LinearDynamicalSystem{T}, data::Data{T}) where {T<:Real}
     T_max = maximum(data.tsteps)
     npool = min(Threads.maxthreadid(), length(data.y))
+    #=
+    Sized at the widest session, not at the parent's `obs_dim`: under stitching
+    each cell has its own channel count and the parent's is only the template's.
+    Cells narrower than the maximum use the leading rows and columns.
+    =#
+    obs_max = maximum(size(yt, 1) for yt in data.y)
     return [
         SmoothWorkspace(
-            T, lds.latent_dim, lds.obs_dim, T_max; ux_dim=lds.ux_dim, uy_dim=lds.uy_dim
+            T, lds.latent_dim, obs_max, T_max; ux_dim=lds.ux_dim, uy_dim=lds.uy_dim
         ) for _ in 1:npool
     ]
 end

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -286,6 +286,23 @@ end
 
 _slot_arrays(base, nslots::Int) = [i == 1 ? base : copy(base) for i in 1:nslots]
 
+"""
+    ObsSlotSpec{T}
+
+**Internal.** Per-slot observation shape and data-derived seed for one
+observation-model parameter group. `dims[s]` is slot `s`'s channel count;
+`mean[s]` / `var[s]` are that slot's per-channel statistics, used only to seed
+a slot whose shape differs from the template.
+"""
+struct ObsSlotSpec{T<:Real}
+    dims::Vector{Int}
+    mean::Vector{Vector{T}}
+    var::Vector{Vector{T}}
+end
+
+_spec_dim(::Nothing, slot::Int, fallback::Int) = fallback
+_spec_dim(spec::ObsSlotSpec, slot::Int, ::Int) = spec.dims[slot]
+
 #=============================================================================
 Per-session observation dimensions ("stitching")
 
@@ -498,23 +515,6 @@ function _build_variants!(
     sm.variants = variants
     return variants
 end
-
-"""
-    ObsSlotSpec{T}
-
-**Internal.** Per-slot observation shape and data-derived seed for one
-observation-model parameter group. `dims[s]` is slot `s`'s channel count;
-`mean[s]` / `var[s]` are that slot's per-channel statistics, used only to seed
-a slot whose shape differs from the template.
-"""
-struct ObsSlotSpec{T<:Real}
-    dims::Vector{Int}
-    mean::Vector{Vector{T}}
-    var::Vector{Vector{T}}
-end
-
-_spec_dim(::Nothing, slot::Int, fallback::Int) = fallback
-_spec_dim(spec::ObsSlotSpec, slot::Int, ::Int) = spec.dims[slot]
 
 function _build_variants!(
     om::GaussianObservationModel{T,M,V},

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -286,6 +286,183 @@ end
 
 _slot_arrays(base, nslots::Int) = [i == 1 ? base : copy(base) for i in 1:nslots]
 
+#=============================================================================
+Per-session observation dimensions ("stitching")
+
+`obs_dim` is a property of the `[C d D]` group, not of the model as a whole:
+`C` is `obs_dim × latent_dim`, `d` is `obs_dim`, `D` is `obs_dim × uy_dim` and
+`R` is `obs_dim × obs_dim`. So when sessions observe different numbers of
+channels, every observation-model group has to be constant in `obs_dim` within
+each of its slots. A shared `:R` alongside a per-session `:C` has no
+well-defined size, and is rejected here rather than left to a downstream shape
+error.
+
+The dimensions come from the data: each slot's `obs_dim` is the row count of
+the trials assigned to it. The latent dimension stays shared.
+=============================================================================#
+
+"""
+    _slot_obs_dims(dep, g, labels_g, obs_dims, template_dim) -> Vector{Int}
+
+Observation dimension of each slot of observation-model group `g`.
+
+`obs_dims[n]` is trial `n`'s channel count. A group that does not vary gets a
+single slot, which then requires every trial to share one dimension.
+"""
+function _slot_obs_dims(
+    dep::ParameterDependence,
+    g::Int,
+    labels_g::AbstractVector,
+    obs_dims::AbstractVector{Int},
+    template_dim::Int,
+)
+    name = dep.names[g]
+    if !dep.varies[g]
+        p = first(obs_dims)
+        for q in obs_dims
+            q == p || throw(
+                ArgumentError(
+                    "observations have $p and $q channels in the same dataset, but " *
+                    "`:$name` is shared across all trials, so it has no well-defined " *
+                    "size. Make `:$name` depend on the same ancillary variable as the " *
+                    "emission, e.g. `depends_on = (C = session, R = session)`.",
+                ),
+            )
+        end
+        return [p]
+    end
+
+    dims = Vector{Int}(undef, dep.nslots[g])
+    seen = falses(dep.nslots[g])
+    for (n, label) in enumerate(labels_g)
+        s = _slot_of(dep, g, label)
+        p = obs_dims[n]
+        if !seen[s]
+            dims[s] = p
+            seen[s] = true
+        elseif dims[s] != p
+            throw(
+                ArgumentError(
+                    "trials grouped under `:$name = $(repr(dep.labels[g][s]))` have " *
+                    "differing channel counts ($(dims[s]) and $p). A parameter version " *
+                    "is one matrix, so every trial sharing it must have the same number " *
+                    "of channels.",
+                ),
+            )
+        end
+    end
+
+    # A slot with no trials in this dataset keeps whatever the template implies.
+    for s in eachindex(dims)
+        seen[s] || (dims[s] = template_dim)
+    end
+    return dims
+end
+
+#=
+Initialization of a variant whose shape differs from the template. Same-sized
+slots keep copying the template, so a fit whose sessions happen to agree on
+`obs_dim` is bit-identical to before this feature existed.
+
+A differently-sized slot cannot copy anything, so it is seeded from the data
+it will be fitted to: `d` at the per-channel mean and `R` at the per-channel
+variance put the emission on the right scale immediately, and `C` cycles the
+template's rows so that the loading matrix starts at the template's magnitude
+rather than at zero (which the M-step could not move off of). One M-step
+replaces all three.
+=#
+_obs_stats(::Nothing, p::Int, ::Type{T}) where {T} = (zeros(T, p), ones(T, p))
+
+function _obs_stats(ys::AbstractVector, p::Int, ::Type{T}) where {T}
+    mean_y = zeros(T, p)
+    var_y = zeros(T, p)
+    n = 0
+    for y in ys
+        n += size(y, 2)
+        for t in axes(y, 2), i in 1:p
+            mean_y[i] += y[i, t]
+        end
+    end
+    n == 0 && return (mean_y, fill!(var_y, one(T)))
+    mean_y ./= n
+    for y in ys
+        for t in axes(y, 2), i in 1:p
+            var_y[i] += abs2(y[i, t] - mean_y[i])
+        end
+    end
+    var_y ./= max(n - 1, 1)
+    for i in 1:p
+        var_y[i] > 0 || (var_y[i] = one(T))
+    end
+    return (mean_y, var_y)
+end
+
+#=
+Slot 1 aliases the parent's array (as `_slot_arrays` has always done) so the
+model object stays in sync with its first version; every other slot gets its
+own storage. A slot whose shape matches the template is still a plain copy, so
+nothing about the equal-`obs_dim` path changes.
+=#
+function _seed_slot_C(base::AbstractMatrix{T}, i::Int, p::Int) where {T}
+    size(base, 1) == p && return i == 1 ? base : copy(base)
+    out = similar(base, p, size(base, 2))
+    nrows = size(base, 1)
+    for r in 1:p
+        out[r, :] .= @view base[mod1(r, nrows), :]
+    end
+    return out
+end
+
+function _seed_slot_D(base::AbstractMatrix{T}, i::Int, p::Int) where {T}
+    size(base, 1) == p && return i == 1 ? base : copy(base)
+    out = similar(base, p, size(base, 2))
+    return fill!(out, zero(T))
+end
+
+function _seed_slot_d(
+    base::AbstractVector{T}, i::Int, p::Int, spec::Union{Nothing,ObsSlotSpec{T}}
+) where {T}
+    length(base) == p && return i == 1 ? base : copy(base)
+    out = similar(base, p)
+    spec === nothing ? fill!(out, zero(T)) : copyto!(out, spec.mean[i])
+    return out
+end
+
+function _seed_slot_R(
+    base::AbstractMatrix{T}, j::Int, p::Int, spec::Union{Nothing,ObsSlotSpec{T}}
+) where {T}
+    size(base, 1) == p && return j == 1 ? base : copy(base)
+    out = similar(base, p, p)
+    fill!(out, zero(T))
+    for k in 1:p
+        out[k, k] = spec === nothing ? one(T) : spec.var[j][k]
+    end
+    return out
+end
+
+#=
+A rebuild is skipped only when the cached variants already have the shapes this
+dataset asks for; otherwise re-fitting the same model against a dataset with
+different channel counts would silently reuse the wrong-sized arrays.
+=#
+function _variants_match(
+    variants::AbstractVector,
+    dep::ParameterDependence,
+    spec_C::Union{Nothing,ObsSlotSpec},
+    spec_R::Union{Nothing,ObsSlotSpec},
+)
+    spec_C === nothing && spec_R === nothing && return true
+    for cell in eachindex(variants)
+        s = _variant_slots(dep.nslots, cell)
+        v = variants[cell]
+        spec_C === nothing || size(v.C, 1) == spec_C.dims[s[1]] || return false
+        if spec_R !== nothing && hasproperty(v, :R)
+            size(v.R, 1) == spec_R.dims[s[2]] || return false
+        end
+    end
+    return true
+end
+
 function _build_variants!(
     sm::GaussianStateModel{T,M,V}, dep::ParameterDependence
 ) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
@@ -322,19 +499,46 @@ function _build_variants!(
     return variants
 end
 
+"""
+    ObsSlotSpec{T}
+
+**Internal.** Per-slot observation shape and data-derived seed for one
+observation-model parameter group. `dims[s]` is slot `s`'s channel count;
+`mean[s]` / `var[s]` are that slot's per-channel statistics, used only to seed
+a slot whose shape differs from the template.
+"""
+struct ObsSlotSpec{T<:Real}
+    dims::Vector{Int}
+    mean::Vector{Vector{T}}
+    var::Vector{Vector{T}}
+end
+
+_spec_dim(::Nothing, slot::Int, fallback::Int) = fallback
+_spec_dim(spec::ObsSlotSpec, slot::Int, ::Int) = spec.dims[slot]
+
 function _build_variants!(
-    om::GaussianObservationModel{T,M,V}, dep::ParameterDependence
+    om::GaussianObservationModel{T,M,V},
+    dep::ParameterDependence,
+    spec_C::Union{Nothing,ObsSlotSpec{T}}=nothing,
+    spec_R::Union{Nothing,ObsSlotSpec{T}}=nothing,
 ) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
     ncells = prod(dep.nslots)
     existing = om.variants
-    if existing !== nothing && length(existing) == ncells
+    if existing !== nothing &&
+        length(existing) == ncells &&
+        _variants_match(existing, dep, spec_C, spec_R)
         return existing
     end
 
-    Cs = _slot_arrays(om.C, dep.nslots[1])
-    ds = _slot_arrays(om.d, dep.nslots[1])
-    Ds = _slot_arrays(om.D, dep.nslots[1])
-    Rs = _slot_arrays(om.R, dep.nslots[2])
+    p0 = size(om.C, 1)
+    Cs = [_seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
+    ds = [
+        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C) for i in 1:(dep.nslots[1])
+    ]
+    Ds = [_seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
+    Rs = [
+        _seed_slot_R(om.R, j, _spec_dim(spec_R, j, p0), spec_R) for j in 1:(dep.nslots[2])
+    ]
 
     variants = Vector{GaussianObservationModel{T,M,V}}(undef, ncells)
     for cell in 1:ncells
@@ -353,17 +557,25 @@ function _build_variants!(
 end
 
 function _build_variants!(
-    om::PoissonObservationModel{T,M,V}, dep::ParameterDependence
+    om::PoissonObservationModel{T,M,V},
+    dep::ParameterDependence,
+    spec_C::Union{Nothing,ObsSlotSpec{T}}=nothing,
+    ::Union{Nothing,ObsSlotSpec{T}}=nothing,
 ) where {T<:Real,M<:AbstractMatrix{T},V<:AbstractVector{T}}
     ncells = prod(dep.nslots)
     existing = om.variants
-    if existing !== nothing && length(existing) == ncells
+    if existing !== nothing &&
+        length(existing) == ncells &&
+        _variants_match(existing, dep, spec_C, nothing)
         return existing
     end
 
-    Cs = _slot_arrays(om.C, dep.nslots[1])
-    ds = _slot_arrays(om.d, dep.nslots[1])
-    Ds = _slot_arrays(om.D, dep.nslots[1])
+    p0 = size(om.C, 1)
+    Cs = [_seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
+    ds = [
+        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C) for i in 1:(dep.nslots[1])
+    ]
+    Ds = [_seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
 
     variants = Vector{PoissonObservationModel{T,M,V}}(undef, ncells)
     for cell in 1:ncells
@@ -460,7 +672,10 @@ when no parameter of either sub-model depends on an ancillary variable.
 scoring a dataset whose trial count differs from the fitted one.
 """
 function parameter_grouping(
-    lds::LinearDynamicalSystem, ntrials::Int; depends_on::Union{Nothing,NamedTuple}=nothing
+    lds::LinearDynamicalSystem,
+    ntrials::Int;
+    depends_on::Union{Nothing,NamedTuple}=nothing,
+    y=nothing,
 )
     sm = lds.state_model
     om = lds.obs_model
@@ -485,7 +700,6 @@ function parameter_grouping(
     _validate_override_keys(sm, om, dep_s, dep_o, depends_on)
 
     _build_variants!(sm, dep_s)
-    _build_variants!(om, dep_o)
 
     ngroups_s = length(dep_s.names)
     ngroups_o = length(dep_o.names)
@@ -510,6 +724,16 @@ function parameter_grouping(
             ),
         )
     end
+
+    #=
+    Observation variants are built after the labels are known, because a
+    stitching dataset fixes each slot's `obs_dim` from the trials assigned to
+    it. `y === nothing`, or a dataset whose trials all have the template's
+    channel count, reproduces the previous shapes exactly.
+    =#
+    labels_o = [trial_labels[ngroups_s + g] for g in 1:ngroups_o]
+    spec_C, spec_R = _obs_slot_specs(om, dep_o, labels_o, ntrials, y)
+    _build_variants!(om, dep_o, spec_C, spec_R)
 
     # Per-trial slot indices, then the per-trial variant index of each sub-model.
     state_idx = Vector{Int}(undef, ntrials)
@@ -586,6 +810,57 @@ function parameter_grouping(
     )
 end
 
+#=
+`d` is seeded on the emission's natural scale: the per-channel mean for a
+Gaussian emission, its log for a Poisson one (`λ = exp(Cx + d)`).
+=#
+_natural_seed(::GaussianObservationModel, m::AbstractVector) = m
+function _natural_seed(::PoissonObservationModel, m::AbstractVector{T}) where {T<:Real}
+    return T[log(max(mi, eps(T))) for mi in m]
+end
+
+"""
+    _obs_slot_specs(om, dep_o, labels_o, ntrials, y) -> (spec_C, spec_R)
+
+Per-slot observation shapes for this dataset, or `(nothing, nothing)` when
+every trial carries the template's channel count — the ordinary single-`obs_dim`
+case, which must keep its existing arrays untouched.
+"""
+function _obs_slot_specs(
+    om::AbstractObservationModel{T},
+    dep_o::ParameterDependence,
+    labels_o::AbstractVector,
+    ntrials::Int,
+    y,
+) where {T<:Real}
+    y === nothing && return (nothing, nothing)
+    length(y) == ntrials || return (nothing, nothing)
+    obs_dims = [size(yi, 1) for yi in y]
+    p0 = size(om.C, 1)
+    all(isequal(p0), obs_dims) && return (nothing, nothing)
+
+    specs = Vector{ObsSlotSpec{T}}(undef, length(dep_o.names))
+    for g in eachindex(dep_o.names)
+        dims = _slot_obs_dims(dep_o, g, labels_o[g], obs_dims, p0)
+        nslots = length(dims)
+        means = Vector{Vector{T}}(undef, nslots)
+        vars = Vector{Vector{T}}(undef, nslots)
+        for s in 1:nslots
+            trials = [
+                n for n in 1:ntrials if
+                (dep_o.varies[g] ? _slot_of(dep_o, g, labels_o[g][n]) : 1) == s
+            ]
+            m, v = _obs_stats(
+                isempty(trials) ? nothing : [y[n] for n in trials], dims[s], T
+            )
+            means[s] = _natural_seed(om, m)
+            vars[s] = v
+        end
+        specs[g] = ObsSlotSpec{T}(dims, means, vars)
+    end
+    return (specs[1], length(specs) > 1 ? specs[2] : nothing)
+end
+
 """
     _has_parameter_dependence(model) -> Bool
 
@@ -632,8 +907,13 @@ function _cell_lds(
 ) where {T<:Real,S<:AbstractStateModel{T},O<:AbstractObservationModel{T}}
     sm = (lds.state_model.variants::Vector{S})[grp.cell_state[cell]]
     om = (lds.obs_model.variants::Vector{O})[grp.cell_obs[cell]]
+    #=
+    The cell's `obs_dim` comes from its own emission, not from the parent: under
+    stitching each session contributes a different number of channels, and the
+    parent's `obs_dim` is only the template's.
+    =#
     return LinearDynamicalSystem{T,S,O}(
-        sm, om, lds.latent_dim, lds.obs_dim, lds.ux_dim, lds.uy_dim, lds.fit_bool
+        sm, om, lds.latent_dim, size(om.C, 1), lds.ux_dim, lds.uy_dim, lds.fit_bool
     )
 end
 

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -316,6 +316,14 @@ error.
 
 The dimensions come from the data: each slot's `obs_dim` is the row count of
 the trials assigned to it. The latent dimension stays shared.
+
+`variants` is indexed by the Cartesian product of every group's slots, so with
+both `:C` and `:R` varying over two sessions it holds four entries while only
+two describe a real cell. Under stitching the two cross terms pair one
+session's `C` with another session's `R` and are therefore inconsistent — but
+they are unreachable: `_cell_lds` only ever indexes `grp.cell_obs`, and both
+groups take their width from the same per-trial data, so every combination an
+occupied cell names has matching `C` and `R` widths.
 =============================================================================#
 
 """

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -425,9 +425,17 @@ function Data(
     uy::Union{Nothing,AbstractVector{<:AbstractMatrix{T}}}=nothing,
 ) where {T<:Real}
     isempty(y) && throw(ArgumentError("y must contain at least one trial"))
-    for (i, yt) in enumerate(y)
-        size(yt, 1) == lds.obs_dim ||
-            throw(DimensionMismatchError("y[$i] rows", lds.obs_dim, size(yt, 1)))
+    #=
+    A group-dependent emission is the stitching case: each session brings its
+    own channel count, so rows are checked per parameter version once the trial
+    partition is known (`_slot_obs_dims`) rather than against the template's
+    `obs_dim` here. Everything else keeps the strict single-`obs_dim` check.
+    =#
+    if !_has_parameter_dependence(lds.obs_model)
+        for (i, yt) in enumerate(y)
+            size(yt, 1) == lds.obs_dim ||
+                throw(DimensionMismatchError("y[$i] rows", lds.obs_dim, size(yt, 1)))
+        end
     end
     tsteps = Int[size(yt, 2) for yt in y]
     ux_seq = _normalize_multitrial_ux(ux, lds.ux_dim, tsteps, T, "ux")

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -68,11 +68,21 @@ function test_stitching_variant_shapes()
     @test grp !== nothing
     @test grp.ncells == 2
 
+    #=
+    `variants` is indexed by the Cartesian product of every group's slots, so a
+    two-session model with both `:C` and `:R` varying stores four entries. Only
+    the combinations an actual cell uses are meaningful; the cross terms pair
+    one session's `C` with another's `R` and are never reached, since
+    `_cell_lds` indexes `grp.cell_obs`.
+    =#
     variants = lds.obs_model.variants
-    widths = sort([size(v.C, 1) for v in variants])
+    occupied = unique(grp.cell_obs)
+    @test length(occupied) == 2
+    widths = sort([size(variants[i].C, 1) for i in occupied])
     @test widths == sort([p1, p2])
 
-    for v in variants
+    for i in occupied
+        v = variants[i]
         p = size(v.C, 1)
         @test size(v.C, 2) == ST_LATENT_DIM
         @test length(v.d) == p
@@ -118,11 +128,11 @@ function test_stitching_data_validation()
     y, session, p1, _ = st_two_session_data()
 
     plain = st_grouped_lds(p1)
-    @test_throws SSD.DimensionMismatchError Data(plain, y)
+    @test_throws SSD.DimensionMismatchError SSD.Data(plain, y)
 
     grouped = st_grouped_lds(p1)
     grouped.obs_model.depends_on = (C=session, R=session)
-    data = Data(grouped, y)
+    data = SSD.Data(grouped, y)
     @test length(data.y) == length(y)
     return nothing
 end
@@ -148,7 +158,7 @@ function test_uniform_obs_dim_is_unchanged()
     # Slot 1 shares storage with the parent, as before this feature.
     @test any(v -> v.C === lds.obs_model.C, variants)
 
-    data = Data(lds, y)
+    data = SSD.Data(lds, y)
     pool = SSD._grouped_sws_pool(lds, data)
     cell_lds = SSD._cell_ldss(lds, grp)
     pools = SSD._cell_sws_pools(lds, data, grp, cell_lds, pool)
@@ -190,7 +200,7 @@ function test_grouped_pool_sized_at_widest_session()
     y, session, p1, p2 = st_two_session_data()
     lds = st_grouped_lds(p1)
     lds.obs_model.depends_on = (C=session, R=session)
-    data = Data(lds, y)
+    data = SSD.Data(lds, y)
     pool = SSD._grouped_sws_pool(lds, data)
     @test size(pool[1].agg.obs_yy_const, 1) == max(p1, p2)
     return nothing
@@ -209,9 +219,13 @@ function test_stitching_fit_runs_and_improves()
     @test all(isfinite, elbos)
     @test pd_is_monotone(elbos)
 
+    grp = SSD.parameter_grouping(lds, length(y); y=y)
     variants = lds.obs_model.variants
-    @test sort([size(v.C, 1) for v in variants]) == sort([p1, p2])
-    for v in variants
+    occupied = unique(grp.cell_obs)
+    @test sort([size(variants[i].C, 1) for i in occupied]) == sort([p1, p2])
+    for i in occupied
+        v = variants[i]
+        @test size(v.R, 1) == size(v.C, 1)
         @test all(isfinite, v.C)
         @test all(isfinite, v.R)
         @test isposdef(Symmetric(v.R))
@@ -328,11 +342,15 @@ function test_stitching_slds_fit()
     @test length(elbos) == 5
     @test all(isfinite, elbos)
 
+    grp = SSD._slds_parameter_grouping(slds, length(y); y=y)
+    occupied = unique(grp.cell_obs)
     for k in 1:2
         om = slds.LDSs[k].obs_model
-        widths = sort([size(v.C, 1) for v in om.variants])
+        widths = sort([size(om.variants[i].C, 1) for i in occupied])
         @test widths == sort([p1, p2])
-        for v in om.variants
+        for i in occupied
+            v = om.variants[i]
+            @test size(v.R, 1) == size(v.C, 1)
             @test all(isfinite, v.C)
             @test isposdef(Symmetric(v.R))
         end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -361,3 +361,111 @@ function test_stitching_slds_fit()
     @test size(slds.A) == (2, 2)
     return nothing
 end
+
+#=
+Stitching with a Poisson emission. The tests above are Gaussian throughout, but
+the per-session sizing is emission-agnostic and the seeding is not: `d` starts
+at the per-channel mean for a Gaussian emission and at its *log* for a Poisson
+one, since `λ = exp(Cx + d)`.
+=#
+function st_poisson_lds(p::Int; seed::Int=0)
+    C = Float64.(randn(StableRNG(700 + seed), p, ST_LATENT_DIM)) .* 0.4
+    om = PoissonObservationModel(C, fill(-0.2, p))
+    return LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om,
+        latent_dim=ST_LATENT_DIM,
+        obs_dim=p,
+        fit_bool=fill(true, 5),
+    )
+end
+
+function st_poisson_two_session_data(; p1::Int=3, p2::Int=5, ntrials::Int=4, tsteps::Int=25)
+    _, y1 = rand(StableRNG(71), st_poisson_lds(p1; seed=1), fill(tsteps, ntrials))
+    _, y2 = rand(StableRNG(72), st_poisson_lds(p2; seed=2), fill(tsteps, ntrials))
+    session = vcat(fill(:a, ntrials), fill(:b, ntrials))
+    return vcat(y1, y2), session, p1, p2
+end
+
+function test_stitching_poisson_fit()
+    y, session, p1, p2 = st_poisson_two_session_data()
+
+    om = PoissonObservationModel(
+        Float64.(randn(StableRNG(73), p1, ST_LATENT_DIM)) .* 0.3, zeros(p1)
+    )
+    om.depends_on = (C=session,)
+    fitted = LinearDynamicalSystem(;
+        state_model=pd_state_model(),
+        obs_model=om,
+        latent_dim=ST_LATENT_DIM,
+        obs_dim=p1,
+        fit_bool=fill(true, 5),
+    )
+
+    elbos = fit!(fitted, y; max_iter=6, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    # Each session's emission is sized from its own channel count.
+    @test size(group_parameter(om, :C, :a)) == (p1, ST_LATENT_DIM)
+    @test size(group_parameter(om, :C, :b)) == (p2, ST_LATENT_DIM)
+    @test length(group_parameter(om, :d, :a)) == p1
+    @test length(group_parameter(om, :d, :b)) == p2
+    @test all(isfinite, group_parameter(om, :C, :b))
+    @test all(isfinite, group_parameter(om, :d, :b))
+
+    # The shared latent process is recovered at one width for every trial.
+    xs, Ps = smooth(fitted, y)
+    @test length(xs) == length(y)
+    @test all(x -> size(x, 1) == ST_LATENT_DIM, xs)
+    @test size(Ps[1]) == (ST_LATENT_DIM, ST_LATENT_DIM, size(y[1], 2))
+    # The marginal `log p(y)` is intractable for a Poisson emission, so the
+    # ELBO from the fit is the available scalar summary.
+    @test isfinite(elbo(fitted, y))
+    return nothing
+end
+
+#=
+A parameter that is shared across trials has no per-session size to derive, so
+it takes the one width the dataset has. That is only well defined when the
+widths agree — the mixed case is what `test_stitching_requires_grouped_R`
+rejects — and this is the accepting side of the same check.
+=#
+function test_shared_obs_parameter_at_uniform_width()
+    ntrials = 4
+    session = [:a, :a, :b, :b]
+
+    # The dataset's width matches the template's: nothing to resize.
+    lds = st_lds(3)
+    _, y = rand(StableRNG(74), lds, fill(20, ntrials))
+    om = lds.obs_model
+    om.depends_on = (C=session,)          # `:R` stays shared
+    fitted = st_build_lds(pd_state_model(), om)
+
+    elbos = fit!(fitted, y; max_iter=5, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+    @test length(om.variants) == 2
+    @test om.variants[1].R === om.variants[2].R
+    @test size(om.variants[1].R) == (3, 3)
+    @test !(group_parameter(om, :C, :a) ≈ group_parameter(om, :C, :b))
+
+    #=
+    The dataset is wider than the template everywhere. The width is still
+    unambiguous, so the shared `:R` takes the data's rather than the template's
+    — and `[C d]` is resized to match even though it varies.
+    =#
+    wide = 5
+    _, y_wide = rand(StableRNG(75), st_lds(wide), fill(20, 2 * ntrials))
+    om2 = st_obs_model(3)
+    om2.depends_on = (C=vcat(fill(:a, ntrials), fill(:b, ntrials)),)
+    fitted2 = st_build_lds(pd_state_model(), om2)
+
+    elbos2 = fit!(fitted2, y_wide; max_iter=5, progress=false)
+    @test all(isfinite, elbos2)
+    @test size(group_parameter(om2, :C, :a)) == (wide, ST_LATENT_DIM)
+    @test size(group_parameter(om2, :C, :b)) == (wide, ST_LATENT_DIM)
+    @test om2.variants[1].R === om2.variants[2].R
+    @test size(om2.variants[1].R) == (wide, wide)
+    return nothing
+end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -469,3 +469,41 @@ function test_shared_obs_parameter_at_uniform_width()
     @test size(om2.variants[1].R) == (wide, wide)
     return nothing
 end
+
+#=
+Pooling writes into a scratch `obs_xy` whose column count is the slot's channel
+count. The preallocated one is sized from the model's own `obs_dim`, so a slot
+shared across cells at some *other* width needs its own — built on first use and
+cached for the rest of the fit.
+
+Reaching it takes a shared `[C d D]` pooled over more than one cell at a width
+the model was not built at: group `:R` so there are two cells, leave `[C d D]`
+shared so they pool into one slot, and give the data a width the template does
+not have.
+=#
+function test_pooled_slot_at_a_width_the_model_was_not_built_at()
+    ntrials, wide, template = 4, 5, 3
+    _, y = rand(StableRNG(76), st_lds(wide), fill(20, 2 * ntrials))
+
+    om = st_obs_model(template)
+    om.depends_on = (R=vcat(fill(:a, ntrials), fill(:b, ntrials)),)
+    fitted = st_build_lds(pd_state_model(), om)
+    @test size(om.C, 1) == template     # the model really does start narrower
+
+    elbos = fit!(fitted, y; max_iter=5, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    # Two cells pooling into one `[C d]`, at the data's width rather than the
+    # template's...
+    @test length(om.variants) == 2
+    @test om.variants[1].C === om.variants[2].C
+    @test size(om.variants[1].C) == (wide, ST_LATENT_DIM)
+    @test length(om.variants[1].d) == wide
+    # ... while each keeps its own noise covariance, also resized.
+    @test size(group_parameter(om, :R, :a)) == (wide, wide)
+    @test !(group_parameter(om, :R, :a) ≈ group_parameter(om, :R, :b))
+    @test isposdef(group_parameter(om, :R, :a))
+    @test isposdef(group_parameter(om, :R, :b))
+    return nothing
+end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -238,7 +238,8 @@ function st_slds(labels; p_template::Int=3, K::Int=2)
         sm = pd_state_model()
         sm.A .= k == 1 ? [0.95 0.05; -0.05 0.95] : [0.60 0.30; -0.30 0.60]
         om = st_obs_model(p_template; seed=10 + k)
-        om.depends_on = (C=labels, R=labels)
+        # `nothing` builds the ungrouped model each session is sampled from.
+        labels === nothing || (om.depends_on = (C=labels, R=labels))
         return pd_lds(sm, om)
     end
     return SLDS(; A=[0.9 0.1; 0.1 0.9], πₖ=[0.5, 0.5], LDSs=ldss)
@@ -246,8 +247,8 @@ end
 
 function st_slds_two_session_data(; p1::Int=3, p2::Int=4, ntrials::Int=3, tsteps::Int=30)
     labels = vcat(fill(:s1, ntrials), fill(:s2, ntrials))
-    t1 = st_slds(labels; p_template=p1)
-    t2 = st_slds(labels; p_template=p2)
+    t1 = st_slds(nothing; p_template=p1)
+    t2 = st_slds(nothing; p_template=p2)
     _, _, y1 = rand(StableRNG(31), t1, fill(tsteps, ntrials))
     _, _, y2 = rand(StableRNG(32), t2, fill(tsteps, ntrials))
     return vcat(y1, y2), labels, p1, p2

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -1,0 +1,228 @@
+#=============================================================================
+Stitching: sessions that observe different numbers of channels
+
+These reuse the `pd_*` helpers from `ParameterDependencies.jl`, which is
+included first. The latent dimension is shared across sessions throughout;
+only `obs_dim` varies.
+=============================================================================#
+
+const ST_LATENT_DIM = 2
+
+# A Gaussian emission of width `p`, deterministic so failures are reproducible.
+function st_obs_model(p::Int, ::Type{T}=Float64; seed::Int=0) where {T<:Real}
+    rng = StableRNG(1234 + seed)
+    C = T.(randn(rng, p, ST_LATENT_DIM))
+    R = Matrix{T}(0.1I, p, p)
+    d = zeros(T, p)
+    return GaussianObservationModel(C, R, d)
+end
+
+function st_lds(p::Int; seed::Int=0)
+    return pd_lds(pd_state_model(), st_obs_model(p; seed=seed))
+end
+
+#=
+Two sessions of differing width sharing one latent process: draw each session
+from its own model, then hand both to a single model whose emission is
+session-dependent.
+=#
+function st_two_session_data(; p1::Int=3, p2::Int=5, ntrials::Int=4, tsteps::Int=25)
+    lds1 = st_lds(p1; seed=1)
+    lds2 = st_lds(p2; seed=2)
+    _, y1 = rand(StableRNG(11), lds1, fill(tsteps, ntrials))
+    _, y2 = rand(StableRNG(22), lds2, fill(tsteps, ntrials))
+    y = vcat(y1, y2)
+    session = vcat(fill(:a, ntrials), fill(:b, ntrials))
+    return y, session, p1, p2
+end
+
+function st_grouped_lds(p_template::Int)
+    lds = st_lds(p_template)
+    return lds
+end
+
+"""
+Per-slot shapes come from the data, and each cell's LDS reports its own width.
+"""
+function test_stitching_variant_shapes()
+    y, session, p1, p2 = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    lds.obs_model.depends_on = (C=session, R=session)
+
+    grp = SSD.parameter_grouping(lds, length(y); y=y)
+    @test grp !== nothing
+    @test grp.ncells == 2
+
+    variants = lds.obs_model.variants
+    widths = sort([size(v.C, 1) for v in variants])
+    @test widths == sort([p1, p2])
+
+    for v in variants
+        p = size(v.C, 1)
+        @test size(v.C, 2) == ST_LATENT_DIM
+        @test length(v.d) == p
+        @test size(v.R) == (p, p)
+        @test size(v.D, 1) == p
+    end
+
+    # Each cell's LDS carries its own obs_dim, not the parent's template.
+    cell_widths = sort([SSD._cell_lds(lds, grp, c).obs_dim for c in 1:(grp.ncells)])
+    @test cell_widths == sort([p1, p2])
+    return nothing
+end
+
+"""
+`obs_dim` belongs to the emission group, so a shared `:R` beside a
+session-dependent `:C` has no well-defined size.
+"""
+function test_stitching_requires_grouped_R()
+    y, session, p1, _ = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    lds.obs_model.depends_on = (C=session,)
+    @test_throws ArgumentError SSD.parameter_grouping(lds, length(y); y=y)
+    return nothing
+end
+
+"""
+One parameter version is one matrix, so trials sharing a label must agree.
+"""
+function test_stitching_rejects_mixed_widths_in_slot()
+    y, session, p1, _ = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    # Collapse both sessions onto one label while the data still has two widths.
+    same = fill(:only, length(y))
+    lds.obs_model.depends_on = (C=same, R=same)
+    @test_throws ArgumentError SSD.parameter_grouping(lds, length(y); y=y)
+    return nothing
+end
+
+"""
+Ragged channel counts are accepted only when the emission is group-dependent.
+"""
+function test_stitching_data_validation()
+    y, session, p1, _ = st_two_session_data()
+
+    plain = st_grouped_lds(p1)
+    @test_throws SSD.DimensionMismatchError Data(plain, y)
+
+    grouped = st_grouped_lds(p1)
+    grouped.obs_model.depends_on = (C=session, R=session)
+    data = Data(grouped, y)
+    @test length(data.y) == length(y)
+    return nothing
+end
+
+"""
+Nothing about the uniform-`obs_dim` path changes: no specs are computed, slot 1
+still aliases the model's own arrays, and the cell pools are the shared pool.
+"""
+function test_uniform_obs_dim_is_unchanged()
+    ntrials = 4
+    lds = st_lds(3)
+    _, y = rand(StableRNG(7), lds, fill(20, ntrials))
+    session = [:a, :a, :b, :b]
+    lds.obs_model.depends_on = (C=session, R=session)
+
+    dep = SSD._resolve_dependence(lds.obs_model)
+    labels = [dep.trial_labels[g] for g in eachindex(dep.names)]
+    @test SSD._obs_slot_specs(lds.obs_model, dep, labels, ntrials, y) === (nothing, nothing)
+
+    grp = SSD.parameter_grouping(lds, ntrials; y=y)
+    variants = lds.obs_model.variants
+    @test all(v -> size(v.C, 1) == 3, variants)
+    # Slot 1 shares storage with the parent, as before this feature.
+    @test any(v -> v.C === lds.obs_model.C, variants)
+
+    data = Data(lds, y)
+    pool = SSD._grouped_sws_pool(lds, data)
+    cell_lds = SSD._cell_ldss(lds, grp)
+    pools = SSD._cell_sws_pools(lds, data, grp, cell_lds, pool)
+    @test all(p -> p === pool, pools)
+    return nothing
+end
+
+"""
+A cell workspace reuses the O(D²·T) storage and allocates only what `obs_dim`
+shapes — the property that keeps a many-session fit's memory bounded.
+"""
+function test_cell_workspace_shares_big_buffers()
+    D, tsteps = ST_LATENT_DIM, 30
+    base = SSD.SmoothWorkspace(Float64, D, 6, tsteps)
+    cell = SSD._cell_workspace(base, D, 3, tsteps)
+
+    # Shared: the expensive buffers are the same objects.
+    @test cell.btd === base.btd
+    @test cell.agg.p_smooth_shared === base.agg.p_smooth_shared
+    @test cell.agg.p_smooth_tt1_shared === base.agg.p_smooth_tt1_shared
+
+    # Private and correctly sized: everything shaped by obs_dim.
+    @test cell.agg.obs_yy_const !== base.agg.obs_yy_const
+    @test size(cell.agg.obs_yy_const) == (3, 3)
+    @test size(cell.agg.obs_xy, 2) == 3
+    @test size(cell.consts.tmp_RC, 1) == 3
+    @test size(cell.elbo.sum_yy) == (3, 3)
+    @test cell.batched === nothing
+
+    # The latent-shaped aggregates keep the shared latent dimension.
+    @test size(cell.agg.sum_smooth_cov_all) == (D, D)
+    return nothing
+end
+
+"""
+The grouped pool is sized at the widest session, so every cell fits in it.
+"""
+function test_grouped_pool_sized_at_widest_session()
+    y, session, p1, p2 = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    lds.obs_model.depends_on = (C=session, R=session)
+    data = Data(lds, y)
+    pool = SSD._grouped_sws_pool(lds, data)
+    @test size(pool[1].agg.obs_yy_const, 1) == max(p1, p2)
+    return nothing
+end
+
+"""
+End-to-end: a stitched fit runs, improves monotonically, and leaves each
+session's emission at its own width with the shared dynamics still shared.
+"""
+function test_stitching_fit_runs_and_improves()
+    y, session, p1, p2 = st_two_session_data(; ntrials=4, tsteps=30)
+    lds = st_grouped_lds(p1)
+    lds.obs_model.depends_on = (C=session, R=session)
+
+    elbos = fit!(lds, y; max_iter=8, progress=false)
+    @test all(isfinite, elbos)
+    @test pd_is_monotone(elbos)
+
+    variants = lds.obs_model.variants
+    @test sort([size(v.C, 1) for v in variants]) == sort([p1, p2])
+    for v in variants
+        @test all(isfinite, v.C)
+        @test all(isfinite, v.R)
+        @test isposdef(Symmetric(v.R))
+    end
+
+    # Latent dynamics stay shared: one version, and it is the model's own array.
+    @test lds.state_model.variants === nothing ||
+        all(v -> v.A === lds.state_model.A, lds.state_model.variants)
+    return nothing
+end
+
+"""
+Smoothing a stitched model returns per-trial latents of the shared latent
+dimension regardless of each trial's channel count.
+"""
+function test_stitching_smooth_shapes()
+    y, session, _, _ = st_two_session_data(; ntrials=3, tsteps=20)
+    lds = st_grouped_lds(3)
+    lds.obs_model.depends_on = (C=session, R=session)
+
+    xs, Ps = smooth(lds, y)
+    @test length(xs) == length(y)
+    for (n, x) in enumerate(xs)
+        @test size(x, 1) == ST_LATENT_DIM
+        @test size(x, 2) == size(y[n], 2)
+        @test size(Ps[n], 1) == ST_LATENT_DIM
+    end
+    return nothing
+end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -226,3 +226,104 @@ function test_stitching_smooth_shapes()
     end
     return nothing
 end
+
+#=============================================================================
+SLDS
+=============================================================================#
+
+# An SLDS whose regimes share the latent chain and each carry a session-dependent
+# emission of the template width; the per-session widths come from the data.
+function st_slds(labels; p_template::Int=3, K::Int=2)
+    ldss = map(1:K) do k
+        sm = pd_state_model()
+        sm.A .= k == 1 ? [0.95 0.05; -0.05 0.95] : [0.60 0.30; -0.30 0.60]
+        om = st_obs_model(p_template; seed=10 + k)
+        om.depends_on = (C=labels, R=labels)
+        return pd_lds(sm, om)
+    end
+    return SLDS(; A=[0.9 0.1; 0.1 0.9], πₖ=[0.5, 0.5], LDSs=ldss)
+end
+
+function st_slds_two_session_data(; p1::Int=3, p2::Int=4, ntrials::Int=3, tsteps::Int=30)
+    labels = vcat(fill(:s1, ntrials), fill(:s2, ntrials))
+    t1 = st_slds(labels; p_template=p1)
+    t2 = st_slds(labels; p_template=p2)
+    _, _, y1 = rand(StableRNG(31), t1, fill(tsteps, ntrials))
+    _, _, y2 = rand(StableRNG(32), t2, fill(tsteps, ntrials))
+    return vcat(y1, y2), labels, p1, p2
+end
+
+"""
+Every regime of a stitched SLDS gets that session's width, and the trial
+partition is still shared across regimes.
+"""
+function test_stitching_slds_shapes()
+    y, labels, p1, p2 = st_slds_two_session_data()
+    slds = st_slds(labels; p_template=p1)
+
+    grp = SSD._slds_parameter_grouping(slds, length(y); y=y)
+    @test grp !== nothing
+    @test grp.ncells == 2
+
+    cells = SSD._slds_cell_sldss(slds, grp)
+    for sc in cells
+        widths = unique([lds.obs_dim for lds in sc.LDSs])
+        # All regimes of one cell observe the same session, hence one width.
+        @test length(widths) == 1
+    end
+    @test sort([sc.LDSs[1].obs_dim for sc in cells]) == sort([p1, p2])
+    return nothing
+end
+
+"""
+The per-cell SLDS workspace shares the expensive storage and sizes the rest to
+the cell; an equal-width model gets the base workspace itself.
+"""
+function test_slds_cell_workspace_sharing()
+    y, labels, p1, p2 = st_slds_two_session_data()
+    slds = st_slds(labels; p_template=p1)
+    grp = SSD._slds_parameter_grouping(slds, length(y); y=y)
+    cells = SSD._slds_cell_sldss(slds, grp)
+
+    base = SSD.SLDSSmoothWorkspace(Float64, slds, 30)
+    ws = SSD._slds_cell_workspaces(slds, cells, base, 30)
+    @test ws !== nothing
+    for (c, w) in enumerate(ws)
+        @test w.btd === base.btd          # shared O(D²·T)
+        @test w.ll_tmp === base.ll_tmp    # shared O(T)
+        p = cells[c].LDSs[1].obs_dim
+        @test all(cc -> size(cc.tmp_RC, 1) == p, w.consts)
+    end
+
+    # Equal widths: the base workspace is handed back unchanged.
+    uniform = SSD._slds_cell_workspaces(slds, [cells[1], cells[1]], base, 30)
+    @test all(w -> w === base, uniform)
+    return nothing
+end
+
+"""
+End-to-end stitched SLDS fit: finite ELBOs and per-session emission widths.
+"""
+function test_stitching_slds_fit()
+    y, labels, p1, p2 = st_slds_two_session_data(; ntrials=3, tsteps=30)
+    slds = st_slds(labels; p_template=p1)
+
+    elbos = fit!(slds, y; max_iter=5, progress=false, rng=StableRNG(99))
+    @test length(elbos) == 5
+    @test all(isfinite, elbos)
+
+    for k in 1:2
+        om = slds.LDSs[k].obs_model
+        widths = sort([size(v.C, 1) for v in om.variants])
+        @test widths == sort([p1, p2])
+        for v in om.variants
+            @test all(isfinite, v.C)
+            @test isposdef(Symmetric(v.R))
+        end
+    end
+
+    # The discrete chain and the initial state stay shared.
+    @test slds.LDSs[2].state_model.x0 ≈ slds.LDSs[1].state_model.x0
+    @test size(slds.A) == (2, 2)
+    return nothing
+end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -17,8 +17,23 @@ function st_obs_model(p::Int, ::Type{T}=Float64; seed::Int=0) where {T<:Real}
     return GaussianObservationModel(C, R, d)
 end
 
+#=
+`pd_lds` fixes `obs_dim` at `PD_OBS_DIM`, which is exactly the assumption this
+feature removes, so these build the model with `obs_dim` taken from the
+emission itself.
+=#
+function st_build_lds(sm, om)
+    return LinearDynamicalSystem(;
+        state_model=sm,
+        obs_model=om,
+        latent_dim=ST_LATENT_DIM,
+        obs_dim=size(om.C, 1),
+        fit_bool=fill(true, 6),
+    )
+end
+
 function st_lds(p::Int; seed::Int=0)
-    return pd_lds(pd_state_model(), st_obs_model(p; seed=seed))
+    return st_build_lds(pd_state_model(), st_obs_model(p; seed=seed))
 end
 
 #=
@@ -240,7 +255,7 @@ function st_slds(labels; p_template::Int=3, K::Int=2)
         om = st_obs_model(p_template; seed=10 + k)
         # `nothing` builds the ungrouped model each session is sampled from.
         labels === nothing || (om.depends_on = (C=labels, R=labels))
-        return pd_lds(sm, om)
+        return st_build_lds(sm, om)
     end
     return SLDS(; A=[0.9 0.1; 0.1 0.9], πₖ=[0.5, 0.5], LDSs=ldss)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,7 @@ using SSDTest
 
             @testset "Non-breaking" begin
                 test_uniform_obs_dim_is_unchanged()
+                test_shared_obs_parameter_at_uniform_width()
             end
 
             @testset "Workspaces" begin
@@ -319,6 +320,7 @@ using SSDTest
 
             @testset "Fitting" begin
                 test_stitching_fit_runs_and_improves()
+                test_stitching_poisson_fit()
                 test_stitching_smooth_shapes()
             end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -311,6 +311,7 @@ using SSDTest
             @testset "Non-breaking" begin
                 test_uniform_obs_dim_is_unchanged()
                 test_shared_obs_parameter_at_uniform_width()
+                test_pooled_slot_at_a_width_the_model_was_not_built_at()
             end
 
             @testset "Workspaces" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,12 @@ using SSDTest
                 test_stitching_fit_runs_and_improves()
                 test_stitching_smooth_shapes()
             end
+
+            @testset "SLDS" begin
+                test_stitching_slds_shapes()
+                test_slds_cell_workspace_sharing()
+                test_stitching_slds_fit()
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,6 +290,30 @@ using SSDTest
                 test_grouped_slds_requires_matching_labels()
             end
         end
+
+        include("LinearDynamicalSystems/Stitching.jl")
+        @testset "Stitching (per-session obs_dim)" begin
+            @testset "Shapes and validation" begin
+                test_stitching_variant_shapes()
+                test_stitching_requires_grouped_R()
+                test_stitching_rejects_mixed_widths_in_slot()
+                test_stitching_data_validation()
+            end
+
+            @testset "Non-breaking" begin
+                test_uniform_obs_dim_is_unchanged()
+            end
+
+            @testset "Workspaces" begin
+                test_cell_workspace_shares_big_buffers()
+                test_grouped_pool_sized_at_widest_session()
+            end
+
+            @testset "Fitting" begin
+                test_stitching_fit_runs_and_improves()
+                test_stitching_smooth_shapes()
+            end
+        end
     end
 
     # Optimization primitives (line search + Newton)


### PR DESCRIPTION
Draft — opened for CI. Stacked on the grouped-EM SLDS branch.

Lets each group of trials carry its own `obs_dim`, so recording sessions that observe different numbers of neurons can be pooled into one fit with shared latent dynamics. The latent dimension stays shared. Gaussian, Poisson and SLDS paths are all wired.

## Design

`obs_dim` is a property of the `[C d D]` group rather than of the model: `C` is `obs_dim × latent_dim`, `d` is `obs_dim`, `D` is `obs_dim × uy_dim`, `R` is `obs_dim × obs_dim`. Two consequences drive the implementation:

- **Every observation group must be constant in `obs_dim` within a slot.** A shared `:R` beside a per-session `:C` has no well-defined size, and mixed widths under one label cannot be one matrix. Both are rejected with a message naming the fix.
- **Dimensions come from the data.** Each slot's `obs_dim` is the row count of the trials assigned to it. A slot whose shape matches the template still copies it; a slot that differs is seeded from its own trials — `d` at the per-channel mean (its log for Poisson, the natural scale for `λ = exp(Cx + d)`), `R` at the per-channel variance, and `C` by cycling the template's rows so the M-step starts at the template's magnitude rather than at zero.

The cell abstraction already did the hard part: a cell is a maximal set of trials sharing every parameter, gets its own `LinearDynamicalSystem`, and runs the ordinary smoother on its sub-`Data`. So per-session `obs_dim` never reaches the smoothing kernels.

## Buffer organisation

A cell's E-step runs across the whole workspace pool in parallel, so each cell needs a *pool*, not a single workspace — every entry owns the block-tridiagonal storage its task writes through. The split is by what the buffer's shape depends on: anything sized by `latent_dim` and `tsteps` is shared by reference; anything sized by `obs_dim` is per cell.

```mermaid
flowchart LR
    subgraph base["Pool entry i · allocated once per fit"]
        direction TB
        BTD["<b>btd</b><br/>BlockTridiagonalWorkspace<br/><i>O(D²·T)</i>"]
        PSM["<b>agg.p_smooth_shared</b><br/><b>agg.p_smooth_tt1_shared</b><br/><i>O(D²·T)</i>"]
        LLT["<b>ll_tmp</b> (SLDS only)<br/><i>O(T)</i>"]
    end

    subgraph cells["Per cell · sized by that session's width pᶜ"]
        direction TB
        C1["<b>Cell 1 · p₁ channels</b><br/>consts · opt · reg · elbo<br/>agg: obs_xy, obs_yy_const, obs_xy_const<br/><i>O(p₁²) + O(p₁·D)</i>"]
        C2["<b>Cell 2 · p₂ channels</b><br/>consts · opt · reg · elbo<br/>agg: obs_xy, obs_yy_const, obs_xy_const<br/><i>O(p₂²) + O(p₂·D)</i>"]
        CN["<b>Cell n · pₙ channels</b><br/>⋯"]
    end

    BTD -. "shared by reference" .-> C1
    BTD -. " " .-> C2
    BTD -. " " .-> CN
    PSM -. " " .-> C1
    PSM -. " " .-> C2
    PSM -. " " .-> CN
    LLT -. " " .-> C1
    LLT -. " " .-> C2
    LLT -. " " .-> CN
```

Sharing is safe for the same reason sharing the pool across cells already was: cells run one at a time, and a cell's smoothed covariances and Hessian blocks are consumed by its own aggregation before the next cell overwrites them.

| | Shared across cells | Allocated per cell |
|---|---|---|
| **LDS** (`_cell_workspace`) | `btd`, `agg.p_smooth_shared`, `agg.p_smooth_tt1_shared` | `consts`, `opt`, `reg`, `elbo`, `agg`'s `obs_*` blocks |
| **SLDS E-step** (`_cell_slds_workspace`) | `btd`, `ll_tmp` | per-regime `consts`, `opt` |
| **SLDS M-step** (`_slds_cell_mstep_workspaces`) | as LDS | regression buffers for `[Cₖ dₖ Dₖ]`, `R` scatter |

So the O(D²·T) storage stays single-instance no matter how many sessions are stitched. The per-cell cost is O(p²) and O(p·D) plus `NewtonBuffers`' O(D·T_max), i.e. linear in sessions and well under the shared term. Pools are built **once per fit**, never per iteration, and the per-slot pooling scratch is cached in a `Dict` keyed by width, so it is bounded by the number of *distinct* widths rather than by cells or iterations.

## Non-breaking

Every new path is gated on shapes actually differing:

- `_obs_slot_specs` returns `(nothing, nothing)` when all trials have the template width, so `_build_variants!` runs its original code and slot 1 still aliases the model's own arrays.
- `_cell_sws_pools` returns the shared pool itself, and `_slds_cell_workspaces` / `_slds_cell_mstep_workspaces` return the base workspace (or `nothing`), when every cell has the parent's `obs_dim`.
- The `Data` relaxation for ragged rows is behind `_has_parameter_dependence`.
- `cell_lds[c].obs_dim == lds.obs_dim` whenever widths agree.

A fit without `depends_on` reaches none of it. There are tests pinning this.

## Tests

`test/LinearDynamicalSystems/Stitching.jl`: per-slot shapes and per-cell `obs_dim`; both validation rules; the ragged-`y` data rule; a non-breaking test asserting no specs are computed, slot 1 stays aliased, and the shared pool is reused; diagnostics asserting **by identity** that the big buffers are shared while the `obs_dim`-shaped ones are not; the pool sized at the widest session; an end-to-end two-session Gaussian fit checking monotonicity, per-session widths and positive-definite `R`; a stitched-SLDS shape test showing all regimes of a cell share one width while the partition stays common across regimes; the SLDS workspace-sharing diagnostic; and an end-to-end stitched SLDS fit.

## Status / caveats

- **None of this has been executed.** There is no Julia toolchain in the environment I'm working in and the julialang download hosts are refused by the egress policy, so this is verified by reading only. CI is the first run — which is why it's a draft.
- Also fixes a latent bug in the grouped SLDS M-step: sufficient statistics were sized from cell 1's LDS for every unit, which is only correct when all cells share a width.
- The formatting and JET failures inherited from the branches below this one are pre-existing and being handled separately.