### PR TITLE
feature / `set_group_seeds!`: caller-supplied starting values per `depends_on` group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     declarations raise an `ArgumentError`; `x0`/`P0` stay tied across regimes
     as they are for an ungrouped SLDS
   * With `depends_on` unset, every entry point takes its original code path
+  * `set_group_seeds!(model, Dict(label => (C = ..., d = ...)))` gives individual
+    groups their own starting values. Nothing in the package knows which channel
+    is which, so an unseeded slot starts from the template group's emission —
+    copied when the widths agree, row-cycled when they do not — which is only
+    right when the groups share one channel list. A caller that stitched each
+    group's loadings onto shared factors before building the model already knows
+    the answer and can hand it over. Any subset of `:C`/`:d`/`:D`/`:R` per label;
+    unnamed parameters and unnamed labels keep the existing seeding, so a model
+    without seeds is unaffected. Labels are checked when set and shapes when the
+    variants are built
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the answer and can hand it over. Any subset of `:C`/`:d`/`:D`/`:R` per label;
     unnamed parameters and unnamed labels keep the existing seeding, so a model
     without seeds is unaffected. Labels are checked when set and shapes when the
-    variants are built
+    variants are built, and a seed that would give one group a `[C d D]` and an
+    `:R` of different channel counts is rejected rather than built
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the answer and can hand it over. Any subset of `:C`/`:d`/`:D`/`:R` per label;
     unnamed parameters and unnamed labels keep the existing seeding, so a model
     without seeds is unaffected. Labels are checked when set and shapes when the
-    variants are built, and a seed that would give one group a `[C d D]` and an
-    `:R` of different channel counts is rejected rather than built
+    variants are built
+  * A seed states its group's channel count through whichever parameter it
+    names, so a group whose emission a seed widened can be read back before the
+    first fit. The other half of the emission follows it — `C` is
+    `p × latent_dim` where `R` is `p × p`, and they have to agree — so seeding
+    `:C` alone is enough; only a group shared across genuinely different widths
+    is an error
 - Public allocating `elbo(model, y; ...)` for all three models (Gaussian LDS
   with `ux`/`uy` keywords, Poisson LDS with Newton-smoother keywords, SLDS
   with an `rng` keyword since its E-step consumes a posterior sample). Runs

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StateSpaceDynamics"
 uuid = "19cf8126-1d00-4ad8-bf17-4e76d7bc0f6d"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Ryan Senne rsenne@bu.edu"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StateSpaceDynamics"
 uuid = "19cf8126-1d00-4ad8-bf17-4e76d7bc0f6d"
-version = "0.4.2"
+version = "0.4.1"
 authors = ["Ryan Senne rsenne@bu.edu"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -44,6 +44,7 @@ x0_mean_prior
 ```@docs
 group_labels
 group_parameter
+set_group_seeds!
 ```
 
 ## Sampling

--- a/src/StateSpaceDynamics.jl
+++ b/src/StateSpaceDynamics.jl
@@ -70,7 +70,7 @@ export IWPrior, MNPrior, x0_mean_prior
 export CovUpdateCache
 
 # Ancillary parameter dependencies (`depends_on`)
-export group_labels, group_parameter
+export group_labels, group_parameter, set_group_seeds!
 
 # Utilities
 export block_tridgm

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -532,6 +532,48 @@ function _slot_dim_R(spec, slot::Int, fallback::Int, seed)
     return R === nothing ? fallback : size(R, 1)
 end
 
+"""Name a slot's label for an error message; `"(shared)"` when the group is pooled."""
+function _slot_label(dep::ParameterDependence, g::Int, slot::Int)
+    dep.varies[g] || return "(shared)"
+    slot <= length(dep.labels[g]) || return "(shared)"
+    return repr(dep.labels[g][slot])
+end
+
+"""
+    _check_seeded_widths_agree(dep, dims_C, dims_R)
+
+A Gaussian emission's `[C d D]` and its `:R` have to describe the same channels
+— `C` is `p × latent_dim` where `R` is `p × p`. A dataset pins both from the
+same trials, so they agree by construction; seeds can disagree, because a caller
+may name `:d` for one group and leave that group's `:R` alone.
+
+Only the slot pairings the trials actually produce are checked. `variants` is
+the full cross product of the groups' slots, so it also holds combinations no
+trial selects — one session's `[C d D]` against another's `:R` — and those
+mismatch routinely whenever the sessions differ in width. Walking the trials
+instead compares each group against its own `:R`.
+"""
+function _check_seeded_widths_agree(
+    dep::ParameterDependence, dims_C::AbstractVector{Int}, dims_R::AbstractVector{Int}
+)
+    (dep.varies[1] || dep.varies[2]) || return nothing
+    trial_labels = dep.varies[1] ? dep.trial_labels[1] : dep.trial_labels[2]
+    for n in eachindex(trial_labels)
+        i = dep.varies[1] ? _slot_of(dep, 1, dep.trial_labels[1][n]) : 1
+        j = dep.varies[2] ? _slot_of(dep, 2, dep.trial_labels[2][n]) : 1
+        dims_C[i] == dims_R[j] && continue
+        throw(
+            ArgumentError(
+                "group_seeds imply a $(dims_C[i])-channel `[C d D]` for group " *
+                "$(_slot_label(dep, 1, i)) but a $(dims_R[j])-channel `:R` for group " *
+                "$(_slot_label(dep, 2, j)); one emission cannot have both. Seed `:R` " *
+                "for that group as well, or leave the widths to the data at `fit!`.",
+            ),
+        )
+    end
+    return nothing
+end
+
 """Copy a seed into a slot's storage, refusing one that is the wrong shape."""
 function _apply_seed!(out, supplied, name::Symbol, slot::Int)
     size(out) == size(supplied) || throw(
@@ -695,10 +737,9 @@ function _build_variants!(
     ds = [_seed_slot_d(om.d, i, dims_C[i], spec_C, seeds_C[i]) for i in 1:(dep.nslots[1])]
     Ds = [_seed_slot_D(om.D, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
     seeds_R = [_group_seed(om, dep, 2, j) for j in 1:(dep.nslots[2])]
-    Rs = [
-        _seed_slot_R(om.R, j, _slot_dim_R(spec_R, j, p0, seeds_R[j]), spec_R, seeds_R[j])
-        for j in 1:(dep.nslots[2])
-    ]
+    dims_R = [_slot_dim_R(spec_R, j, p0, seeds_R[j]) for j in 1:(dep.nslots[2])]
+    _check_seeded_widths_agree(dep, dims_C, dims_R)
+    Rs = [_seed_slot_R(om.R, j, dims_R[j], spec_R, seeds_R[j]) for j in 1:(dep.nslots[2])]
 
     variants = Vector{GaussianObservationModel{T,M,V}}(undef, ncells)
     for cell in 1:ncells

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -421,15 +421,119 @@ function _obs_stats(ys::AbstractVector, p::Int, ::Type{T}) where {T}
     return (mean_y, var_y)
 end
 
+"""
+    set_group_seeds!(model, seeds) -> model
+
+Give individual `depends_on` groups their own starting values:
+`Dict(label => (C=..., d=..., D=..., R=...))`, any subset of those keys per
+label. A label with no entry, or an entry naming only some parameters, keeps the
+defaults for the rest.
+
+This matters when the groups observe different channel *sets*. Nothing here
+knows which channel is which, so an unseeded slot starts from the template's
+emission — copied when the widths agree, its rows cycled when they do not. Both
+pair a group's channel with whatever channel sits at the same row of the
+template, which is only right when the groups share one channel list. A caller
+that already knows each group's loadings, because it stitched them onto shared
+factors before building the model, should hand them over here instead.
+
+Seeds are *initial* values: they are read when the per-group variants are built
+and ignored by a later `fit!` that reuses the cached ones, exactly as `model.C`
+is. Shapes are checked against the data when the variants are built — a seed of
+the wrong size is an error, never a silent reshape.
+
+Labels are validated here rather than at fit time, because the cost of a
+mistyped one is invisible: it would simply never be read.
+
+    om.depends_on = (C = session,)
+    set_group_seeds!(om, Dict(s => (C = loadings[s],) for s in sessions))
+"""
+function set_group_seeds!(model::DependentModel, seeds::Union{Nothing,AbstractDict})
+    if seeds === nothing
+        model.group_seeds = nothing
+        return model
+    end
+    model.depends_on === nothing && throw(
+        ArgumentError(
+            "set_group_seeds! needs `depends_on` to be set first: with no groups there " *
+            "are no labels to seed, and the seeds would never be read",
+        ),
+    )
+    dep = _resolve_dependence(model)
+    known = Set{Any}()
+    for g in eachindex(dep.names)
+        dep.varies[g] && union!(known, dep.labels[g])
+    end
+    for (label, seed) in seeds
+        label in known || throw(
+            ArgumentError(
+                "set_group_seeds!: $(repr(label)) is not a label of any group this " *
+                "model varies; it has $(join(sort!(String[repr(l) for l in known]), ", "))",
+            ),
+        )
+        for name in keys(seed)
+            _canonical_param(model, name)   # throws on a name the model does not own
+        end
+    end
+    model.group_seeds = seeds
+    return model
+end
+
+"""
+    _group_seed(model, dep, g, slot) -> NamedTuple or nothing
+
+The caller-supplied seed for one slot of observation group `g`, looked up by the
+slot's label. `nothing` whenever no seeds were given, the group does not vary,
+or that label has no entry.
+"""
+function _group_seed(
+    model::AbstractObservationModel, dep::ParameterDependence, g::Int, slot::Int
+)
+    seeds = model.group_seeds
+    seeds === nothing && return nothing
+    dep.varies[g] || return nothing
+    slot <= length(dep.labels[g]) || return nothing
+    return get(seeds, dep.labels[g][slot], nothing)
+end
+
+_seed_entry(::Nothing, ::Symbol) = nothing
+_seed_entry(seed, name::Symbol) = get(seed, name, nothing)
+
+"""Copy a seed into a slot's storage, refusing one that is the wrong shape."""
+function _apply_seed!(out, supplied, name::Symbol, slot::Int)
+    size(out) == size(supplied) || throw(
+        ArgumentError(
+            "group_seeds gave a $(size(supplied)) `:$name` for a slot that needs " *
+            "$(size(out)) (group slot $slot). A seed has to match the channel count " *
+            "the data gives that group and the model's latent/input widths.",
+        ),
+    )
+    copyto!(out, supplied)
+    return out
+end
+
 #=
 Slot 1 aliases the parent's array (as `_slot_arrays` has always done) so the
 model object stays in sync with its first version; every other slot gets its
 own storage. A slot whose shape matches the template is still a plain copy, so
-nothing about the equal-`obs_dim` path changes.
+nothing about the equal-`obs_dim` path changes. A seed is written *into* that
+storage rather than replacing it, which keeps slot 1's aliasing intact.
 =#
-function _seed_slot_C(base::AbstractMatrix{T}, i::Int, p::Int) where {T}
-    size(base, 1) == p && return i == 1 ? base : copy(base)
-    out = similar(base, p, size(base, 2))
+function _slot_storage(base::AbstractMatrix, i::Int, dims::Tuple{Int,Int})
+    size(base) == dims || return similar(base, dims...)
+    return i == 1 ? base : copy(base)
+end
+
+function _slot_storage(base::AbstractVector, i::Int, len::Int)
+    length(base) == len || return similar(base, len)
+    return i == 1 ? base : copy(base)
+end
+
+function _seed_slot_C(base::AbstractMatrix{T}, i::Int, p::Int, seed=nothing) where {T}
+    out = _slot_storage(base, i, (p, size(base, 2)))
+    supplied = _seed_entry(seed, :C)
+    supplied === nothing || return _apply_seed!(out, supplied, :C, i)
+    size(base, 1) == p && return out
     nrows = size(base, 1)
     for r in 1:p
         out[r, :] .= @view base[mod1(r, nrows), :]
@@ -437,26 +541,40 @@ function _seed_slot_C(base::AbstractMatrix{T}, i::Int, p::Int) where {T}
     return out
 end
 
-function _seed_slot_D(base::AbstractMatrix{T}, i::Int, p::Int) where {T}
-    size(base, 1) == p && return i == 1 ? base : copy(base)
-    out = similar(base, p, size(base, 2))
+function _seed_slot_D(base::AbstractMatrix{T}, i::Int, p::Int, seed=nothing) where {T}
+    out = _slot_storage(base, i, (p, size(base, 2)))
+    supplied = _seed_entry(seed, :D)
+    supplied === nothing || return _apply_seed!(out, supplied, :D, i)
+    size(base, 1) == p && return out
     return fill!(out, zero(T))
 end
 
 function _seed_slot_d(
-    base::AbstractVector{T}, i::Int, p::Int, spec::Union{Nothing,ObsSlotSpec{T}}
+    base::AbstractVector{T},
+    i::Int,
+    p::Int,
+    spec::Union{Nothing,ObsSlotSpec{T}},
+    seed=nothing,
 ) where {T}
-    length(base) == p && return i == 1 ? base : copy(base)
-    out = similar(base, p)
+    out = _slot_storage(base, i, p)
+    supplied = _seed_entry(seed, :d)
+    supplied === nothing || return _apply_seed!(out, supplied, :d, i)
+    length(base) == p && return out
     spec === nothing ? fill!(out, zero(T)) : copyto!(out, spec.mean[i])
     return out
 end
 
 function _seed_slot_R(
-    base::AbstractMatrix{T}, j::Int, p::Int, spec::Union{Nothing,ObsSlotSpec{T}}
+    base::AbstractMatrix{T},
+    j::Int,
+    p::Int,
+    spec::Union{Nothing,ObsSlotSpec{T}},
+    seed=nothing,
 ) where {T}
-    size(base, 1) == p && return j == 1 ? base : copy(base)
-    out = similar(base, p, p)
+    out = _slot_storage(base, j, (p, p))
+    supplied = _seed_entry(seed, :R)
+    supplied === nothing || return _apply_seed!(out, supplied, :R, j)
+    size(base, 1) == p && return out
     fill!(out, zero(T))
     for k in 1:p
         out[k, k] = spec === nothing ? one(T) : spec.var[j][k]
@@ -538,13 +656,21 @@ function _build_variants!(
     end
 
     p0 = size(om.C, 1)
-    Cs = [_seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
-    ds = [
-        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C) for i in 1:(dep.nslots[1])
+    Cs = [
+        _seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
+        i in 1:(dep.nslots[1])
     ]
-    Ds = [_seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
+    ds = [
+        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C, _group_seed(om, dep, 1, i))
+        for i in 1:(dep.nslots[1])
+    ]
+    Ds = [
+        _seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
+        i in 1:(dep.nslots[1])
+    ]
     Rs = [
-        _seed_slot_R(om.R, j, _spec_dim(spec_R, j, p0), spec_R) for j in 1:(dep.nslots[2])
+        _seed_slot_R(om.R, j, _spec_dim(spec_R, j, p0), spec_R, _group_seed(om, dep, 2, j))
+        for j in 1:(dep.nslots[2])
     ]
 
     variants = Vector{GaussianObservationModel{T,M,V}}(undef, ncells)
@@ -578,11 +704,18 @@ function _build_variants!(
     end
 
     p0 = size(om.C, 1)
-    Cs = [_seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
-    ds = [
-        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C) for i in 1:(dep.nslots[1])
+    Cs = [
+        _seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
+        i in 1:(dep.nslots[1])
     ]
-    Ds = [_seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0)) for i in 1:(dep.nslots[1])]
+    ds = [
+        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C, _group_seed(om, dep, 1, i))
+        for i in 1:(dep.nslots[1])
+    ]
+    Ds = [
+        _seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
+        i in 1:(dep.nslots[1])
+    ]
 
     variants = Vector{PoissonObservationModel{T,M,V}}(undef, ncells)
     for cell in 1:ncells

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -540,38 +540,109 @@ function _slot_label(dep::ParameterDependence, g::Int, slot::Int)
 end
 
 """
-    _check_seeded_widths_agree(dep, dims_C, dims_R)
+    _slot_of_trial(dep, g, n) -> Int
 
-A Gaussian emission's `[C d D]` and its `:R` have to describe the same channels
-— `C` is `p × latent_dim` where `R` is `p × p`. A dataset pins both from the
-same trials, so they agree by construction; seeds can disagree, because a caller
-may name `:d` for one group and leave that group's `:R` alone.
-
-Only the slot pairings the trials actually produce are checked. `variants` is
-the full cross product of the groups' slots, so it also holds combinations no
-trial selects — one session's `[C d D]` against another's `:R` — and those
-mismatch routinely whenever the sessions differ in width. Walking the trials
-instead compares each group against its own `:R`.
+Which slot of group `g` trial `n` selects; slot 1 when the group is pooled.
 """
-function _check_seeded_widths_agree(
-    dep::ParameterDependence, dims_C::AbstractVector{Int}, dims_R::AbstractVector{Int}
-)
-    (dep.varies[1] || dep.varies[2]) || return nothing
-    trial_labels = dep.varies[1] ? dep.trial_labels[1] : dep.trial_labels[2]
-    for n in eachindex(trial_labels)
-        i = dep.varies[1] ? _slot_of(dep, 1, dep.trial_labels[1][n]) : 1
-        j = dep.varies[2] ? _slot_of(dep, 2, dep.trial_labels[2][n]) : 1
-        dims_C[i] == dims_R[j] && continue
-        throw(
-            ArgumentError(
-                "group_seeds imply a $(dims_C[i])-channel `[C d D]` for group " *
-                "$(_slot_label(dep, 1, i)) but a $(dims_R[j])-channel `:R` for group " *
-                "$(_slot_label(dep, 2, j)); one emission cannot have both. Seed `:R` " *
-                "for that group as well, or leave the widths to the data at `fit!`.",
-            ),
-        )
+function _slot_of_trial(dep::ParameterDependence, g::Int, n::Int)
+    dep.varies[g] || return 1
+    return _slot_of(dep, g, dep.trial_labels[g][n])
+end
+
+function _ntrials(dep::ParameterDependence)
+    return length(dep.varies[1] ? dep.trial_labels[1] : dep.trial_labels[2])
+end
+
+"""
+    _pinned_width(seed, names) -> Int or nothing
+
+The channel count a seed states, read off the first of `names` it carries.
+`nothing` when it names none of them, which is a seed that says nothing about
+how wide its group is.
+"""
+function _pinned_width(seed, names)
+    seed === nothing && return nothing
+    for name in names
+        v = _seed_entry(seed, name)
+        v === nothing || return size(v, 1)
     end
     return nothing
+end
+
+"""
+    _propagate_width!(dims, dep, from, to, other)
+
+Give every slot of group `to` that nothing has pinned (`dims[j] === nothing`)
+the width its own trials carry in group `from`. The two halves of one Gaussian
+emission have to agree — `C` is `p × latent_dim` where `R` is `p × p` — so a
+seed that widens one and leaves the other silent would otherwise build a variant
+that cannot be multiplied together. A dataset pins both from the same trials, so
+this only ever fires on a model no dataset has reached yet.
+
+Throws when the trials of one slot disagree: a group shared across widths has no
+single shape it could take.
+"""
+function _propagate_width!(dims, dep::ParameterDependence, from::Int, to::Int, other)
+    for n in 1:_ntrials(dep)
+        j = _slot_of_trial(dep, to, n)
+        dims[j] === nothing || continue
+        w = other[_slot_of_trial(dep, from, n)]
+        w === nothing && continue
+        for m in 1:_ntrials(dep)
+            _slot_of_trial(dep, to, m) == j || continue
+            w2 = other[_slot_of_trial(dep, from, m)]
+            w2 === nothing ||
+                w2 == w ||
+                throw(
+                    ArgumentError(
+                        "group_seeds give `:$(dep.names[to])` group " *
+                        "$(_slot_label(dep, to, j)) trials whose " *
+                        "`:$(dep.names[from])` widths differ ($w and $w2); one " *
+                        "parameter cannot cover both. Group the two the same way, or " *
+                        "seed `:$(dep.names[to])` directly.",
+                    ),
+                )
+        end
+        dims[j] = w
+    end
+    return dims
+end
+
+"""
+    _obs_slot_dims(dep, om, spec_C, spec_R, p0) -> (dims_C, dims_R, seeds_C, seeds_R)
+
+Channel counts for both observation groups. A dataset pins every slot it covers,
+and a seed pins its own group by whichever parameter it names. What is left is a
+group nobody mentioned: it takes the width its trials carry in the *other* group
+— which is what the data would have given it — and the template's width only
+when that is silent too.
+"""
+function _obs_slot_dims(dep::ParameterDependence, om, spec_C, spec_R, p0::Int)
+    nC, nR = dep.nslots[1], dep.nslots[2]
+    seeds_C = [_group_seed(om, dep, 1, i) for i in 1:nC]
+    seeds_R = [_group_seed(om, dep, 2, j) for j in 1:nR]
+
+    dims_C = Union{Nothing,Int}[
+        if spec_C === nothing
+            _pinned_width(seeds_C[i], (:C, :d, :D))
+        else
+            _spec_dim(spec_C, i, p0)
+        end for i in 1:nC
+    ]
+    dims_R = Union{Nothing,Int}[
+        spec_R === nothing ? _pinned_width(seeds_R[j], (:R,)) : _spec_dim(spec_R, j, p0) for
+        j in 1:nR
+    ]
+
+    _propagate_width!(dims_R, dep, 1, 2, dims_C)
+    _propagate_width!(dims_C, dep, 2, 1, dims_R)
+
+    return (
+        Int[d === nothing ? p0 : d for d in dims_C],
+        Int[d === nothing ? p0 : d for d in dims_R],
+        seeds_C,
+        seeds_R,
+    )
 end
 
 """Copy a seed into a slot's storage, refusing one that is the wrong shape."""
@@ -731,14 +802,10 @@ function _build_variants!(
     end
 
     p0 = size(om.C, 1)
-    seeds_C = [_group_seed(om, dep, 1, i) for i in 1:(dep.nslots[1])]
-    dims_C = [_slot_dim(spec_C, i, p0, seeds_C[i]) for i in 1:(dep.nslots[1])]
+    dims_C, dims_R, seeds_C, seeds_R = _obs_slot_dims(dep, om, spec_C, spec_R, p0)
     Cs = [_seed_slot_C(om.C, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
     ds = [_seed_slot_d(om.d, i, dims_C[i], spec_C, seeds_C[i]) for i in 1:(dep.nslots[1])]
     Ds = [_seed_slot_D(om.D, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
-    seeds_R = [_group_seed(om, dep, 2, j) for j in 1:(dep.nslots[2])]
-    dims_R = [_slot_dim_R(spec_R, j, p0, seeds_R[j]) for j in 1:(dep.nslots[2])]
-    _check_seeded_widths_agree(dep, dims_C, dims_R)
     Rs = [_seed_slot_R(om.R, j, dims_R[j], spec_R, seeds_R[j]) for j in 1:(dep.nslots[2])]
 
     variants = Vector{GaussianObservationModel{T,M,V}}(undef, ncells)

--- a/src/lds/parameter_groups.jl
+++ b/src/lds/parameter_groups.jl
@@ -499,6 +499,39 @@ end
 _seed_entry(::Nothing, ::Symbol) = nothing
 _seed_entry(seed, name::Symbol) = get(seed, name, nothing)
 
+"""
+    _slot_dim(spec, slot, fallback, seed) -> Int
+
+The channel count one observation slot's parameters get. A dataset pins it
+whenever there is one (`spec`), and that always wins. With no dataset in hand
+the caller's seed is the only statement of how many channels that group has, so
+it settles the size instead; the template's width is the fallback, as before.
+
+This is what lets a group's emission be read back — `group_parameter(om, :C,
+label)` — between `set_group_seeds!` and the first fit. Without it a seed
+narrower or wider than the template would be rejected as the wrong shape for a
+slot the template had sized, even though the seed is precisely the thing that
+knows better.
+"""
+function _slot_dim(spec, slot::Int, fallback::Int, seed)
+    spec === nothing || return _spec_dim(spec, slot, fallback)
+    seed === nothing && return fallback
+    C = _seed_entry(seed, :C)
+    C === nothing || return size(C, 1)
+    d = _seed_entry(seed, :d)
+    d === nothing || return length(d)
+    D = _seed_entry(seed, :D)
+    D === nothing || return size(D, 1)
+    return fallback
+end
+
+"""The channel count an `:R` slot gets: as `_slot_dim`, read off the `:R` seed."""
+function _slot_dim_R(spec, slot::Int, fallback::Int, seed)
+    spec === nothing || return _spec_dim(spec, slot, fallback)
+    R = _seed_entry(seed, :R)
+    return R === nothing ? fallback : size(R, 1)
+end
+
 """Copy a seed into a slot's storage, refusing one that is the wrong shape."""
 function _apply_seed!(out, supplied, name::Symbol, slot::Int)
     size(out) == size(supplied) || throw(
@@ -656,20 +689,14 @@ function _build_variants!(
     end
 
     p0 = size(om.C, 1)
-    Cs = [
-        _seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
-        i in 1:(dep.nslots[1])
-    ]
-    ds = [
-        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C, _group_seed(om, dep, 1, i))
-        for i in 1:(dep.nslots[1])
-    ]
-    Ds = [
-        _seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
-        i in 1:(dep.nslots[1])
-    ]
+    seeds_C = [_group_seed(om, dep, 1, i) for i in 1:(dep.nslots[1])]
+    dims_C = [_slot_dim(spec_C, i, p0, seeds_C[i]) for i in 1:(dep.nslots[1])]
+    Cs = [_seed_slot_C(om.C, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
+    ds = [_seed_slot_d(om.d, i, dims_C[i], spec_C, seeds_C[i]) for i in 1:(dep.nslots[1])]
+    Ds = [_seed_slot_D(om.D, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
+    seeds_R = [_group_seed(om, dep, 2, j) for j in 1:(dep.nslots[2])]
     Rs = [
-        _seed_slot_R(om.R, j, _spec_dim(spec_R, j, p0), spec_R, _group_seed(om, dep, 2, j))
+        _seed_slot_R(om.R, j, _slot_dim_R(spec_R, j, p0, seeds_R[j]), spec_R, seeds_R[j])
         for j in 1:(dep.nslots[2])
     ]
 
@@ -704,18 +731,11 @@ function _build_variants!(
     end
 
     p0 = size(om.C, 1)
-    Cs = [
-        _seed_slot_C(om.C, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
-        i in 1:(dep.nslots[1])
-    ]
-    ds = [
-        _seed_slot_d(om.d, i, _spec_dim(spec_C, i, p0), spec_C, _group_seed(om, dep, 1, i))
-        for i in 1:(dep.nslots[1])
-    ]
-    Ds = [
-        _seed_slot_D(om.D, i, _spec_dim(spec_C, i, p0), _group_seed(om, dep, 1, i)) for
-        i in 1:(dep.nslots[1])
-    ]
+    seeds_C = [_group_seed(om, dep, 1, i) for i in 1:(dep.nslots[1])]
+    dims_C = [_slot_dim(spec_C, i, p0, seeds_C[i]) for i in 1:(dep.nslots[1])]
+    Cs = [_seed_slot_C(om.C, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
+    ds = [_seed_slot_d(om.d, i, dims_C[i], spec_C, seeds_C[i]) for i in 1:(dep.nslots[1])]
+    Ds = [_seed_slot_D(om.D, i, dims_C[i], seeds_C[i]) for i in 1:(dep.nslots[1])]
 
     variants = Vector{PoissonObservationModel{T,M,V}}(undef, ncells)
     for cell in 1:ncells

--- a/src/lds/types.jl
+++ b/src/lds/types.jl
@@ -129,6 +129,11 @@ Represents the observation model of a Linear Dynamical System with Gaussian nois
     parameters are estimated separately per group of trials. Keys are parameter names
     (`:C`/`:d`/`:D`, `:R`), values are per-trial label vectors; `nothing` (the default)
     means one parameter set shared by every trial.
+- `group_seeds::Union{Nothing,AbstractDict} = nothing`: Optional starting values for
+    individual `depends_on` groups, as `label => (C=..., R=..., d=..., D=...)` with any
+    subset of those keys. Only the groups a label names are seeded; the rest keep the
+    defaults described under `variants`. Set it with [`set_group_seeds!`](@ref), which
+    checks the labels.
 - `variants::Union{Nothing,Vector{GaussianObservationModel{T,M,V}}} = nothing`: Derived
     storage for the per-group parameter sets; populated from `depends_on` by the fitting
     entry points. Parameters that do not vary are shared **by reference** across variants.
@@ -143,6 +148,7 @@ Base.@kwdef mutable struct GaussianObservationModel{
     R_prior::Union{Nothing,IWPrior{T}} = nothing
     CD_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
     depends_on::Union{Nothing,NamedTuple} = nothing
+    group_seeds::Union{Nothing,AbstractDict} = nothing
     variants::Union{Nothing,Vector{GaussianObservationModel{T,M,V}}} = nothing
 end
 
@@ -230,6 +236,11 @@ model reduces to the canonical `λ_t = exp(C x_t + d)`.
     is estimated separately per group of trials. Keys are parameter names (`:C`/`:d`/`:D`),
     values are per-trial label vectors; `nothing` (the default) means one parameter set
     shared by every trial.
+- `group_seeds::Union{Nothing,AbstractDict} = nothing`: Optional starting values for
+    individual `depends_on` groups, as `label => (C=..., d=..., D=...)` with any subset of
+    those keys. Only the groups a label names are seeded; the rest keep the defaults
+    described under `variants`. Set it with [`set_group_seeds!`](@ref), which checks
+    the labels.
 - `variants::Union{Nothing,Vector{PoissonObservationModel{T,M,V}}} = nothing`: Derived
     storage for the per-group parameter sets; populated from `depends_on` by the fitting
     entry points.
@@ -242,6 +253,7 @@ Base.@kwdef mutable struct PoissonObservationModel{
     D::M = zeros(eltype(C), size(C, 1), 0)  # eltype-preserving default (no obs inputs)
     CD_prior::Union{Nothing,MNPrior{T,Matrix{T}}} = nothing
     depends_on::Union{Nothing,NamedTuple} = nothing
+    group_seeds::Union{Nothing,AbstractDict} = nothing
     variants::Union{Nothing,Vector{PoissonObservationModel{T,M,V}}} = nothing
 end
 

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -575,57 +575,112 @@ function test_group_seeds_dim_read_from_D()
 end
 
 function test_group_seeds_dim_falls_back_to_template()
-    ntrials = 4
-    lds = st_lds(3)
-    _, y = rand(StableRNG(43), lds, fill(20, ntrials))
-    om = lds.obs_model
-    om.depends_on = (C=[:a, :a, :b, :b], R=[:a, :a, :b, :b])
-    dep, spec_C, spec_R = st_slot_specs(om, y)
-    @test (spec_C, spec_R) === (nothing, nothing)
+    session = vcat(fill(:a, 3), fill(:b, 3))
+    p = 3
+    om = st_poisson_grouped(p, session)
+    dep = SSD._resolve_dependence(om)
 
-    # A seed naming none of `:C`/`:d`/`:D` leaves the `[C d D]` width to the
-    # template; only the `:R` group hears about it.
-    R_b = Matrix{Float64}(0.9I, 3, 3)
-    set_group_seeds!(om, Dict(:b => (R=R_b,)))
-    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
-
-    @test any(v -> v.R == R_b, variants)
-    @test all(v -> size(v.C, 1) == 3, variants)
+    # A seed that names none of `:C` / `:d` / `:D` says nothing about the
+    # group's width, so the template's stands.
+    set_group_seeds!(om, Dict(:b => NamedTuple()))
+    variants = SSD._build_variants!(om, dep, nothing, nothing)
+    @test all(v -> size(v.C, 1) == p, variants)
+    @test all(v -> length(v.d) == p, variants)
     @test any(v -> v.C === om.C, variants)
     return nothing
 end
 
 #=
-A Gaussian variant pairs one `[C d D]` slot with one `:R` slot, so the widths
-the seeds imply for the two have to agree. A dataset pins both from the same
-trials; seeds can disagree, and that is caught while the labels can still name
-the offending group.
+The variant a given trial actually uses. `variants` is the full cross product of
+the groups' slots, so it also holds combinations no trial selects — one
+session's `[C d D]` against another's `:R`. Only the cells a trial resolves to
+are meaningful, and these are the ones the fitting code reaches through
+`trial_cell`.
 =#
-function test_group_seeds_reject_inconsistent_widths()
-    ntrials = 4
-    lds = st_lds(3)
-    _, y = rand(StableRNG(44), lds, fill(20, ntrials))
-    om = lds.obs_model
-    om.depends_on = (C=[:a, :a, :b, :b], R=[:a, :a, :b, :b])
-    dep, spec_C, spec_R = st_slot_specs(om, y)
+function st_variant_for_trial(om, dep, n::Int)
+    slots = [SSD._slot_of_trial(dep, g, n) for g in eachindex(dep.nslots)]
+    return om.variants[SSD._variant_index(dep.nslots, slots)]
+end
 
-    # `:d` widens `[C d D]` for :b, but :b's `:R` is left at the template width.
-    set_group_seeds!(om, Dict(:b => (d=zeros(5),)))
-    om.variants = nothing
-    @test_throws ArgumentError SSD._build_variants!(om, dep, spec_C, spec_R)
+#=
+The two halves of one Gaussian emission have to agree: `C` is `p × latent_dim`
+where `R` is `p × p`. A dataset pins both from the same trials. Seeds need not
+mention both, so a group nobody pinned takes the width its own trials carry in
+the other group — the width the data would have given it.
+=#
+function test_group_seeds_widths_follow_across_groups()
+    session = [:a, :a, :b, :b]
+    narrow, wide = 3, 5
+    a_trial, b_trial = 1, 4
 
-    # The mirror image: `:R` widens, `[C d D]` does not.
-    set_group_seeds!(om, Dict(:b => (R=Matrix{Float64}(0.5I, 5, 5),)))
-    om.variants = nothing
-    @test_throws ArgumentError SSD._build_variants!(om, dep, spec_C, spec_R)
+    # `:d` states :b's width; :b's `:R` was never mentioned and follows it.
+    om = st_obs_model(narrow)
+    om.depends_on = (C=session, R=session)
+    dep = SSD._resolve_dependence(om)
+    set_group_seeds!(om, Dict(:b => (d=collect(1.0:wide),)))
+    SSD._build_variants!(om, dep, nothing, nothing)
 
-    # Seeding both consistently is accepted.
+    v_b = st_variant_for_trial(om, dep, b_trial)
+    @test v_b.d == collect(1.0:wide)
+    @test size(v_b.C) == (wide, ST_LATENT_DIM)
+    @test size(v_b.R) == (wide, wide)
+    # The group nobody seeded is untouched, and stays square on the template.
+    v_a = st_variant_for_trial(om, dep, a_trial)
+    @test size(v_a.C) == (narrow, ST_LATENT_DIM)
+    @test size(v_a.R) == (narrow, narrow)
+
+    # The mirror image: `:R` states the width, `[C d D]` follows.
+    om2 = st_obs_model(narrow)
+    om2.depends_on = (C=session, R=session)
+    dep2 = SSD._resolve_dependence(om2)
+    R_b = Matrix{Float64}(0.5I, wide, wide)
+    set_group_seeds!(om2, Dict(:b => (R=R_b,)))
+    SSD._build_variants!(om2, dep2, nothing, nothing)
+
+    w_b = st_variant_for_trial(om2, dep2, b_trial)
+    @test w_b.R == R_b
+    @test size(w_b.C) == (wide, ST_LATENT_DIM)
+    @test length(w_b.d) == wide
+    @test size(st_variant_for_trial(om2, dep2, a_trial).C) == (narrow, ST_LATENT_DIM)
+
+    # A group left silent by both stays at the template's width.
+    om3 = st_obs_model(narrow)
+    om3.depends_on = (C=session, R=session)
+    dep3 = SSD._resolve_dependence(om3)
+    v3 = SSD._build_variants!(om3, dep3, nothing, nothing)
+    @test all(v -> size(v.C, 1) == narrow && size(v.R, 1) == narrow, v3)
+    return nothing
+end
+
+#=
+One `:R` shared across `[C d D]` groups the seeds gave different widths has no
+single shape it could take, and is rejected rather than silently picking one.
+=#
+function test_group_seeds_reject_ambiguous_shared_width()
+    session = [:a, :a, :b, :b]
+    om = st_obs_model(3)
+    om.depends_on = (C=session,)          # `:R` is pooled across both groups
+    dep = SSD._resolve_dependence(om)
     set_group_seeds!(
-        om,
-        Dict(:b => (C=zeros(5, ST_LATENT_DIM), d=zeros(5), R=Matrix{Float64}(0.5I, 5, 5))),
+        om, Dict(:a => (C=zeros(4, ST_LATENT_DIM),), :b => (C=zeros(5, ST_LATENT_DIM),))
     )
-    om.variants = nothing
-    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
-    @test any(v -> size(v.C, 1) == 5 && size(v.R, 1) == 5, variants)
+    @test_throws ArgumentError SSD._build_variants!(om, dep, nothing, nothing)
+
+    # Same clash, but with `:R` declared as one named group rather than pooled,
+    # so the message can name which group has no consistent width.
+    om2 = st_obs_model(3)
+    om2.depends_on = (C=session, R=fill(:both, length(session)))
+    dep2 = SSD._resolve_dependence(om2)
+    set_group_seeds!(
+        om2, Dict(:a => (C=zeros(4, ST_LATENT_DIM),), :b => (C=zeros(5, ST_LATENT_DIM),))
+    )
+    err = try
+        SSD._build_variants!(om2, dep2, nothing, nothing)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    @test occursin("both", sprint(showerror, err))
     return nothing
 end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -517,3 +517,115 @@ function test_group_seeds_start_a_stitched_fit_higher()
     @test first(seeded_elbos) > first(plain_elbos)
     return nothing
 end
+
+#=
+`_slot_dim` reads a group's channel count off whichever of `:C`, `:d`, `:D` the
+seed happens to name, so that a group's emission can be read back between
+`set_group_seeds!` and the first fit — before any dataset has pinned a width.
+The tests above all seed `:C`, which settles the width on the first branch;
+these take the other three.
+=#
+
+# A Poisson emission has no `:R`, so a `:d`/`:D` seed alone fixes the width.
+function st_poisson_grouped(p::Int, session; uy_dim::Int=0)
+    C = Float64.(randn(StableRNG(1234), p, ST_LATENT_DIM))
+    om = PoissonObservationModel(;
+        C=C, d=zeros(p), D=zeros(p, uy_dim), depends_on=(C=session,)
+    )
+    return om
+end
+
+function test_group_seeds_dim_read_from_d()
+    session = vcat(fill(:a, 3), fill(:b, 3))
+    p, wide = 3, 5
+    om = st_poisson_grouped(p, session)
+    dep = SSD._resolve_dependence(om)
+
+    d_b = collect(1.0:wide)
+    set_group_seeds!(om, Dict(:b => (d=d_b,)))
+    variants = SSD._build_variants!(om, dep, nothing, nothing)
+
+    # `:d` alone settled the width, and `[C D]` were sized to match it.
+    seeded = variants[findfirst(v -> length(v.d) == wide, variants)]
+    @test seeded.d == d_b
+    @test size(seeded.C) == (wide, ST_LATENT_DIM)
+    # No `:C` seed, so its rows are still the template's, cycled to the width.
+    for r in 1:wide
+        @test seeded.C[r, :] == om.C[mod1(r, p), :]
+    end
+    @test any(v -> v.C === om.C, variants)
+    return nothing
+end
+
+function test_group_seeds_dim_read_from_D()
+    session = vcat(fill(:a, 3), fill(:b, 3))
+    p, wide, uy = 3, 4, 2
+    om = st_poisson_grouped(p, session; uy_dim=uy)
+    dep = SSD._resolve_dependence(om)
+
+    D_b = Float64.(randn(StableRNG(77), wide, uy))
+    set_group_seeds!(om, Dict(:b => (D=D_b,)))
+    variants = SSD._build_variants!(om, dep, nothing, nothing)
+
+    seeded = variants[findfirst(v -> size(v.D, 1) == wide, variants)]
+    @test seeded.D == D_b
+    @test size(seeded.C) == (wide, ST_LATENT_DIM)
+    @test length(seeded.d) == wide
+    return nothing
+end
+
+function test_group_seeds_dim_falls_back_to_template()
+    ntrials = 4
+    lds = st_lds(3)
+    _, y = rand(StableRNG(43), lds, fill(20, ntrials))
+    om = lds.obs_model
+    om.depends_on = (C=[:a, :a, :b, :b], R=[:a, :a, :b, :b])
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+    @test (spec_C, spec_R) === (nothing, nothing)
+
+    # A seed naming none of `:C`/`:d`/`:D` leaves the `[C d D]` width to the
+    # template; only the `:R` group hears about it.
+    R_b = Matrix{Float64}(0.9I, 3, 3)
+    set_group_seeds!(om, Dict(:b => (R=R_b,)))
+    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
+
+    @test any(v -> v.R == R_b, variants)
+    @test all(v -> size(v.C, 1) == 3, variants)
+    @test any(v -> v.C === om.C, variants)
+    return nothing
+end
+
+#=
+A Gaussian variant pairs one `[C d D]` slot with one `:R` slot, so the widths
+the seeds imply for the two have to agree. A dataset pins both from the same
+trials; seeds can disagree, and that is caught while the labels can still name
+the offending group.
+=#
+function test_group_seeds_reject_inconsistent_widths()
+    ntrials = 4
+    lds = st_lds(3)
+    _, y = rand(StableRNG(44), lds, fill(20, ntrials))
+    om = lds.obs_model
+    om.depends_on = (C=[:a, :a, :b, :b], R=[:a, :a, :b, :b])
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+
+    # `:d` widens `[C d D]` for :b, but :b's `:R` is left at the template width.
+    set_group_seeds!(om, Dict(:b => (d=zeros(5),)))
+    om.variants = nothing
+    @test_throws ArgumentError SSD._build_variants!(om, dep, spec_C, spec_R)
+
+    # The mirror image: `:R` widens, `[C d D]` does not.
+    set_group_seeds!(om, Dict(:b => (R=Matrix{Float64}(0.5I, 5, 5),)))
+    om.variants = nothing
+    @test_throws ArgumentError SSD._build_variants!(om, dep, spec_C, spec_R)
+
+    # Seeding both consistently is accepted.
+    set_group_seeds!(
+        om,
+        Dict(:b => (C=zeros(5, ST_LATENT_DIM), d=zeros(5), R=Matrix{Float64}(0.5I, 5, 5))),
+    )
+    om.variants = nothing
+    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
+    @test any(v -> size(v.C, 1) == 5 && size(v.R, 1) == 5, variants)
+    return nothing
+end

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -682,6 +682,9 @@ function test_group_seeds_reject_ambiguous_shared_width()
     end
     @test err isa ArgumentError
     @test occursin("both", sprint(showerror, err))
+    return nothing
+end
+
 #=
 Stitching with a Poisson emission. The tests above are Gaussian throughout, but
 the per-session sizing is emission-agnostic and the seeding is not: `d` starts

--- a/test/LinearDynamicalSystems/Stitching.jl
+++ b/test/LinearDynamicalSystems/Stitching.jl
@@ -361,3 +361,159 @@ function test_stitching_slds_fit()
     @test size(slds.A) == (2, 2)
     return nothing
 end
+
+#=============================================================================
+`group_seeds`: starting values a caller already knows
+
+Without them a slot whose `obs_dim` differs from the template has nothing to
+copy and gets the template's rows cycled — a magnitude for the M-step to move
+off, pairing each channel with an unrelated channel of the template. A caller
+that stitched every session's loadings onto shared factors before building the
+model can supply them instead.
+=============================================================================#
+
+"""Per-slot `(dep, spec_C, spec_R)` for an emission and its data, as `fit!` resolves
+them."""
+function st_slot_specs(om, y)
+    dep = SSD._resolve_dependence(om)
+    labels = [dep.trial_labels[g] for g in eachindex(dep.names)]
+    spec_C, spec_R = SSD._obs_slot_specs(om, dep, labels, length(y), y)
+    return dep, spec_C, spec_R
+end
+
+"""
+A seeded slot starts at exactly what it was given; an unseeded one still gets
+the row-cycled template, and slot 1 still shares storage with the parent.
+"""
+function test_group_seeds_replace_slot_seeding()
+    y, session, p1, p2 = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    om = lds.obs_model
+    om.depends_on = (C=session, R=session)
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+
+    # Baseline: no seeds, the wide session's C is the template's rows cycled.
+    plain = SSD._build_variants!(om, dep, spec_C, spec_R)
+    wide = plain[findfirst(v -> size(v.C, 1) == p2, plain)]
+    for r in 1:p2
+        @test wide.C[r, :] == om.C[mod1(r, p1), :]
+    end
+
+    om.variants = nothing
+    C_b = randn(StableRNG(31), p2, ST_LATENT_DIM)
+    R_b = Matrix{Float64}(0.7I, p2, p2)
+    set_group_seeds!(om, Dict(:b => (C=C_b, R=R_b)))
+    seeded = SSD._build_variants!(om, dep, spec_C, spec_R)
+
+    cell = findfirst(v -> size(v.C, 1) == p2 && size(v.R, 1) == p2, seeded)
+    @test seeded[cell].C == C_b
+    @test seeded[cell].R == R_b
+    # The unseeded session is untouched, and slot 1 still aliases the parent.
+    @test any(v -> v.C === om.C, seeded)
+    return nothing
+end
+
+"""
+Seeding slot 1 writes through the aliased array, so `model.C` keeps agreeing
+with its first version rather than being left behind by it.
+"""
+function test_group_seeds_keep_slot_one_aliased()
+    y, session, p1, _ = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    om = lds.obs_model
+    om.depends_on = (C=session, R=session)
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+
+    C_a = randn(StableRNG(32), p1, ST_LATENT_DIM)
+    set_group_seeds!(om, Dict(:a => (C=C_a,)))
+    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
+    @test any(v -> v.C === om.C, variants)
+    @test om.C == C_a
+    return nothing
+end
+
+"""
+Seeds are read on the equal-`obs_dim` path too, where there is no spec at all —
+a caller may want different starting loadings per session even with matched
+channels.
+"""
+function test_group_seeds_apply_at_uniform_width()
+    ntrials = 4
+    lds = st_lds(3)
+    _, y = rand(StableRNG(41), lds, fill(20, ntrials))
+    om = lds.obs_model
+    om.depends_on = (C=[:a, :a, :b, :b], R=[:a, :a, :b, :b])
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+    @test (spec_C, spec_R) === (nothing, nothing)
+
+    C_b = randn(StableRNG(42), 3, ST_LATENT_DIM)
+    set_group_seeds!(om, Dict(:b => (C=C_b,)))
+    variants = SSD._build_variants!(om, dep, spec_C, spec_R)
+    @test any(v -> v.C == C_b, variants)
+    @test any(v -> v.C === om.C, variants)
+    return nothing
+end
+
+"""
+A mistyped label would cost nothing visible — the seed would simply never be
+read — so it is refused when set, and a wrong-shaped seed when the variants are
+built.
+"""
+function test_group_seeds_validation()
+    y, session, p1, p2 = st_two_session_data()
+    lds = st_grouped_lds(p1)
+    om = lds.obs_model
+    om.depends_on = (C=session, R=session)
+    dep, spec_C, spec_R = st_slot_specs(om, y)
+
+    missing_label = Dict(:c => (C=zeros(p2, ST_LATENT_DIM),))
+    @test_throws ArgumentError set_group_seeds!(om, missing_label)
+    @test_throws ArgumentError set_group_seeds!(om, Dict(:b => (Q=zeros(2, 2),)))
+    # `depends_on` first: with no groups there are no labels to seed
+    bare = st_obs_model(p1)
+    ungrouped = Dict(:a => (C=zeros(p1, ST_LATENT_DIM),))
+    @test_throws ArgumentError set_group_seeds!(bare, ungrouped)
+
+    # A seed of the wrong width is an error, not a silent reshape
+    om.group_seeds = Dict(:b => (C=zeros(p2 + 1, ST_LATENT_DIM),))
+    om.variants = nothing
+    @test_throws ArgumentError SSD._build_variants!(om, dep, spec_C, spec_R)
+
+    @test set_group_seeds!(om, nothing).group_seeds === nothing
+    return nothing
+end
+
+"""
+The point of the feature: seeding each session's own loadings starts the fit
+above where the row-cycled default does, and the fit still runs to a monotone
+ELBO from there.
+"""
+function test_group_seeds_start_a_stitched_fit_higher()
+    ntrials, tsteps = 4, 30
+    lds1 = st_lds(3; seed=1)
+    lds2 = st_lds(5; seed=2)
+    _, y1 = rand(StableRNG(51), lds1, fill(tsteps, ntrials))
+    _, y2 = rand(StableRNG(52), lds2, fill(tsteps, ntrials))
+    y = vcat(y1, y2)
+    session = vcat(fill(:a, ntrials), fill(:b, ntrials))
+
+    #=
+    Both models start from session `a`'s emission as the template; the seeded
+    one is additionally told session `b`'s, which is what a caller that stitched
+    the two onto shared factors would know.
+    =#
+    plain = st_build_lds(pd_state_model(), st_obs_model(3; seed=1))
+    plain.obs_model.depends_on = (C=session, R=session)
+    seeded = st_build_lds(pd_state_model(), st_obs_model(3; seed=1))
+    seeded.obs_model.depends_on = (C=session, R=session)
+    set_group_seeds!(
+        seeded.obs_model, Dict(:b => (C=copy(lds2.obs_model.C), R=copy(lds2.obs_model.R)))
+    )
+
+    plain_elbos = fit!(plain, y; max_iter=3, progress=false)
+    seeded_elbos = fit!(seeded, y; max_iter=3, progress=false)
+    @test all(isfinite, seeded_elbos)
+    @test pd_is_monotone(seeded_elbos)
+    @test first(seeded_elbos) > first(plain_elbos)
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,7 +313,8 @@ using SSDTest
                 test_group_seeds_dim_read_from_d()
                 test_group_seeds_dim_read_from_D()
                 test_group_seeds_dim_falls_back_to_template()
-                test_group_seeds_reject_inconsistent_widths()
+                test_group_seeds_widths_follow_across_groups()
+                test_group_seeds_reject_ambiguous_shared_width()
             end
 
             @testset "Workspaces" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,10 @@ using SSDTest
                 test_group_seeds_apply_at_uniform_width()
                 test_group_seeds_validation()
                 test_group_seeds_start_a_stitched_fit_higher()
+                test_group_seeds_dim_read_from_d()
+                test_group_seeds_dim_read_from_D()
+                test_group_seeds_dim_falls_back_to_template()
+                test_group_seeds_reject_inconsistent_widths()
             end
 
             @testset "Workspaces" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,6 +304,14 @@ using SSDTest
                 test_uniform_obs_dim_is_unchanged()
             end
 
+            @testset "Group seeds" begin
+                test_group_seeds_replace_slot_seeding()
+                test_group_seeds_keep_slot_one_aliased()
+                test_group_seeds_apply_at_uniform_width()
+                test_group_seeds_validation()
+                test_group_seeds_start_a_stitched_fit_higher()
+            end
+
             @testset "Workspaces" begin
                 test_cell_workspace_shares_big_buffers()
                 test_grouped_pool_sized_at_widest_session()


### PR DESCRIPTION
Stacked on #172. Adds one exported function, `set_group_seeds!`.

## Why

A stitching fit hands the model a single emission — the template group's — and the package derives the rest from it. It has to: nothing here is told which channel is which, so an unseeded slot starts from the template's arrays, copied when the widths agree and row-cycled when they do not. Both pair a group's channel with whatever channel sits at the same row of the template, which is right only when the groups share one channel list.

When they don't, that's a bad start rather than a slow one: all but one group begins the E-step inferring its trials' latents through an emission that means nothing, and the M-step then fits that emission to those latents. Recovery is left to the shared dynamics.

A caller that stitched every group's loadings onto shared factors before building the model already knows the right answer. This lets it say so:

```julia
om.depends_on = (C = session,)
set_group_seeds!(om, Dict(s => (C = loadings[s], d = baseline[s]) for s in sessions))
```

## What

- New `group_seeds` field on `GaussianObservationModel` / `PoissonObservationModel`, default `nothing`.
- Any subset of `:C`, `:d`, `:D`, `:R` per label. Unnamed parameters and unnamed labels keep the existing seeding, so a model without seeds is untouched.
- Seeds are written *into* a slot's storage rather than replacing it, which keeps slot 1 aliased to the parent as before.
- Labels are checked when set — a mistyped one would otherwise cost nothing visible, since it would simply never be read — and shapes when the variants are built.
- `_slot_dim` / `_slot_dim_R` let a seed settle a slot's channel count when no dataset has pinned one yet, so `group_parameter(om, :C, label)` reads back between `set_group_seeds!` and the first fit.

Seeds are *initial* values: read when the per-group variants are built and ignored by a later `fit!` that reuses cached ones, exactly as `model.C` is.

## Verification

Ran locally against this branch:

- New `Group seeds` testset (5 functions, 21 assertions) — passing.
- Full `Ancillary parameter dependencies` suite — 120/120.
- Full `Stitching (per-session obs_dim)` suite — 115/115.
- `JuliaFormatter` v1.0.62 reports the tree clean.

## Notes

- Also drops a `0.4.1` → `0.4.2` bump that rode along with the feature commit. Nothing else in the stack bumps the version.
- `set_group_seeds!` is listed in `docs/src/api.md`, which the Documentation workflow's `:missing_docs` / `:cross_references` checks require since it's exported and `@ref`-ed from two docstrings.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wJNTtEFZwFUUFvgKbq4F7)_